### PR TITLE
(fix)chore/Update collection id type for Postgres

### DIFF
--- a/src/app/_blocks/ArchiveBlock/index.tsx
+++ b/src/app/_blocks/ArchiveBlock/index.tsx
@@ -5,7 +5,7 @@ import { CollectionArchive } from '../../_components/CollectionArchive'
 import RichText from '../../_components/RichText'
 
 export type ArchiveBlockProps = ArchiveBlockType & {
-  id?: string
+  id?: number
 }
 
 export const ArchiveBlock: React.FC<ArchiveBlockProps> = props => {

--- a/src/app/_blocks/CallToAction/index.tsx
+++ b/src/app/_blocks/CallToAction/index.tsx
@@ -7,7 +7,7 @@ import RichText from '../../_components/RichText'
 // import classes from './index.module.scss'
 
 type Props = CallToActionBlockType & {
-  id?: string
+  id?: number
 }
 
 export const CallToActionBlock: React.FC<Props> = ({ links, richText, invertBackground }) => {

--- a/src/app/_blocks/Content/index.tsx
+++ b/src/app/_blocks/Content/index.tsx
@@ -7,7 +7,7 @@ import RichText from '../../_components/RichText'
 // import classes from './index.module.scss'
 
 export type ContentProps = ContentBlockType & {
-  id?: string
+  id?: number
 }
 
 export const ContentBlock: React.FC<ContentProps> = props => {

--- a/src/app/_components/CollectionArchive/index.tsx
+++ b/src/app/_components/CollectionArchive/index.tsx
@@ -1,6 +1,5 @@
 'use client'
-import React, { Fragment, useCallback, useEffect, useRef, useState } from 'react'
-import { animated, useTransition } from '@react-spring/web'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 import qs from 'qs'
 
 import { Post } from '../../../payload/payload-types'
@@ -100,13 +99,12 @@ export const CollectionArchive: React.FC<Props> = props => {
         {
           sort,
           where: {
-            ...(catsFromProps && catsFromProps?.length > 0
+            ...(catsFromProps && catsFromProps.length > 0
               ? {
                   categories: {
-                    in:
-                      typeof catsFromProps === 'string'
-                        ? [catsFromProps]
-                        : catsFromProps.map(category => category).join(','),
+                    in: catsFromProps
+                      .map(category => (typeof category === 'number' ? category : category.id))
+                      .join(','),
                   },
                 }
               : {}),


### PR DESCRIPTION
The id type was initially defined as a string for use with a mongo database. As This project now uses Postgres, I have updates all id type definitions to number in the next.js app.