### PR TITLE
Fix/Category archive not fetching data

### DIFF
--- a/src/app/(pages)/posts/[slug]/page.tsx
+++ b/src/app/(pages)/posts/[slug]/page.tsx
@@ -6,9 +6,8 @@ import { notFound } from 'next/navigation'
 import { Keyword, Post } from '../../../../payload/payload-types'
 import { fetchDoc } from '../../../_api/fetchDoc'
 import { fetchDocs } from '../../../_api/fetchDocs'
-import { RelatedPosts } from '../../../_blocks/RelatedPosts'
 import { Layout } from '../../../_components/Layout'
-import { Padding } from '../../../_components/Padding'
+import { RelatedPosts } from '../../../_components/RelatedPosts'
 import { PageState } from '../../../_providers/Context/Page/pageContext'
 import { generateMeta } from '../../../_utilities/generateMeta'
 
@@ -50,7 +49,7 @@ export default async function Post({ params: { slug } }) {
       />
       <Layout layouts={layout} />
       {relatedPosts && relatedPosts.length > 0 && (
-        <RelatedPosts introContent="More:" docs={relatedPosts} />
+        <RelatedPosts introContent="More" docs={relatedPosts} />
       )}
     </main>
   )

--- a/src/app/_blocks/ArchiveBlock/index.tsx
+++ b/src/app/_blocks/ArchiveBlock/index.tsx
@@ -17,7 +17,7 @@ export const ArchiveBlock: React.FC<ArchiveBlockProps> = props => {
     showPageRange,
     populatedDocs,
     populatedDocsTotal,
-    categories,
+    category,
   } = props
 
   return (
@@ -30,7 +30,7 @@ export const ArchiveBlock: React.FC<ArchiveBlockProps> = props => {
         relationTo={relationTo}
         populatedDocs={populatedDocs}
         populatedDocsTotal={populatedDocsTotal}
-        categories={categories}
+        category={category}
         limit={limit}
         showPageRange={showPageRange}
         sort="-publishedAt"

--- a/src/app/_components/Blocks/index.tsx
+++ b/src/app/_components/Blocks/index.tsx
@@ -6,8 +6,8 @@ import { HiddenLayout } from '../../../payload/payload-types'
 import { ArchiveBlock } from '../../_blocks/ArchiveBlock'
 import { CallToActionBlock } from '../../_blocks/CallToAction'
 import { MediaBlock } from '../../_blocks/MediaBlock'
-import { RelatedPosts, type RelatedPostsProps } from '../../_blocks/RelatedPosts'
 import { toKebabCase } from '../../_utilities/toKebabCase'
+import { RelatedPosts, type RelatedPostsProps } from '../RelatedPosts'
 
 const blockComponents = {
   cta: CallToActionBlock,

--- a/src/app/_components/Card/index.tsx
+++ b/src/app/_components/Card/index.tsx
@@ -13,7 +13,7 @@ import { Media } from '../Media'
 export const Card: React.FC<{
   alignItems?: 'center'
   className?: string
-  showCategories?: boolean
+  showCategory?: boolean
   hideImagesOnMobile?: boolean
   title?: string
   relationTo?: 'posts'

--- a/src/app/_components/CollectionArchive/index.tsx
+++ b/src/app/_components/CollectionArchive/index.tsx
@@ -30,7 +30,7 @@ export type Props = {
   populatedDocs?: ArchiveBlockProps['populatedDocs']
   selectedDocs?: ArchiveBlockProps['selectedDocs']
   populatedDocsTotal?: ArchiveBlockProps['populatedDocsTotal']
-  categories?: ArchiveBlockProps['categories']
+  category?: ArchiveBlockProps['category']
 }
 
 export const CollectionArchive: React.FC<Props> = props => {
@@ -44,7 +44,7 @@ export const CollectionArchive: React.FC<Props> = props => {
     populatedDocs,
     populatedDocsTotal,
     selectedDocs,
-    categories: catsFromProps,
+    category: catFromProps,
     populateBy,
   } = props
 
@@ -99,10 +99,10 @@ export const CollectionArchive: React.FC<Props> = props => {
         {
           sort,
           where: {
-            ...(catsFromProps && catsFromProps.length > 0
+            ...(catFromProps && catFromProps.length > 0
               ? {
-                  categories: {
-                    in: catsFromProps
+                  category: {
+                    in: catFromProps
                       .map(category => (typeof category === 'number' ? category : category.id))
                       .join(','),
                   },
@@ -148,7 +148,7 @@ export const CollectionArchive: React.FC<Props> = props => {
     return () => {
       if (timer) clearTimeout(timer)
     }
-  }, [page, catsFromProps, relationTo, onResultChange, sort, limit, populateBy])
+  }, [page, catFromProps, relationTo, onResultChange, sort, limit, populateBy])
 
   const [currentResult, setCurrentResult] = useState<Result>()
   useEffect(() => {
@@ -166,7 +166,7 @@ export const CollectionArchive: React.FC<Props> = props => {
           currentResult.docs?.map((result, index) => {
             return (
               <div key={index}>
-                <Card index={index} relationTo={relationTo} doc={result} showCategories />
+                <Card index={index} relationTo={relationTo} doc={result} showCategory />
               </div>
             )
           })}

--- a/src/app/_components/Footer/index.tsx
+++ b/src/app/_components/Footer/index.tsx
@@ -52,20 +52,20 @@ export async function Footer({ siteSettings }: FooterProps) {
             ,&nbsp;
             <Link
               className="hover:underline hover:underline-offset-4"
+              href="https://payloadcms.com"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              PayloadCMS
+            </Link>
+            &nbsp;and&nbsp;
+            <Link
+              className="hover:underline hover:underline-offset-4"
               href="https://tailwindcss.com/"
               target="_blank"
               rel="noopener noreferrer"
             >
               TailwindCSS
-            </Link>
-            &nbsp;and&nbsp;
-            <Link
-              className="hover:underline hover:underline-offset-4"
-              href="https://payloadcms.com"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Payload
             </Link>
           </div>
           <Link

--- a/src/app/_components/RelatedPosts/index.tsx
+++ b/src/app/_components/RelatedPosts/index.tsx
@@ -25,7 +25,7 @@ export const RelatedPosts: React.FC<RelatedPostsProps> = props => {
         {docs?.map((doc, index) => {
           if (typeof doc === 'string') return null
 
-          return <Card key={index} doc={doc} relationTo="posts" showCategories />
+          return <Card key={index} doc={doc} relationTo="posts" showCategory />
         })}
       </div>
     </Padding>

--- a/src/app/_components/RichText/serialize.tsx
+++ b/src/app/_components/RichText/serialize.tsx
@@ -111,7 +111,7 @@ const serialize = (nodes?: LexicalNode[], i = 1): React.ReactNode => {
         }
         return <Fragment key={i}>{text}</Fragment>
       case 'linebreak':
-        return <br />
+        return <br key={i} />
       case 'heading':
         switch (node.tag) {
           case 'h1':
@@ -178,7 +178,7 @@ const serialize = (nodes?: LexicalNode[], i = 1): React.ReactNode => {
       case 'upload':
         return <Media key={i} resource={node.value} fill />
       case 'block':
-        return <Blocks blocks={[node.fields]} />
+        return <Blocks key={i} blocks={[node.fields]} />
     }
   })
 }

--- a/src/app/_graphql/blocks.ts
+++ b/src/app/_graphql/blocks.ts
@@ -1,4 +1,4 @@
-import { CATEGORIES } from './categories'
+import { CATEGORY } from './category'
 import { LINK_FIELDS } from './link'
 import { MEDIA } from './media'
 import { META } from './meta'
@@ -28,7 +28,7 @@ export const ARCHIVE_BLOCK = `
   introContent
   populateBy
   relationTo
-  ${CATEGORIES}
+  ${CATEGORY}
   limit
   showPageRange
   selectedDocs {
@@ -48,7 +48,7 @@ export const ARCHIVE_BLOCK = `
         id
         slug
         title
-        ${CATEGORIES}
+        ${CATEGORY}
         ${META}
       }
     }

--- a/src/app/_graphql/categories.ts
+++ b/src/app/_graphql/categories.ts
@@ -1,4 +1,0 @@
-export const CATEGORIES = `categories {
-  title
-  id
-}`

--- a/src/app/_graphql/category.ts
+++ b/src/app/_graphql/category.ts
@@ -1,0 +1,4 @@
+export const CATEGORY = `category {
+  title
+  id
+}`

--- a/src/app/_providers/Context/Page/pageContext.tsx
+++ b/src/app/_providers/Context/Page/pageContext.tsx
@@ -7,7 +7,7 @@ import { Category, Keyword } from '../../../../payload/payload-types'
 // The page context handles both page and post scenarios
 // Settings states are optional covering both contexts
 // eg. Pages and Posts share some common values such as title and description
-// but not categories or keywords
+// but category or keywords
 interface PageContextType {
   title: string
   description: string

--- a/src/payload/blocks/ArchiveBlock/index.ts
+++ b/src/payload/blocks/ArchiveBlock/index.ts
@@ -45,9 +45,9 @@ export const Archive: Block = {
     },
     {
       type: 'relationship',
-      name: 'categories',
-      label: 'Categories To Show',
-      relationTo: 'categories',
+      name: 'category',
+      label: 'Category To Show',
+      relationTo: 'category',
       hasMany: true,
       admin: {
         condition: (_, siblingData) => siblingData.populateBy === 'collection',

--- a/src/payload/collections/Category.ts
+++ b/src/payload/collections/Category.ts
@@ -1,10 +1,10 @@
 import type { CollectionConfig } from 'payload/types'
 
-const Categories: CollectionConfig = {
-  slug: 'categories',
+const Category: CollectionConfig = {
+  slug: 'category',
   admin: {
     useAsTitle: 'title',
-    hidden: true,
+    // hidden: true,
   },
   access: {
     read: () => true,
@@ -17,4 +17,4 @@ const Categories: CollectionConfig = {
   ],
 }
 
-export default Categories
+export default Category

--- a/src/payload/collections/Posts/index.ts
+++ b/src/payload/collections/Posts/index.ts
@@ -63,7 +63,7 @@ export const Posts: CollectionConfig = {
           name: 'category',
           label: 'Category',
           type: 'relationship',
-          relationTo: 'categories',
+          relationTo: 'category',
           hasMany: false,
           required: true,
         },

--- a/src/payload/generated-schema.graphql
+++ b/src/payload/generated-schema.graphql
@@ -14,10 +14,13 @@ type Query {
   docAccessMedia(id: Int!): mediaDocAccess
   Category(id: Int!, draft: Boolean): Category
   Categories(draft: Boolean, where: Category_where, limit: Int, page: Int, sort: String): Categories
-  docAccessCategory(id: Int!): categoriesDocAccess
+  docAccessCategory(id: Int!): categoryDocAccess
   Keyword(id: Int!, draft: Boolean): Keyword
   Keywords(draft: Boolean, where: Keyword_where, limit: Int, page: Int, sort: String): Keywords
   docAccessKeyword(id: Int!): keywordsDocAccess
+  Client(id: Int!, draft: Boolean): Client
+  Clients(draft: Boolean, where: Client_where, limit: Int, page: Int, sort: String): Clients
+  docAccessClient(id: Int!): clientsDocAccess
   User(id: Int!, draft: Boolean): User
   Users(draft: Boolean, where: User_where, limit: Int, page: Int, sort: String): Users
   docAccessUser(id: Int!): usersDocAccess
@@ -41,7 +44,6 @@ type Page {
   title: String
   publishedAt: DateTime
   slug: String
-  hero: HeroField
   layout: [Layout!]
   meta: Page_Meta
   updatedAt: DateTime
@@ -54,23 +56,239 @@ A date-time string at UTC, such as 2007-12-03T10:15:30Z, compliant with the `dat
 """
 scalar DateTime
 
-type HeroField {
-  type: HeroField_type
+type Layout {
+  sideContentPosition: Layout_sideContentPosition
+  scrollSnap: Boolean
+  fullPageHeight: Boolean
+  sideColumn: SideColumn
+  mainColumn: MainColumn
+  id: String
+}
+
+enum Layout_sideContentPosition {
+  scrollSideContent
+  fixedSideContentWhenVisible
+  fixedSideContentAlways
+}
+
+type SideColumn {
+  style: SideColumn_style
+  hero: Hero
+  projectHero: ProjectHero
+  sideContent1(depth: Int): JSON
+  sideContent2(depth: Int): JSON
+}
+
+enum SideColumn_style {
+  none
+  hero
+  postHero
+  projectHero
+  singleLayout
+  twoRows
+}
+
+type Hero {
+  media(where: Hero_Media_where): Media
   description(depth: Int): JSON
   links: [LinkGroupField!]
 }
 
-enum HeroField_type {
-  none
-  fixedSidePanel
-  halfPage
-  fullPage
+type Media {
+  id: Int
+  alt: String!
+  caption(depth: Int): JSON
+  blurhash: String
+  updatedAt: DateTime
+  createdAt: DateTime
+  url: String
+  filename: String
+  mimeType: String
+  filesize: Float
+  width: Float
+  height: Float
 }
 
 """
 The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
 """
 scalar JSON
+
+input Hero_Media_where {
+  alt: Hero_Media_alt_operator
+  caption: Hero_Media_caption_operator
+  blurhash: Hero_Media_blurhash_operator
+  updatedAt: Hero_Media_updatedAt_operator
+  createdAt: Hero_Media_createdAt_operator
+  url: Hero_Media_url_operator
+  filename: Hero_Media_filename_operator
+  mimeType: Hero_Media_mimeType_operator
+  filesize: Hero_Media_filesize_operator
+  width: Hero_Media_width_operator
+  height: Hero_Media_height_operator
+  id: Hero_Media_id_operator
+  AND: [Hero_Media_where_and]
+  OR: [Hero_Media_where_or]
+}
+
+input Hero_Media_alt_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+}
+
+input Hero_Media_caption_operator {
+  equals: JSON
+  not_equals: JSON
+  like: JSON
+  contains: JSON
+  exists: Boolean
+}
+
+input Hero_Media_blurhash_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Hero_Media_updatedAt_operator {
+  equals: DateTime
+  not_equals: DateTime
+  greater_than_equal: DateTime
+  greater_than: DateTime
+  less_than_equal: DateTime
+  less_than: DateTime
+  like: DateTime
+  exists: Boolean
+}
+
+input Hero_Media_createdAt_operator {
+  equals: DateTime
+  not_equals: DateTime
+  greater_than_equal: DateTime
+  greater_than: DateTime
+  less_than_equal: DateTime
+  less_than: DateTime
+  like: DateTime
+  exists: Boolean
+}
+
+input Hero_Media_url_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Hero_Media_filename_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Hero_Media_mimeType_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Hero_Media_filesize_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Hero_Media_width_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Hero_Media_height_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Hero_Media_id_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Hero_Media_where_and {
+  alt: Hero_Media_alt_operator
+  caption: Hero_Media_caption_operator
+  blurhash: Hero_Media_blurhash_operator
+  updatedAt: Hero_Media_updatedAt_operator
+  createdAt: Hero_Media_createdAt_operator
+  url: Hero_Media_url_operator
+  filename: Hero_Media_filename_operator
+  mimeType: Hero_Media_mimeType_operator
+  filesize: Hero_Media_filesize_operator
+  width: Hero_Media_width_operator
+  height: Hero_Media_height_operator
+  id: Hero_Media_id_operator
+  AND: [Hero_Media_where_and]
+  OR: [Hero_Media_where_or]
+}
+
+input Hero_Media_where_or {
+  alt: Hero_Media_alt_operator
+  caption: Hero_Media_caption_operator
+  blurhash: Hero_Media_blurhash_operator
+  updatedAt: Hero_Media_updatedAt_operator
+  createdAt: Hero_Media_createdAt_operator
+  url: Hero_Media_url_operator
+  filename: Hero_Media_filename_operator
+  mimeType: Hero_Media_mimeType_operator
+  filesize: Hero_Media_filesize_operator
+  width: Hero_Media_width_operator
+  height: Hero_Media_height_operator
+  id: Hero_Media_id_operator
+  AND: [Hero_Media_where_and]
+  OR: [Hero_Media_where_or]
+}
 
 type LinkGroupField {
   link: LinkField
@@ -108,92 +326,38 @@ enum LinkField_appearance {
   secondary
 }
 
-type Layout {
-  fixedSideContent: Boolean
-  scrollSnap: Boolean
-  fullPageHeight: Boolean
-  sideColumn: sideColumn
-  mainColumn: Layout_MainColumn
-  id: String
+type ProjectHero {
+  year: Float
+  client: Client
+  links: [LinkGroupField!]
 }
 
-type sideColumn {
-  sideStyle: sideColumn_sideStyle
-  sideContent1(depth: Int): JSON
-  sideContent2(depth: Int): JSON
+type Client {
+  id: Int
+  title: String
+  updatedAt: DateTime
+  createdAt: DateTime
 }
 
-enum sideColumn_sideStyle {
-  none
-  singleLayout
-  twoRows
+type MainColumn {
+  style: MainColumn_style
+  row1column1(depth: Int): JSON
+  row1column2(depth: Int): JSON
+  row2column1(depth: Int): JSON
+  row2column2(depth: Int): JSON
 }
 
-type Layout_MainColumn {
-  layoutStyle: Layout_MainColumn_layoutStyle
-  singleLayout: SingleLayout
-  twoRows: TwoRows
-  twoColumns: TwoColumns
-  threeColumns: ThreeColumns
-  threeSectionGrid: ThreeSectionGrid
-}
-
-enum Layout_MainColumn_layoutStyle {
+enum MainColumn_style {
   singleLayout
   twoRows
   twoColumns
   threeSectionGrid
 }
 
-type SingleLayout {
-  singleLayout1(depth: Int): JSON
-}
-
-type TwoRows {
-  row1(depth: Int): JSON
-  row2(depth: Int): JSON
-}
-
-type TwoColumns {
-  col1(depth: Int): JSON
-  col2(depth: Int): JSON
-}
-
-type ThreeColumns {
-  col1(depth: Int): JSON
-  col2(depth: Int): JSON
-  col3(depth: Int): JSON
-}
-
-type ThreeSectionGrid {
-  left(depth: Int): JSON
-  right: ThreeSectionGrid_Right
-}
-
-type ThreeSectionGrid_Right {
-  rightTop(depth: Int): JSON
-  rightBottom(depth: Int): JSON
-}
-
 type Page_Meta {
   title: String
   description: String
   image(where: Page_Meta_Image_where): Media
-}
-
-type Media {
-  id: Int
-  alt: String!
-  caption(depth: Int): JSON
-  blurhash: String
-  updatedAt: DateTime
-  createdAt: DateTime
-  url: String
-  filename: String
-  mimeType: String
-  filesize: Float
-  width: Float
-  height: Float
 }
 
 input Page_Meta_Image_where {
@@ -395,33 +559,35 @@ input Page_where {
   title: Page_title_operator
   publishedAt: Page_publishedAt_operator
   slug: Page_slug_operator
-  hero__type: Page_hero__type_operator
-  hero__description: Page_hero__description_operator
-  hero__links__link__type: Page_hero__links__link__type_operator
-  hero__links__link__newTab: Page_hero__links__link__newTab_operator
-  hero__links__link__reference: Page_hero__links__link__reference_Relation
-  hero__links__link__url: Page_hero__links__link__url_operator
-  hero__links__link__label: Page_hero__links__link__label_operator
-  hero__links__link__appearance: Page_hero__links__link__appearance_operator
-  hero__links__id: Page_hero__links__id_operator
-  layout__fixedSideContent: Page_layout__fixedSideContent_operator
+  layout__sideContentPosition: Page_layout__sideContentPosition_operator
   layout__scrollSnap: Page_layout__scrollSnap_operator
   layout__fullPageHeight: Page_layout__fullPageHeight_operator
-  layout__sideColumn__sideStyle: Page_layout__sideColumn__sideStyle_operator
+  layout__sideColumn__style: Page_layout__sideColumn__style_operator
+  layout__sideColumn__hero__media: Page_layout__sideColumn__hero__media_operator
+  layout__sideColumn__hero__description: Page_layout__sideColumn__hero__description_operator
+  layout__sideColumn__hero__links__link__type: Page_layout__sideColumn__hero__links__link__type_operator
+  layout__sideColumn__hero__links__link__newTab: Page_layout__sideColumn__hero__links__link__newTab_operator
+  layout__sideColumn__hero__links__link__reference: Page_layout__sideColumn__hero__links__link__reference_Relation
+  layout__sideColumn__hero__links__link__url: Page_layout__sideColumn__hero__links__link__url_operator
+  layout__sideColumn__hero__links__link__label: Page_layout__sideColumn__hero__links__link__label_operator
+  layout__sideColumn__hero__links__link__appearance: Page_layout__sideColumn__hero__links__link__appearance_operator
+  layout__sideColumn__hero__links__id: Page_layout__sideColumn__hero__links__id_operator
+  layout__sideColumn__projectHero__year: Page_layout__sideColumn__projectHero__year_operator
+  layout__sideColumn__projectHero__client: Page_layout__sideColumn__projectHero__client_operator
+  layout__sideColumn__projectHero__links__link__type: Page_layout__sideColumn__projectHero__links__link__type_operator
+  layout__sideColumn__projectHero__links__link__newTab: Page_layout__sideColumn__projectHero__links__link__newTab_operator
+  layout__sideColumn__projectHero__links__link__reference: Page_layout__sideColumn__projectHero__links__link__reference_Relation
+  layout__sideColumn__projectHero__links__link__url: Page_layout__sideColumn__projectHero__links__link__url_operator
+  layout__sideColumn__projectHero__links__link__label: Page_layout__sideColumn__projectHero__links__link__label_operator
+  layout__sideColumn__projectHero__links__link__appearance: Page_layout__sideColumn__projectHero__links__link__appearance_operator
+  layout__sideColumn__projectHero__links__id: Page_layout__sideColumn__projectHero__links__id_operator
   layout__sideColumn__sideContent1: Page_layout__sideColumn__sideContent1_operator
   layout__sideColumn__sideContent2: Page_layout__sideColumn__sideContent2_operator
-  layout__mainColumn__layoutStyle: Page_layout__mainColumn__layoutStyle_operator
-  layout__mainColumn__singleLayout__singleLayout1: Page_layout__mainColumn__singleLayout__singleLayout1_operator
-  layout__mainColumn__twoRows__row1: Page_layout__mainColumn__twoRows__row1_operator
-  layout__mainColumn__twoRows__row2: Page_layout__mainColumn__twoRows__row2_operator
-  layout__mainColumn__twoColumns__col1: Page_layout__mainColumn__twoColumns__col1_operator
-  layout__mainColumn__twoColumns__col2: Page_layout__mainColumn__twoColumns__col2_operator
-  layout__mainColumn__threeColumns__col1: Page_layout__mainColumn__threeColumns__col1_operator
-  layout__mainColumn__threeColumns__col2: Page_layout__mainColumn__threeColumns__col2_operator
-  layout__mainColumn__threeColumns__col3: Page_layout__mainColumn__threeColumns__col3_operator
-  layout__mainColumn__threeSectionGrid__left: Page_layout__mainColumn__threeSectionGrid__left_operator
-  layout__mainColumn__threeSectionGrid__right__rightTop: Page_layout__mainColumn__threeSectionGrid__right__rightTop_operator
-  layout__mainColumn__threeSectionGrid__right__rightBottom: Page_layout__mainColumn__threeSectionGrid__right__rightBottom_operator
+  layout__mainColumn__style: Page_layout__mainColumn__style_operator
+  layout__mainColumn__row1column1: Page_layout__mainColumn__row1column1_operator
+  layout__mainColumn__row1column2: Page_layout__mainColumn__row1column2_operator
+  layout__mainColumn__row2column1: Page_layout__mainColumn__row2column1_operator
+  layout__mainColumn__row2column2: Page_layout__mainColumn__row2column2_operator
   layout__id: Page_layout__id_operator
   meta__title: Page_meta__title_operator
   meta__description: Page_meta__description_operator
@@ -466,107 +632,18 @@ input Page_slug_operator {
   exists: Boolean
 }
 
-input Page_hero__type_operator {
-  equals: Page_hero__type_Input
-  not_equals: Page_hero__type_Input
-  in: [Page_hero__type_Input]
-  not_in: [Page_hero__type_Input]
-  all: [Page_hero__type_Input]
+input Page_layout__sideContentPosition_operator {
+  equals: Page_layout__sideContentPosition_Input
+  not_equals: Page_layout__sideContentPosition_Input
+  in: [Page_layout__sideContentPosition_Input]
+  not_in: [Page_layout__sideContentPosition_Input]
+  all: [Page_layout__sideContentPosition_Input]
 }
 
-enum Page_hero__type_Input {
-  none
-  fixedSidePanel
-  halfPage
-  fullPage
-}
-
-input Page_hero__description_operator {
-  equals: JSON
-  not_equals: JSON
-  like: JSON
-  contains: JSON
-  exists: Boolean
-}
-
-input Page_hero__links__link__type_operator {
-  equals: Page_hero__links__link__type_Input
-  not_equals: Page_hero__links__link__type_Input
-  like: Page_hero__links__link__type_Input
-  contains: Page_hero__links__link__type_Input
-  exists: Boolean
-}
-
-enum Page_hero__links__link__type_Input {
-  reference
-  custom
-}
-
-input Page_hero__links__link__newTab_operator {
-  equals: Boolean
-  not_equals: Boolean
-  exists: Boolean
-}
-
-input Page_hero__links__link__reference_Relation {
-  relationTo: Page_hero__links__link__reference_Relation_RelationTo
-  value: JSON
-}
-
-enum Page_hero__links__link__reference_Relation_RelationTo {
-  pages
-}
-
-input Page_hero__links__link__url_operator {
-  equals: String
-  not_equals: String
-  like: String
-  contains: String
-  in: [String]
-  not_in: [String]
-  all: [String]
-}
-
-input Page_hero__links__link__label_operator {
-  equals: String
-  not_equals: String
-  like: String
-  contains: String
-  in: [String]
-  not_in: [String]
-  all: [String]
-}
-
-input Page_hero__links__link__appearance_operator {
-  equals: Page_hero__links__link__appearance_Input
-  not_equals: Page_hero__links__link__appearance_Input
-  in: [Page_hero__links__link__appearance_Input]
-  not_in: [Page_hero__links__link__appearance_Input]
-  all: [Page_hero__links__link__appearance_Input]
-  exists: Boolean
-}
-
-enum Page_hero__links__link__appearance_Input {
-  default
-  primary
-  secondary
-}
-
-input Page_hero__links__id_operator {
-  equals: String
-  not_equals: String
-  like: String
-  contains: String
-  in: [String]
-  not_in: [String]
-  all: [String]
-  exists: Boolean
-}
-
-input Page_layout__fixedSideContent_operator {
-  equals: Boolean
-  not_equals: Boolean
-  exists: Boolean
+enum Page_layout__sideContentPosition_Input {
+  scrollSideContent
+  fixedSideContentWhenVisible
+  fixedSideContentAlways
 }
 
 input Page_layout__scrollSnap_operator {
@@ -581,18 +658,202 @@ input Page_layout__fullPageHeight_operator {
   exists: Boolean
 }
 
-input Page_layout__sideColumn__sideStyle_operator {
-  equals: Page_layout__sideColumn__sideStyle_Input
-  not_equals: Page_layout__sideColumn__sideStyle_Input
-  in: [Page_layout__sideColumn__sideStyle_Input]
-  not_in: [Page_layout__sideColumn__sideStyle_Input]
-  all: [Page_layout__sideColumn__sideStyle_Input]
+input Page_layout__sideColumn__style_operator {
+  equals: Page_layout__sideColumn__style_Input
+  not_equals: Page_layout__sideColumn__style_Input
+  in: [Page_layout__sideColumn__style_Input]
+  not_in: [Page_layout__sideColumn__style_Input]
+  all: [Page_layout__sideColumn__style_Input]
 }
 
-enum Page_layout__sideColumn__sideStyle_Input {
+enum Page_layout__sideColumn__style_Input {
   none
+  hero
+  postHero
+  projectHero
   singleLayout
   twoRows
+}
+
+input Page_layout__sideColumn__hero__media_operator {
+  equals: String
+  not_equals: String
+  exists: Boolean
+}
+
+input Page_layout__sideColumn__hero__description_operator {
+  equals: JSON
+  not_equals: JSON
+  like: JSON
+  contains: JSON
+  exists: Boolean
+}
+
+input Page_layout__sideColumn__hero__links__link__type_operator {
+  equals: Page_layout__sideColumn__hero__links__link__type_Input
+  not_equals: Page_layout__sideColumn__hero__links__link__type_Input
+  like: Page_layout__sideColumn__hero__links__link__type_Input
+  contains: Page_layout__sideColumn__hero__links__link__type_Input
+  exists: Boolean
+}
+
+enum Page_layout__sideColumn__hero__links__link__type_Input {
+  reference
+  custom
+}
+
+input Page_layout__sideColumn__hero__links__link__newTab_operator {
+  equals: Boolean
+  not_equals: Boolean
+  exists: Boolean
+}
+
+input Page_layout__sideColumn__hero__links__link__reference_Relation {
+  relationTo: Page_layout__sideColumn__hero__links__link__reference_Relation_RelationTo
+  value: JSON
+}
+
+enum Page_layout__sideColumn__hero__links__link__reference_Relation_RelationTo {
+  pages
+}
+
+input Page_layout__sideColumn__hero__links__link__url_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+}
+
+input Page_layout__sideColumn__hero__links__link__label_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+}
+
+input Page_layout__sideColumn__hero__links__link__appearance_operator {
+  equals: Page_layout__sideColumn__hero__links__link__appearance_Input
+  not_equals: Page_layout__sideColumn__hero__links__link__appearance_Input
+  in: [Page_layout__sideColumn__hero__links__link__appearance_Input]
+  not_in: [Page_layout__sideColumn__hero__links__link__appearance_Input]
+  all: [Page_layout__sideColumn__hero__links__link__appearance_Input]
+  exists: Boolean
+}
+
+enum Page_layout__sideColumn__hero__links__link__appearance_Input {
+  default
+  primary
+  secondary
+}
+
+input Page_layout__sideColumn__hero__links__id_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Page_layout__sideColumn__projectHero__year_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Page_layout__sideColumn__projectHero__client_operator {
+  equals: JSON
+  not_equals: JSON
+  in: [JSON]
+  not_in: [JSON]
+  all: [JSON]
+  exists: Boolean
+}
+
+input Page_layout__sideColumn__projectHero__links__link__type_operator {
+  equals: Page_layout__sideColumn__projectHero__links__link__type_Input
+  not_equals: Page_layout__sideColumn__projectHero__links__link__type_Input
+  like: Page_layout__sideColumn__projectHero__links__link__type_Input
+  contains: Page_layout__sideColumn__projectHero__links__link__type_Input
+  exists: Boolean
+}
+
+enum Page_layout__sideColumn__projectHero__links__link__type_Input {
+  reference
+  custom
+}
+
+input Page_layout__sideColumn__projectHero__links__link__newTab_operator {
+  equals: Boolean
+  not_equals: Boolean
+  exists: Boolean
+}
+
+input Page_layout__sideColumn__projectHero__links__link__reference_Relation {
+  relationTo: Page_layout__sideColumn__projectHero__links__link__reference_Relation_RelationTo
+  value: JSON
+}
+
+enum Page_layout__sideColumn__projectHero__links__link__reference_Relation_RelationTo {
+  pages
+}
+
+input Page_layout__sideColumn__projectHero__links__link__url_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+}
+
+input Page_layout__sideColumn__projectHero__links__link__label_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+}
+
+input Page_layout__sideColumn__projectHero__links__link__appearance_operator {
+  equals: Page_layout__sideColumn__projectHero__links__link__appearance_Input
+  not_equals: Page_layout__sideColumn__projectHero__links__link__appearance_Input
+  in: [Page_layout__sideColumn__projectHero__links__link__appearance_Input]
+  not_in: [Page_layout__sideColumn__projectHero__links__link__appearance_Input]
+  all: [Page_layout__sideColumn__projectHero__links__link__appearance_Input]
+  exists: Boolean
+}
+
+enum Page_layout__sideColumn__projectHero__links__link__appearance_Input {
+  default
+  primary
+  secondary
+}
+
+input Page_layout__sideColumn__projectHero__links__id_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
 }
 
 input Page_layout__sideColumn__sideContent1_operator {
@@ -611,22 +872,22 @@ input Page_layout__sideColumn__sideContent2_operator {
   exists: Boolean
 }
 
-input Page_layout__mainColumn__layoutStyle_operator {
-  equals: Page_layout__mainColumn__layoutStyle_Input
-  not_equals: Page_layout__mainColumn__layoutStyle_Input
-  in: [Page_layout__mainColumn__layoutStyle_Input]
-  not_in: [Page_layout__mainColumn__layoutStyle_Input]
-  all: [Page_layout__mainColumn__layoutStyle_Input]
+input Page_layout__mainColumn__style_operator {
+  equals: Page_layout__mainColumn__style_Input
+  not_equals: Page_layout__mainColumn__style_Input
+  in: [Page_layout__mainColumn__style_Input]
+  not_in: [Page_layout__mainColumn__style_Input]
+  all: [Page_layout__mainColumn__style_Input]
 }
 
-enum Page_layout__mainColumn__layoutStyle_Input {
+enum Page_layout__mainColumn__style_Input {
   singleLayout
   twoRows
   twoColumns
   threeSectionGrid
 }
 
-input Page_layout__mainColumn__singleLayout__singleLayout1_operator {
+input Page_layout__mainColumn__row1column1_operator {
   equals: JSON
   not_equals: JSON
   like: JSON
@@ -634,7 +895,7 @@ input Page_layout__mainColumn__singleLayout__singleLayout1_operator {
   exists: Boolean
 }
 
-input Page_layout__mainColumn__twoRows__row1_operator {
+input Page_layout__mainColumn__row1column2_operator {
   equals: JSON
   not_equals: JSON
   like: JSON
@@ -642,7 +903,7 @@ input Page_layout__mainColumn__twoRows__row1_operator {
   exists: Boolean
 }
 
-input Page_layout__mainColumn__twoRows__row2_operator {
+input Page_layout__mainColumn__row2column1_operator {
   equals: JSON
   not_equals: JSON
   like: JSON
@@ -650,63 +911,7 @@ input Page_layout__mainColumn__twoRows__row2_operator {
   exists: Boolean
 }
 
-input Page_layout__mainColumn__twoColumns__col1_operator {
-  equals: JSON
-  not_equals: JSON
-  like: JSON
-  contains: JSON
-  exists: Boolean
-}
-
-input Page_layout__mainColumn__twoColumns__col2_operator {
-  equals: JSON
-  not_equals: JSON
-  like: JSON
-  contains: JSON
-  exists: Boolean
-}
-
-input Page_layout__mainColumn__threeColumns__col1_operator {
-  equals: JSON
-  not_equals: JSON
-  like: JSON
-  contains: JSON
-  exists: Boolean
-}
-
-input Page_layout__mainColumn__threeColumns__col2_operator {
-  equals: JSON
-  not_equals: JSON
-  like: JSON
-  contains: JSON
-  exists: Boolean
-}
-
-input Page_layout__mainColumn__threeColumns__col3_operator {
-  equals: JSON
-  not_equals: JSON
-  like: JSON
-  contains: JSON
-  exists: Boolean
-}
-
-input Page_layout__mainColumn__threeSectionGrid__left_operator {
-  equals: JSON
-  not_equals: JSON
-  like: JSON
-  contains: JSON
-  exists: Boolean
-}
-
-input Page_layout__mainColumn__threeSectionGrid__right__rightTop_operator {
-  equals: JSON
-  not_equals: JSON
-  like: JSON
-  contains: JSON
-  exists: Boolean
-}
-
-input Page_layout__mainColumn__threeSectionGrid__right__rightBottom_operator {
+input Page_layout__mainColumn__row2column2_operator {
   equals: JSON
   not_equals: JSON
   like: JSON
@@ -800,33 +1005,35 @@ input Page_where_and {
   title: Page_title_operator
   publishedAt: Page_publishedAt_operator
   slug: Page_slug_operator
-  hero__type: Page_hero__type_operator
-  hero__description: Page_hero__description_operator
-  hero__links__link__type: Page_hero__links__link__type_operator
-  hero__links__link__newTab: Page_hero__links__link__newTab_operator
-  hero__links__link__reference: Page_hero__links__link__reference_Relation
-  hero__links__link__url: Page_hero__links__link__url_operator
-  hero__links__link__label: Page_hero__links__link__label_operator
-  hero__links__link__appearance: Page_hero__links__link__appearance_operator
-  hero__links__id: Page_hero__links__id_operator
-  layout__fixedSideContent: Page_layout__fixedSideContent_operator
+  layout__sideContentPosition: Page_layout__sideContentPosition_operator
   layout__scrollSnap: Page_layout__scrollSnap_operator
   layout__fullPageHeight: Page_layout__fullPageHeight_operator
-  layout__sideColumn__sideStyle: Page_layout__sideColumn__sideStyle_operator
+  layout__sideColumn__style: Page_layout__sideColumn__style_operator
+  layout__sideColumn__hero__media: Page_layout__sideColumn__hero__media_operator
+  layout__sideColumn__hero__description: Page_layout__sideColumn__hero__description_operator
+  layout__sideColumn__hero__links__link__type: Page_layout__sideColumn__hero__links__link__type_operator
+  layout__sideColumn__hero__links__link__newTab: Page_layout__sideColumn__hero__links__link__newTab_operator
+  layout__sideColumn__hero__links__link__reference: Page_layout__sideColumn__hero__links__link__reference_Relation
+  layout__sideColumn__hero__links__link__url: Page_layout__sideColumn__hero__links__link__url_operator
+  layout__sideColumn__hero__links__link__label: Page_layout__sideColumn__hero__links__link__label_operator
+  layout__sideColumn__hero__links__link__appearance: Page_layout__sideColumn__hero__links__link__appearance_operator
+  layout__sideColumn__hero__links__id: Page_layout__sideColumn__hero__links__id_operator
+  layout__sideColumn__projectHero__year: Page_layout__sideColumn__projectHero__year_operator
+  layout__sideColumn__projectHero__client: Page_layout__sideColumn__projectHero__client_operator
+  layout__sideColumn__projectHero__links__link__type: Page_layout__sideColumn__projectHero__links__link__type_operator
+  layout__sideColumn__projectHero__links__link__newTab: Page_layout__sideColumn__projectHero__links__link__newTab_operator
+  layout__sideColumn__projectHero__links__link__reference: Page_layout__sideColumn__projectHero__links__link__reference_Relation
+  layout__sideColumn__projectHero__links__link__url: Page_layout__sideColumn__projectHero__links__link__url_operator
+  layout__sideColumn__projectHero__links__link__label: Page_layout__sideColumn__projectHero__links__link__label_operator
+  layout__sideColumn__projectHero__links__link__appearance: Page_layout__sideColumn__projectHero__links__link__appearance_operator
+  layout__sideColumn__projectHero__links__id: Page_layout__sideColumn__projectHero__links__id_operator
   layout__sideColumn__sideContent1: Page_layout__sideColumn__sideContent1_operator
   layout__sideColumn__sideContent2: Page_layout__sideColumn__sideContent2_operator
-  layout__mainColumn__layoutStyle: Page_layout__mainColumn__layoutStyle_operator
-  layout__mainColumn__singleLayout__singleLayout1: Page_layout__mainColumn__singleLayout__singleLayout1_operator
-  layout__mainColumn__twoRows__row1: Page_layout__mainColumn__twoRows__row1_operator
-  layout__mainColumn__twoRows__row2: Page_layout__mainColumn__twoRows__row2_operator
-  layout__mainColumn__twoColumns__col1: Page_layout__mainColumn__twoColumns__col1_operator
-  layout__mainColumn__twoColumns__col2: Page_layout__mainColumn__twoColumns__col2_operator
-  layout__mainColumn__threeColumns__col1: Page_layout__mainColumn__threeColumns__col1_operator
-  layout__mainColumn__threeColumns__col2: Page_layout__mainColumn__threeColumns__col2_operator
-  layout__mainColumn__threeColumns__col3: Page_layout__mainColumn__threeColumns__col3_operator
-  layout__mainColumn__threeSectionGrid__left: Page_layout__mainColumn__threeSectionGrid__left_operator
-  layout__mainColumn__threeSectionGrid__right__rightTop: Page_layout__mainColumn__threeSectionGrid__right__rightTop_operator
-  layout__mainColumn__threeSectionGrid__right__rightBottom: Page_layout__mainColumn__threeSectionGrid__right__rightBottom_operator
+  layout__mainColumn__style: Page_layout__mainColumn__style_operator
+  layout__mainColumn__row1column1: Page_layout__mainColumn__row1column1_operator
+  layout__mainColumn__row1column2: Page_layout__mainColumn__row1column2_operator
+  layout__mainColumn__row2column1: Page_layout__mainColumn__row2column1_operator
+  layout__mainColumn__row2column2: Page_layout__mainColumn__row2column2_operator
   layout__id: Page_layout__id_operator
   meta__title: Page_meta__title_operator
   meta__description: Page_meta__description_operator
@@ -843,33 +1050,35 @@ input Page_where_or {
   title: Page_title_operator
   publishedAt: Page_publishedAt_operator
   slug: Page_slug_operator
-  hero__type: Page_hero__type_operator
-  hero__description: Page_hero__description_operator
-  hero__links__link__type: Page_hero__links__link__type_operator
-  hero__links__link__newTab: Page_hero__links__link__newTab_operator
-  hero__links__link__reference: Page_hero__links__link__reference_Relation
-  hero__links__link__url: Page_hero__links__link__url_operator
-  hero__links__link__label: Page_hero__links__link__label_operator
-  hero__links__link__appearance: Page_hero__links__link__appearance_operator
-  hero__links__id: Page_hero__links__id_operator
-  layout__fixedSideContent: Page_layout__fixedSideContent_operator
+  layout__sideContentPosition: Page_layout__sideContentPosition_operator
   layout__scrollSnap: Page_layout__scrollSnap_operator
   layout__fullPageHeight: Page_layout__fullPageHeight_operator
-  layout__sideColumn__sideStyle: Page_layout__sideColumn__sideStyle_operator
+  layout__sideColumn__style: Page_layout__sideColumn__style_operator
+  layout__sideColumn__hero__media: Page_layout__sideColumn__hero__media_operator
+  layout__sideColumn__hero__description: Page_layout__sideColumn__hero__description_operator
+  layout__sideColumn__hero__links__link__type: Page_layout__sideColumn__hero__links__link__type_operator
+  layout__sideColumn__hero__links__link__newTab: Page_layout__sideColumn__hero__links__link__newTab_operator
+  layout__sideColumn__hero__links__link__reference: Page_layout__sideColumn__hero__links__link__reference_Relation
+  layout__sideColumn__hero__links__link__url: Page_layout__sideColumn__hero__links__link__url_operator
+  layout__sideColumn__hero__links__link__label: Page_layout__sideColumn__hero__links__link__label_operator
+  layout__sideColumn__hero__links__link__appearance: Page_layout__sideColumn__hero__links__link__appearance_operator
+  layout__sideColumn__hero__links__id: Page_layout__sideColumn__hero__links__id_operator
+  layout__sideColumn__projectHero__year: Page_layout__sideColumn__projectHero__year_operator
+  layout__sideColumn__projectHero__client: Page_layout__sideColumn__projectHero__client_operator
+  layout__sideColumn__projectHero__links__link__type: Page_layout__sideColumn__projectHero__links__link__type_operator
+  layout__sideColumn__projectHero__links__link__newTab: Page_layout__sideColumn__projectHero__links__link__newTab_operator
+  layout__sideColumn__projectHero__links__link__reference: Page_layout__sideColumn__projectHero__links__link__reference_Relation
+  layout__sideColumn__projectHero__links__link__url: Page_layout__sideColumn__projectHero__links__link__url_operator
+  layout__sideColumn__projectHero__links__link__label: Page_layout__sideColumn__projectHero__links__link__label_operator
+  layout__sideColumn__projectHero__links__link__appearance: Page_layout__sideColumn__projectHero__links__link__appearance_operator
+  layout__sideColumn__projectHero__links__id: Page_layout__sideColumn__projectHero__links__id_operator
   layout__sideColumn__sideContent1: Page_layout__sideColumn__sideContent1_operator
   layout__sideColumn__sideContent2: Page_layout__sideColumn__sideContent2_operator
-  layout__mainColumn__layoutStyle: Page_layout__mainColumn__layoutStyle_operator
-  layout__mainColumn__singleLayout__singleLayout1: Page_layout__mainColumn__singleLayout__singleLayout1_operator
-  layout__mainColumn__twoRows__row1: Page_layout__mainColumn__twoRows__row1_operator
-  layout__mainColumn__twoRows__row2: Page_layout__mainColumn__twoRows__row2_operator
-  layout__mainColumn__twoColumns__col1: Page_layout__mainColumn__twoColumns__col1_operator
-  layout__mainColumn__twoColumns__col2: Page_layout__mainColumn__twoColumns__col2_operator
-  layout__mainColumn__threeColumns__col1: Page_layout__mainColumn__threeColumns__col1_operator
-  layout__mainColumn__threeColumns__col2: Page_layout__mainColumn__threeColumns__col2_operator
-  layout__mainColumn__threeColumns__col3: Page_layout__mainColumn__threeColumns__col3_operator
-  layout__mainColumn__threeSectionGrid__left: Page_layout__mainColumn__threeSectionGrid__left_operator
-  layout__mainColumn__threeSectionGrid__right__rightTop: Page_layout__mainColumn__threeSectionGrid__right__rightTop_operator
-  layout__mainColumn__threeSectionGrid__right__rightBottom: Page_layout__mainColumn__threeSectionGrid__right__rightBottom_operator
+  layout__mainColumn__style: Page_layout__mainColumn__style_operator
+  layout__mainColumn__row1column1: Page_layout__mainColumn__row1column1_operator
+  layout__mainColumn__row1column2: Page_layout__mainColumn__row1column2_operator
+  layout__mainColumn__row2column1: Page_layout__mainColumn__row2column1_operator
+  layout__mainColumn__row2column2: Page_layout__mainColumn__row2column2_operator
   layout__id: Page_layout__id_operator
   meta__title: Page_meta__title_operator
   meta__description: Page_meta__description_operator
@@ -895,7 +1104,6 @@ type PagesDocAccessFields {
   title: PagesDocAccessFields_title
   publishedAt: PagesDocAccessFields_publishedAt
   slug: PagesDocAccessFields_slug
-  hero: PagesDocAccessFields_hero
   layout: PagesDocAccessFields_layout
   meta: PagesDocAccessFields_meta
   updatedAt: PagesDocAccessFields_updatedAt
@@ -972,305 +1180,6 @@ type PagesDocAccessFields_slug_Delete {
   permission: Boolean!
 }
 
-type PagesDocAccessFields_hero {
-  create: PagesDocAccessFields_hero_Create
-  read: PagesDocAccessFields_hero_Read
-  update: PagesDocAccessFields_hero_Update
-  delete: PagesDocAccessFields_hero_Delete
-  fields: PagesDocAccessFields_hero_Fields
-}
-
-type PagesDocAccessFields_hero_Create {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_hero_Read {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_hero_Update {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_hero_Delete {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_hero_Fields {
-  type: PagesDocAccessFields_hero_type
-  description: PagesDocAccessFields_hero_description
-  links: PagesDocAccessFields_hero_links
-}
-
-type PagesDocAccessFields_hero_type {
-  create: PagesDocAccessFields_hero_type_Create
-  read: PagesDocAccessFields_hero_type_Read
-  update: PagesDocAccessFields_hero_type_Update
-  delete: PagesDocAccessFields_hero_type_Delete
-}
-
-type PagesDocAccessFields_hero_type_Create {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_hero_type_Read {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_hero_type_Update {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_hero_type_Delete {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_hero_description {
-  create: PagesDocAccessFields_hero_description_Create
-  read: PagesDocAccessFields_hero_description_Read
-  update: PagesDocAccessFields_hero_description_Update
-  delete: PagesDocAccessFields_hero_description_Delete
-}
-
-type PagesDocAccessFields_hero_description_Create {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_hero_description_Read {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_hero_description_Update {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_hero_description_Delete {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_hero_links {
-  create: PagesDocAccessFields_hero_links_Create
-  read: PagesDocAccessFields_hero_links_Read
-  update: PagesDocAccessFields_hero_links_Update
-  delete: PagesDocAccessFields_hero_links_Delete
-  fields: PagesDocAccessFields_hero_links_Fields
-}
-
-type PagesDocAccessFields_hero_links_Create {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_hero_links_Read {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_hero_links_Update {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_hero_links_Delete {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_hero_links_Fields {
-  link: PagesDocAccessFields_hero_links_link
-  id: PagesDocAccessFields_hero_links_id
-}
-
-type PagesDocAccessFields_hero_links_link {
-  create: PagesDocAccessFields_hero_links_link_Create
-  read: PagesDocAccessFields_hero_links_link_Read
-  update: PagesDocAccessFields_hero_links_link_Update
-  delete: PagesDocAccessFields_hero_links_link_Delete
-  fields: PagesDocAccessFields_hero_links_link_Fields
-}
-
-type PagesDocAccessFields_hero_links_link_Create {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_hero_links_link_Read {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_hero_links_link_Update {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_hero_links_link_Delete {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_hero_links_link_Fields {
-  type: PagesDocAccessFields_hero_links_link_type
-  newTab: PagesDocAccessFields_hero_links_link_newTab
-  reference: PagesDocAccessFields_hero_links_link_reference
-  url: PagesDocAccessFields_hero_links_link_url
-  label: PagesDocAccessFields_hero_links_link_label
-  appearance: PagesDocAccessFields_hero_links_link_appearance
-}
-
-type PagesDocAccessFields_hero_links_link_type {
-  create: PagesDocAccessFields_hero_links_link_type_Create
-  read: PagesDocAccessFields_hero_links_link_type_Read
-  update: PagesDocAccessFields_hero_links_link_type_Update
-  delete: PagesDocAccessFields_hero_links_link_type_Delete
-}
-
-type PagesDocAccessFields_hero_links_link_type_Create {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_hero_links_link_type_Read {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_hero_links_link_type_Update {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_hero_links_link_type_Delete {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_hero_links_link_newTab {
-  create: PagesDocAccessFields_hero_links_link_newTab_Create
-  read: PagesDocAccessFields_hero_links_link_newTab_Read
-  update: PagesDocAccessFields_hero_links_link_newTab_Update
-  delete: PagesDocAccessFields_hero_links_link_newTab_Delete
-}
-
-type PagesDocAccessFields_hero_links_link_newTab_Create {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_hero_links_link_newTab_Read {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_hero_links_link_newTab_Update {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_hero_links_link_newTab_Delete {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_hero_links_link_reference {
-  create: PagesDocAccessFields_hero_links_link_reference_Create
-  read: PagesDocAccessFields_hero_links_link_reference_Read
-  update: PagesDocAccessFields_hero_links_link_reference_Update
-  delete: PagesDocAccessFields_hero_links_link_reference_Delete
-}
-
-type PagesDocAccessFields_hero_links_link_reference_Create {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_hero_links_link_reference_Read {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_hero_links_link_reference_Update {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_hero_links_link_reference_Delete {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_hero_links_link_url {
-  create: PagesDocAccessFields_hero_links_link_url_Create
-  read: PagesDocAccessFields_hero_links_link_url_Read
-  update: PagesDocAccessFields_hero_links_link_url_Update
-  delete: PagesDocAccessFields_hero_links_link_url_Delete
-}
-
-type PagesDocAccessFields_hero_links_link_url_Create {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_hero_links_link_url_Read {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_hero_links_link_url_Update {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_hero_links_link_url_Delete {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_hero_links_link_label {
-  create: PagesDocAccessFields_hero_links_link_label_Create
-  read: PagesDocAccessFields_hero_links_link_label_Read
-  update: PagesDocAccessFields_hero_links_link_label_Update
-  delete: PagesDocAccessFields_hero_links_link_label_Delete
-}
-
-type PagesDocAccessFields_hero_links_link_label_Create {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_hero_links_link_label_Read {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_hero_links_link_label_Update {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_hero_links_link_label_Delete {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_hero_links_link_appearance {
-  create: PagesDocAccessFields_hero_links_link_appearance_Create
-  read: PagesDocAccessFields_hero_links_link_appearance_Read
-  update: PagesDocAccessFields_hero_links_link_appearance_Update
-  delete: PagesDocAccessFields_hero_links_link_appearance_Delete
-}
-
-type PagesDocAccessFields_hero_links_link_appearance_Create {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_hero_links_link_appearance_Read {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_hero_links_link_appearance_Update {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_hero_links_link_appearance_Delete {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_hero_links_id {
-  create: PagesDocAccessFields_hero_links_id_Create
-  read: PagesDocAccessFields_hero_links_id_Read
-  update: PagesDocAccessFields_hero_links_id_Update
-  delete: PagesDocAccessFields_hero_links_id_Delete
-}
-
-type PagesDocAccessFields_hero_links_id_Create {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_hero_links_id_Read {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_hero_links_id_Update {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_hero_links_id_Delete {
-  permission: Boolean!
-}
-
 type PagesDocAccessFields_layout {
   create: PagesDocAccessFields_layout_Create
   read: PagesDocAccessFields_layout_Read
@@ -1296,7 +1205,7 @@ type PagesDocAccessFields_layout_Delete {
 }
 
 type PagesDocAccessFields_layout_Fields {
-  fixedSideContent: PagesDocAccessFields_layout_fixedSideContent
+  sideContentPosition: PagesDocAccessFields_layout_sideContentPosition
   scrollSnap: PagesDocAccessFields_layout_scrollSnap
   fullPageHeight: PagesDocAccessFields_layout_fullPageHeight
   sideColumn: PagesDocAccessFields_layout_sideColumn
@@ -1304,26 +1213,26 @@ type PagesDocAccessFields_layout_Fields {
   id: PagesDocAccessFields_layout_id
 }
 
-type PagesDocAccessFields_layout_fixedSideContent {
-  create: PagesDocAccessFields_layout_fixedSideContent_Create
-  read: PagesDocAccessFields_layout_fixedSideContent_Read
-  update: PagesDocAccessFields_layout_fixedSideContent_Update
-  delete: PagesDocAccessFields_layout_fixedSideContent_Delete
+type PagesDocAccessFields_layout_sideContentPosition {
+  create: PagesDocAccessFields_layout_sideContentPosition_Create
+  read: PagesDocAccessFields_layout_sideContentPosition_Read
+  update: PagesDocAccessFields_layout_sideContentPosition_Update
+  delete: PagesDocAccessFields_layout_sideContentPosition_Delete
 }
 
-type PagesDocAccessFields_layout_fixedSideContent_Create {
+type PagesDocAccessFields_layout_sideContentPosition_Create {
   permission: Boolean!
 }
 
-type PagesDocAccessFields_layout_fixedSideContent_Read {
+type PagesDocAccessFields_layout_sideContentPosition_Read {
   permission: Boolean!
 }
 
-type PagesDocAccessFields_layout_fixedSideContent_Update {
+type PagesDocAccessFields_layout_sideContentPosition_Update {
   permission: Boolean!
 }
 
-type PagesDocAccessFields_layout_fixedSideContent_Delete {
+type PagesDocAccessFields_layout_sideContentPosition_Delete {
   permission: Boolean!
 }
 
@@ -1398,31 +1307,631 @@ type PagesDocAccessFields_layout_sideColumn_Delete {
 }
 
 type PagesDocAccessFields_layout_sideColumn_Fields {
-  sideStyle: PagesDocAccessFields_layout_sideColumn_sideStyle
+  style: PagesDocAccessFields_layout_sideColumn_style
+  hero: PagesDocAccessFields_layout_sideColumn_hero
+  projectHero: PagesDocAccessFields_layout_sideColumn_projectHero
   sideContent1: PagesDocAccessFields_layout_sideColumn_sideContent1
   sideContent2: PagesDocAccessFields_layout_sideColumn_sideContent2
 }
 
-type PagesDocAccessFields_layout_sideColumn_sideStyle {
-  create: PagesDocAccessFields_layout_sideColumn_sideStyle_Create
-  read: PagesDocAccessFields_layout_sideColumn_sideStyle_Read
-  update: PagesDocAccessFields_layout_sideColumn_sideStyle_Update
-  delete: PagesDocAccessFields_layout_sideColumn_sideStyle_Delete
+type PagesDocAccessFields_layout_sideColumn_style {
+  create: PagesDocAccessFields_layout_sideColumn_style_Create
+  read: PagesDocAccessFields_layout_sideColumn_style_Read
+  update: PagesDocAccessFields_layout_sideColumn_style_Update
+  delete: PagesDocAccessFields_layout_sideColumn_style_Delete
 }
 
-type PagesDocAccessFields_layout_sideColumn_sideStyle_Create {
+type PagesDocAccessFields_layout_sideColumn_style_Create {
   permission: Boolean!
 }
 
-type PagesDocAccessFields_layout_sideColumn_sideStyle_Read {
+type PagesDocAccessFields_layout_sideColumn_style_Read {
   permission: Boolean!
 }
 
-type PagesDocAccessFields_layout_sideColumn_sideStyle_Update {
+type PagesDocAccessFields_layout_sideColumn_style_Update {
   permission: Boolean!
 }
 
-type PagesDocAccessFields_layout_sideColumn_sideStyle_Delete {
+type PagesDocAccessFields_layout_sideColumn_style_Delete {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_hero {
+  create: PagesDocAccessFields_layout_sideColumn_hero_Create
+  read: PagesDocAccessFields_layout_sideColumn_hero_Read
+  update: PagesDocAccessFields_layout_sideColumn_hero_Update
+  delete: PagesDocAccessFields_layout_sideColumn_hero_Delete
+  fields: PagesDocAccessFields_layout_sideColumn_hero_Fields
+}
+
+type PagesDocAccessFields_layout_sideColumn_hero_Create {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_hero_Read {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_hero_Update {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_hero_Delete {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_hero_Fields {
+  media: PagesDocAccessFields_layout_sideColumn_hero_media
+  description: PagesDocAccessFields_layout_sideColumn_hero_description
+  links: PagesDocAccessFields_layout_sideColumn_hero_links
+}
+
+type PagesDocAccessFields_layout_sideColumn_hero_media {
+  create: PagesDocAccessFields_layout_sideColumn_hero_media_Create
+  read: PagesDocAccessFields_layout_sideColumn_hero_media_Read
+  update: PagesDocAccessFields_layout_sideColumn_hero_media_Update
+  delete: PagesDocAccessFields_layout_sideColumn_hero_media_Delete
+}
+
+type PagesDocAccessFields_layout_sideColumn_hero_media_Create {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_hero_media_Read {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_hero_media_Update {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_hero_media_Delete {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_hero_description {
+  create: PagesDocAccessFields_layout_sideColumn_hero_description_Create
+  read: PagesDocAccessFields_layout_sideColumn_hero_description_Read
+  update: PagesDocAccessFields_layout_sideColumn_hero_description_Update
+  delete: PagesDocAccessFields_layout_sideColumn_hero_description_Delete
+}
+
+type PagesDocAccessFields_layout_sideColumn_hero_description_Create {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_hero_description_Read {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_hero_description_Update {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_hero_description_Delete {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_hero_links {
+  create: PagesDocAccessFields_layout_sideColumn_hero_links_Create
+  read: PagesDocAccessFields_layout_sideColumn_hero_links_Read
+  update: PagesDocAccessFields_layout_sideColumn_hero_links_Update
+  delete: PagesDocAccessFields_layout_sideColumn_hero_links_Delete
+  fields: PagesDocAccessFields_layout_sideColumn_hero_links_Fields
+}
+
+type PagesDocAccessFields_layout_sideColumn_hero_links_Create {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_hero_links_Read {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_hero_links_Update {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_hero_links_Delete {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_hero_links_Fields {
+  link: PagesDocAccessFields_layout_sideColumn_hero_links_link
+  id: PagesDocAccessFields_layout_sideColumn_hero_links_id
+}
+
+type PagesDocAccessFields_layout_sideColumn_hero_links_link {
+  create: PagesDocAccessFields_layout_sideColumn_hero_links_link_Create
+  read: PagesDocAccessFields_layout_sideColumn_hero_links_link_Read
+  update: PagesDocAccessFields_layout_sideColumn_hero_links_link_Update
+  delete: PagesDocAccessFields_layout_sideColumn_hero_links_link_Delete
+  fields: PagesDocAccessFields_layout_sideColumn_hero_links_link_Fields
+}
+
+type PagesDocAccessFields_layout_sideColumn_hero_links_link_Create {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_hero_links_link_Read {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_hero_links_link_Update {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_hero_links_link_Delete {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_hero_links_link_Fields {
+  type: PagesDocAccessFields_layout_sideColumn_hero_links_link_type
+  newTab: PagesDocAccessFields_layout_sideColumn_hero_links_link_newTab
+  reference: PagesDocAccessFields_layout_sideColumn_hero_links_link_reference
+  url: PagesDocAccessFields_layout_sideColumn_hero_links_link_url
+  label: PagesDocAccessFields_layout_sideColumn_hero_links_link_label
+  appearance: PagesDocAccessFields_layout_sideColumn_hero_links_link_appearance
+}
+
+type PagesDocAccessFields_layout_sideColumn_hero_links_link_type {
+  create: PagesDocAccessFields_layout_sideColumn_hero_links_link_type_Create
+  read: PagesDocAccessFields_layout_sideColumn_hero_links_link_type_Read
+  update: PagesDocAccessFields_layout_sideColumn_hero_links_link_type_Update
+  delete: PagesDocAccessFields_layout_sideColumn_hero_links_link_type_Delete
+}
+
+type PagesDocAccessFields_layout_sideColumn_hero_links_link_type_Create {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_hero_links_link_type_Read {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_hero_links_link_type_Update {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_hero_links_link_type_Delete {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_hero_links_link_newTab {
+  create: PagesDocAccessFields_layout_sideColumn_hero_links_link_newTab_Create
+  read: PagesDocAccessFields_layout_sideColumn_hero_links_link_newTab_Read
+  update: PagesDocAccessFields_layout_sideColumn_hero_links_link_newTab_Update
+  delete: PagesDocAccessFields_layout_sideColumn_hero_links_link_newTab_Delete
+}
+
+type PagesDocAccessFields_layout_sideColumn_hero_links_link_newTab_Create {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_hero_links_link_newTab_Read {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_hero_links_link_newTab_Update {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_hero_links_link_newTab_Delete {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_hero_links_link_reference {
+  create: PagesDocAccessFields_layout_sideColumn_hero_links_link_reference_Create
+  read: PagesDocAccessFields_layout_sideColumn_hero_links_link_reference_Read
+  update: PagesDocAccessFields_layout_sideColumn_hero_links_link_reference_Update
+  delete: PagesDocAccessFields_layout_sideColumn_hero_links_link_reference_Delete
+}
+
+type PagesDocAccessFields_layout_sideColumn_hero_links_link_reference_Create {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_hero_links_link_reference_Read {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_hero_links_link_reference_Update {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_hero_links_link_reference_Delete {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_hero_links_link_url {
+  create: PagesDocAccessFields_layout_sideColumn_hero_links_link_url_Create
+  read: PagesDocAccessFields_layout_sideColumn_hero_links_link_url_Read
+  update: PagesDocAccessFields_layout_sideColumn_hero_links_link_url_Update
+  delete: PagesDocAccessFields_layout_sideColumn_hero_links_link_url_Delete
+}
+
+type PagesDocAccessFields_layout_sideColumn_hero_links_link_url_Create {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_hero_links_link_url_Read {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_hero_links_link_url_Update {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_hero_links_link_url_Delete {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_hero_links_link_label {
+  create: PagesDocAccessFields_layout_sideColumn_hero_links_link_label_Create
+  read: PagesDocAccessFields_layout_sideColumn_hero_links_link_label_Read
+  update: PagesDocAccessFields_layout_sideColumn_hero_links_link_label_Update
+  delete: PagesDocAccessFields_layout_sideColumn_hero_links_link_label_Delete
+}
+
+type PagesDocAccessFields_layout_sideColumn_hero_links_link_label_Create {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_hero_links_link_label_Read {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_hero_links_link_label_Update {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_hero_links_link_label_Delete {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_hero_links_link_appearance {
+  create: PagesDocAccessFields_layout_sideColumn_hero_links_link_appearance_Create
+  read: PagesDocAccessFields_layout_sideColumn_hero_links_link_appearance_Read
+  update: PagesDocAccessFields_layout_sideColumn_hero_links_link_appearance_Update
+  delete: PagesDocAccessFields_layout_sideColumn_hero_links_link_appearance_Delete
+}
+
+type PagesDocAccessFields_layout_sideColumn_hero_links_link_appearance_Create {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_hero_links_link_appearance_Read {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_hero_links_link_appearance_Update {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_hero_links_link_appearance_Delete {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_hero_links_id {
+  create: PagesDocAccessFields_layout_sideColumn_hero_links_id_Create
+  read: PagesDocAccessFields_layout_sideColumn_hero_links_id_Read
+  update: PagesDocAccessFields_layout_sideColumn_hero_links_id_Update
+  delete: PagesDocAccessFields_layout_sideColumn_hero_links_id_Delete
+}
+
+type PagesDocAccessFields_layout_sideColumn_hero_links_id_Create {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_hero_links_id_Read {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_hero_links_id_Update {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_hero_links_id_Delete {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_projectHero {
+  create: PagesDocAccessFields_layout_sideColumn_projectHero_Create
+  read: PagesDocAccessFields_layout_sideColumn_projectHero_Read
+  update: PagesDocAccessFields_layout_sideColumn_projectHero_Update
+  delete: PagesDocAccessFields_layout_sideColumn_projectHero_Delete
+  fields: PagesDocAccessFields_layout_sideColumn_projectHero_Fields
+}
+
+type PagesDocAccessFields_layout_sideColumn_projectHero_Create {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_projectHero_Read {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_projectHero_Update {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_projectHero_Delete {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_projectHero_Fields {
+  year: PagesDocAccessFields_layout_sideColumn_projectHero_year
+  client: PagesDocAccessFields_layout_sideColumn_projectHero_client
+  links: PagesDocAccessFields_layout_sideColumn_projectHero_links
+}
+
+type PagesDocAccessFields_layout_sideColumn_projectHero_year {
+  create: PagesDocAccessFields_layout_sideColumn_projectHero_year_Create
+  read: PagesDocAccessFields_layout_sideColumn_projectHero_year_Read
+  update: PagesDocAccessFields_layout_sideColumn_projectHero_year_Update
+  delete: PagesDocAccessFields_layout_sideColumn_projectHero_year_Delete
+}
+
+type PagesDocAccessFields_layout_sideColumn_projectHero_year_Create {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_projectHero_year_Read {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_projectHero_year_Update {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_projectHero_year_Delete {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_projectHero_client {
+  create: PagesDocAccessFields_layout_sideColumn_projectHero_client_Create
+  read: PagesDocAccessFields_layout_sideColumn_projectHero_client_Read
+  update: PagesDocAccessFields_layout_sideColumn_projectHero_client_Update
+  delete: PagesDocAccessFields_layout_sideColumn_projectHero_client_Delete
+}
+
+type PagesDocAccessFields_layout_sideColumn_projectHero_client_Create {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_projectHero_client_Read {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_projectHero_client_Update {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_projectHero_client_Delete {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_projectHero_links {
+  create: PagesDocAccessFields_layout_sideColumn_projectHero_links_Create
+  read: PagesDocAccessFields_layout_sideColumn_projectHero_links_Read
+  update: PagesDocAccessFields_layout_sideColumn_projectHero_links_Update
+  delete: PagesDocAccessFields_layout_sideColumn_projectHero_links_Delete
+  fields: PagesDocAccessFields_layout_sideColumn_projectHero_links_Fields
+}
+
+type PagesDocAccessFields_layout_sideColumn_projectHero_links_Create {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_projectHero_links_Read {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_projectHero_links_Update {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_projectHero_links_Delete {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_projectHero_links_Fields {
+  link: PagesDocAccessFields_layout_sideColumn_projectHero_links_link
+  id: PagesDocAccessFields_layout_sideColumn_projectHero_links_id
+}
+
+type PagesDocAccessFields_layout_sideColumn_projectHero_links_link {
+  create: PagesDocAccessFields_layout_sideColumn_projectHero_links_link_Create
+  read: PagesDocAccessFields_layout_sideColumn_projectHero_links_link_Read
+  update: PagesDocAccessFields_layout_sideColumn_projectHero_links_link_Update
+  delete: PagesDocAccessFields_layout_sideColumn_projectHero_links_link_Delete
+  fields: PagesDocAccessFields_layout_sideColumn_projectHero_links_link_Fields
+}
+
+type PagesDocAccessFields_layout_sideColumn_projectHero_links_link_Create {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_projectHero_links_link_Read {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_projectHero_links_link_Update {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_projectHero_links_link_Delete {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_projectHero_links_link_Fields {
+  type: PagesDocAccessFields_layout_sideColumn_projectHero_links_link_type
+  newTab: PagesDocAccessFields_layout_sideColumn_projectHero_links_link_newTab
+  reference: PagesDocAccessFields_layout_sideColumn_projectHero_links_link_reference
+  url: PagesDocAccessFields_layout_sideColumn_projectHero_links_link_url
+  label: PagesDocAccessFields_layout_sideColumn_projectHero_links_link_label
+  appearance: PagesDocAccessFields_layout_sideColumn_projectHero_links_link_appearance
+}
+
+type PagesDocAccessFields_layout_sideColumn_projectHero_links_link_type {
+  create: PagesDocAccessFields_layout_sideColumn_projectHero_links_link_type_Create
+  read: PagesDocAccessFields_layout_sideColumn_projectHero_links_link_type_Read
+  update: PagesDocAccessFields_layout_sideColumn_projectHero_links_link_type_Update
+  delete: PagesDocAccessFields_layout_sideColumn_projectHero_links_link_type_Delete
+}
+
+type PagesDocAccessFields_layout_sideColumn_projectHero_links_link_type_Create {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_projectHero_links_link_type_Read {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_projectHero_links_link_type_Update {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_projectHero_links_link_type_Delete {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_projectHero_links_link_newTab {
+  create: PagesDocAccessFields_layout_sideColumn_projectHero_links_link_newTab_Create
+  read: PagesDocAccessFields_layout_sideColumn_projectHero_links_link_newTab_Read
+  update: PagesDocAccessFields_layout_sideColumn_projectHero_links_link_newTab_Update
+  delete: PagesDocAccessFields_layout_sideColumn_projectHero_links_link_newTab_Delete
+}
+
+type PagesDocAccessFields_layout_sideColumn_projectHero_links_link_newTab_Create {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_projectHero_links_link_newTab_Read {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_projectHero_links_link_newTab_Update {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_projectHero_links_link_newTab_Delete {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_projectHero_links_link_reference {
+  create: PagesDocAccessFields_layout_sideColumn_projectHero_links_link_reference_Create
+  read: PagesDocAccessFields_layout_sideColumn_projectHero_links_link_reference_Read
+  update: PagesDocAccessFields_layout_sideColumn_projectHero_links_link_reference_Update
+  delete: PagesDocAccessFields_layout_sideColumn_projectHero_links_link_reference_Delete
+}
+
+type PagesDocAccessFields_layout_sideColumn_projectHero_links_link_reference_Create {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_projectHero_links_link_reference_Read {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_projectHero_links_link_reference_Update {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_projectHero_links_link_reference_Delete {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_projectHero_links_link_url {
+  create: PagesDocAccessFields_layout_sideColumn_projectHero_links_link_url_Create
+  read: PagesDocAccessFields_layout_sideColumn_projectHero_links_link_url_Read
+  update: PagesDocAccessFields_layout_sideColumn_projectHero_links_link_url_Update
+  delete: PagesDocAccessFields_layout_sideColumn_projectHero_links_link_url_Delete
+}
+
+type PagesDocAccessFields_layout_sideColumn_projectHero_links_link_url_Create {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_projectHero_links_link_url_Read {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_projectHero_links_link_url_Update {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_projectHero_links_link_url_Delete {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_projectHero_links_link_label {
+  create: PagesDocAccessFields_layout_sideColumn_projectHero_links_link_label_Create
+  read: PagesDocAccessFields_layout_sideColumn_projectHero_links_link_label_Read
+  update: PagesDocAccessFields_layout_sideColumn_projectHero_links_link_label_Update
+  delete: PagesDocAccessFields_layout_sideColumn_projectHero_links_link_label_Delete
+}
+
+type PagesDocAccessFields_layout_sideColumn_projectHero_links_link_label_Create {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_projectHero_links_link_label_Read {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_projectHero_links_link_label_Update {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_projectHero_links_link_label_Delete {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_projectHero_links_link_appearance {
+  create: PagesDocAccessFields_layout_sideColumn_projectHero_links_link_appearance_Create
+  read: PagesDocAccessFields_layout_sideColumn_projectHero_links_link_appearance_Read
+  update: PagesDocAccessFields_layout_sideColumn_projectHero_links_link_appearance_Update
+  delete: PagesDocAccessFields_layout_sideColumn_projectHero_links_link_appearance_Delete
+}
+
+type PagesDocAccessFields_layout_sideColumn_projectHero_links_link_appearance_Create {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_projectHero_links_link_appearance_Read {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_projectHero_links_link_appearance_Update {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_projectHero_links_link_appearance_Delete {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_projectHero_links_id {
+  create: PagesDocAccessFields_layout_sideColumn_projectHero_links_id_Create
+  read: PagesDocAccessFields_layout_sideColumn_projectHero_links_id_Read
+  update: PagesDocAccessFields_layout_sideColumn_projectHero_links_id_Update
+  delete: PagesDocAccessFields_layout_sideColumn_projectHero_links_id_Delete
+}
+
+type PagesDocAccessFields_layout_sideColumn_projectHero_links_id_Create {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_projectHero_links_id_Read {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_projectHero_links_id_Update {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_projectHero_links_id_Delete {
   permission: Boolean!
 }
 
@@ -1497,461 +2006,125 @@ type PagesDocAccessFields_layout_mainColumn_Delete {
 }
 
 type PagesDocAccessFields_layout_mainColumn_Fields {
-  layoutStyle: PagesDocAccessFields_layout_mainColumn_layoutStyle
-  singleLayout: PagesDocAccessFields_layout_mainColumn_singleLayout
-  twoRows: PagesDocAccessFields_layout_mainColumn_twoRows
-  twoColumns: PagesDocAccessFields_layout_mainColumn_twoColumns
-  threeColumns: PagesDocAccessFields_layout_mainColumn_threeColumns
-  threeSectionGrid: PagesDocAccessFields_layout_mainColumn_threeSectionGrid
+  style: PagesDocAccessFields_layout_mainColumn_style
+  row1column1: PagesDocAccessFields_layout_mainColumn_row1column1
+  row1column2: PagesDocAccessFields_layout_mainColumn_row1column2
+  row2column1: PagesDocAccessFields_layout_mainColumn_row2column1
+  row2column2: PagesDocAccessFields_layout_mainColumn_row2column2
 }
 
-type PagesDocAccessFields_layout_mainColumn_layoutStyle {
-  create: PagesDocAccessFields_layout_mainColumn_layoutStyle_Create
-  read: PagesDocAccessFields_layout_mainColumn_layoutStyle_Read
-  update: PagesDocAccessFields_layout_mainColumn_layoutStyle_Update
-  delete: PagesDocAccessFields_layout_mainColumn_layoutStyle_Delete
+type PagesDocAccessFields_layout_mainColumn_style {
+  create: PagesDocAccessFields_layout_mainColumn_style_Create
+  read: PagesDocAccessFields_layout_mainColumn_style_Read
+  update: PagesDocAccessFields_layout_mainColumn_style_Update
+  delete: PagesDocAccessFields_layout_mainColumn_style_Delete
 }
 
-type PagesDocAccessFields_layout_mainColumn_layoutStyle_Create {
+type PagesDocAccessFields_layout_mainColumn_style_Create {
   permission: Boolean!
 }
 
-type PagesDocAccessFields_layout_mainColumn_layoutStyle_Read {
+type PagesDocAccessFields_layout_mainColumn_style_Read {
   permission: Boolean!
 }
 
-type PagesDocAccessFields_layout_mainColumn_layoutStyle_Update {
+type PagesDocAccessFields_layout_mainColumn_style_Update {
   permission: Boolean!
 }
 
-type PagesDocAccessFields_layout_mainColumn_layoutStyle_Delete {
+type PagesDocAccessFields_layout_mainColumn_style_Delete {
   permission: Boolean!
 }
 
-type PagesDocAccessFields_layout_mainColumn_singleLayout {
-  create: PagesDocAccessFields_layout_mainColumn_singleLayout_Create
-  read: PagesDocAccessFields_layout_mainColumn_singleLayout_Read
-  update: PagesDocAccessFields_layout_mainColumn_singleLayout_Update
-  delete: PagesDocAccessFields_layout_mainColumn_singleLayout_Delete
-  fields: PagesDocAccessFields_layout_mainColumn_singleLayout_Fields
+type PagesDocAccessFields_layout_mainColumn_row1column1 {
+  create: PagesDocAccessFields_layout_mainColumn_row1column1_Create
+  read: PagesDocAccessFields_layout_mainColumn_row1column1_Read
+  update: PagesDocAccessFields_layout_mainColumn_row1column1_Update
+  delete: PagesDocAccessFields_layout_mainColumn_row1column1_Delete
 }
 
-type PagesDocAccessFields_layout_mainColumn_singleLayout_Create {
+type PagesDocAccessFields_layout_mainColumn_row1column1_Create {
   permission: Boolean!
 }
 
-type PagesDocAccessFields_layout_mainColumn_singleLayout_Read {
+type PagesDocAccessFields_layout_mainColumn_row1column1_Read {
   permission: Boolean!
 }
 
-type PagesDocAccessFields_layout_mainColumn_singleLayout_Update {
+type PagesDocAccessFields_layout_mainColumn_row1column1_Update {
   permission: Boolean!
 }
 
-type PagesDocAccessFields_layout_mainColumn_singleLayout_Delete {
+type PagesDocAccessFields_layout_mainColumn_row1column1_Delete {
   permission: Boolean!
 }
 
-type PagesDocAccessFields_layout_mainColumn_singleLayout_Fields {
-  singleLayout1: PagesDocAccessFields_layout_mainColumn_singleLayout_singleLayout1
+type PagesDocAccessFields_layout_mainColumn_row1column2 {
+  create: PagesDocAccessFields_layout_mainColumn_row1column2_Create
+  read: PagesDocAccessFields_layout_mainColumn_row1column2_Read
+  update: PagesDocAccessFields_layout_mainColumn_row1column2_Update
+  delete: PagesDocAccessFields_layout_mainColumn_row1column2_Delete
 }
 
-type PagesDocAccessFields_layout_mainColumn_singleLayout_singleLayout1 {
-  create: PagesDocAccessFields_layout_mainColumn_singleLayout_singleLayout1_Create
-  read: PagesDocAccessFields_layout_mainColumn_singleLayout_singleLayout1_Read
-  update: PagesDocAccessFields_layout_mainColumn_singleLayout_singleLayout1_Update
-  delete: PagesDocAccessFields_layout_mainColumn_singleLayout_singleLayout1_Delete
-}
-
-type PagesDocAccessFields_layout_mainColumn_singleLayout_singleLayout1_Create {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_layout_mainColumn_singleLayout_singleLayout1_Read {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_layout_mainColumn_singleLayout_singleLayout1_Update {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_layout_mainColumn_singleLayout_singleLayout1_Delete {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_layout_mainColumn_twoRows {
-  create: PagesDocAccessFields_layout_mainColumn_twoRows_Create
-  read: PagesDocAccessFields_layout_mainColumn_twoRows_Read
-  update: PagesDocAccessFields_layout_mainColumn_twoRows_Update
-  delete: PagesDocAccessFields_layout_mainColumn_twoRows_Delete
-  fields: PagesDocAccessFields_layout_mainColumn_twoRows_Fields
-}
-
-type PagesDocAccessFields_layout_mainColumn_twoRows_Create {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_layout_mainColumn_twoRows_Read {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_layout_mainColumn_twoRows_Update {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_layout_mainColumn_twoRows_Delete {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_layout_mainColumn_twoRows_Fields {
-  row1: PagesDocAccessFields_layout_mainColumn_twoRows_row1
-  row2: PagesDocAccessFields_layout_mainColumn_twoRows_row2
-}
-
-type PagesDocAccessFields_layout_mainColumn_twoRows_row1 {
-  create: PagesDocAccessFields_layout_mainColumn_twoRows_row1_Create
-  read: PagesDocAccessFields_layout_mainColumn_twoRows_row1_Read
-  update: PagesDocAccessFields_layout_mainColumn_twoRows_row1_Update
-  delete: PagesDocAccessFields_layout_mainColumn_twoRows_row1_Delete
-}
-
-type PagesDocAccessFields_layout_mainColumn_twoRows_row1_Create {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_layout_mainColumn_twoRows_row1_Read {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_layout_mainColumn_twoRows_row1_Update {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_layout_mainColumn_twoRows_row1_Delete {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_layout_mainColumn_twoRows_row2 {
-  create: PagesDocAccessFields_layout_mainColumn_twoRows_row2_Create
-  read: PagesDocAccessFields_layout_mainColumn_twoRows_row2_Read
-  update: PagesDocAccessFields_layout_mainColumn_twoRows_row2_Update
-  delete: PagesDocAccessFields_layout_mainColumn_twoRows_row2_Delete
-}
-
-type PagesDocAccessFields_layout_mainColumn_twoRows_row2_Create {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_layout_mainColumn_twoRows_row2_Read {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_layout_mainColumn_twoRows_row2_Update {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_layout_mainColumn_twoRows_row2_Delete {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_layout_mainColumn_twoColumns {
-  create: PagesDocAccessFields_layout_mainColumn_twoColumns_Create
-  read: PagesDocAccessFields_layout_mainColumn_twoColumns_Read
-  update: PagesDocAccessFields_layout_mainColumn_twoColumns_Update
-  delete: PagesDocAccessFields_layout_mainColumn_twoColumns_Delete
-  fields: PagesDocAccessFields_layout_mainColumn_twoColumns_Fields
-}
-
-type PagesDocAccessFields_layout_mainColumn_twoColumns_Create {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_layout_mainColumn_twoColumns_Read {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_layout_mainColumn_twoColumns_Update {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_layout_mainColumn_twoColumns_Delete {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_layout_mainColumn_twoColumns_Fields {
-  col1: PagesDocAccessFields_layout_mainColumn_twoColumns_col1
-  col2: PagesDocAccessFields_layout_mainColumn_twoColumns_col2
-}
-
-type PagesDocAccessFields_layout_mainColumn_twoColumns_col1 {
-  create: PagesDocAccessFields_layout_mainColumn_twoColumns_col1_Create
-  read: PagesDocAccessFields_layout_mainColumn_twoColumns_col1_Read
-  update: PagesDocAccessFields_layout_mainColumn_twoColumns_col1_Update
-  delete: PagesDocAccessFields_layout_mainColumn_twoColumns_col1_Delete
-}
-
-type PagesDocAccessFields_layout_mainColumn_twoColumns_col1_Create {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_layout_mainColumn_twoColumns_col1_Read {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_layout_mainColumn_twoColumns_col1_Update {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_layout_mainColumn_twoColumns_col1_Delete {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_layout_mainColumn_twoColumns_col2 {
-  create: PagesDocAccessFields_layout_mainColumn_twoColumns_col2_Create
-  read: PagesDocAccessFields_layout_mainColumn_twoColumns_col2_Read
-  update: PagesDocAccessFields_layout_mainColumn_twoColumns_col2_Update
-  delete: PagesDocAccessFields_layout_mainColumn_twoColumns_col2_Delete
-}
-
-type PagesDocAccessFields_layout_mainColumn_twoColumns_col2_Create {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_layout_mainColumn_twoColumns_col2_Read {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_layout_mainColumn_twoColumns_col2_Update {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_layout_mainColumn_twoColumns_col2_Delete {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_layout_mainColumn_threeColumns {
-  create: PagesDocAccessFields_layout_mainColumn_threeColumns_Create
-  read: PagesDocAccessFields_layout_mainColumn_threeColumns_Read
-  update: PagesDocAccessFields_layout_mainColumn_threeColumns_Update
-  delete: PagesDocAccessFields_layout_mainColumn_threeColumns_Delete
-  fields: PagesDocAccessFields_layout_mainColumn_threeColumns_Fields
-}
-
-type PagesDocAccessFields_layout_mainColumn_threeColumns_Create {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_layout_mainColumn_threeColumns_Read {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_layout_mainColumn_threeColumns_Update {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_layout_mainColumn_threeColumns_Delete {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_layout_mainColumn_threeColumns_Fields {
-  col1: PagesDocAccessFields_layout_mainColumn_threeColumns_col1
-  col2: PagesDocAccessFields_layout_mainColumn_threeColumns_col2
-  col3: PagesDocAccessFields_layout_mainColumn_threeColumns_col3
-}
-
-type PagesDocAccessFields_layout_mainColumn_threeColumns_col1 {
-  create: PagesDocAccessFields_layout_mainColumn_threeColumns_col1_Create
-  read: PagesDocAccessFields_layout_mainColumn_threeColumns_col1_Read
-  update: PagesDocAccessFields_layout_mainColumn_threeColumns_col1_Update
-  delete: PagesDocAccessFields_layout_mainColumn_threeColumns_col1_Delete
-}
-
-type PagesDocAccessFields_layout_mainColumn_threeColumns_col1_Create {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_layout_mainColumn_threeColumns_col1_Read {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_layout_mainColumn_threeColumns_col1_Update {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_layout_mainColumn_threeColumns_col1_Delete {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_layout_mainColumn_threeColumns_col2 {
-  create: PagesDocAccessFields_layout_mainColumn_threeColumns_col2_Create
-  read: PagesDocAccessFields_layout_mainColumn_threeColumns_col2_Read
-  update: PagesDocAccessFields_layout_mainColumn_threeColumns_col2_Update
-  delete: PagesDocAccessFields_layout_mainColumn_threeColumns_col2_Delete
-}
-
-type PagesDocAccessFields_layout_mainColumn_threeColumns_col2_Create {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_layout_mainColumn_threeColumns_col2_Read {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_layout_mainColumn_threeColumns_col2_Update {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_layout_mainColumn_threeColumns_col2_Delete {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_layout_mainColumn_threeColumns_col3 {
-  create: PagesDocAccessFields_layout_mainColumn_threeColumns_col3_Create
-  read: PagesDocAccessFields_layout_mainColumn_threeColumns_col3_Read
-  update: PagesDocAccessFields_layout_mainColumn_threeColumns_col3_Update
-  delete: PagesDocAccessFields_layout_mainColumn_threeColumns_col3_Delete
-}
-
-type PagesDocAccessFields_layout_mainColumn_threeColumns_col3_Create {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_layout_mainColumn_threeColumns_col3_Read {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_layout_mainColumn_threeColumns_col3_Update {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_layout_mainColumn_threeColumns_col3_Delete {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_layout_mainColumn_threeSectionGrid {
-  create: PagesDocAccessFields_layout_mainColumn_threeSectionGrid_Create
-  read: PagesDocAccessFields_layout_mainColumn_threeSectionGrid_Read
-  update: PagesDocAccessFields_layout_mainColumn_threeSectionGrid_Update
-  delete: PagesDocAccessFields_layout_mainColumn_threeSectionGrid_Delete
-  fields: PagesDocAccessFields_layout_mainColumn_threeSectionGrid_Fields
-}
-
-type PagesDocAccessFields_layout_mainColumn_threeSectionGrid_Create {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_layout_mainColumn_threeSectionGrid_Read {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_layout_mainColumn_threeSectionGrid_Update {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_layout_mainColumn_threeSectionGrid_Delete {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_layout_mainColumn_threeSectionGrid_Fields {
-  left: PagesDocAccessFields_layout_mainColumn_threeSectionGrid_left
-  right: PagesDocAccessFields_layout_mainColumn_threeSectionGrid_right
-}
-
-type PagesDocAccessFields_layout_mainColumn_threeSectionGrid_left {
-  create: PagesDocAccessFields_layout_mainColumn_threeSectionGrid_left_Create
-  read: PagesDocAccessFields_layout_mainColumn_threeSectionGrid_left_Read
-  update: PagesDocAccessFields_layout_mainColumn_threeSectionGrid_left_Update
-  delete: PagesDocAccessFields_layout_mainColumn_threeSectionGrid_left_Delete
-}
-
-type PagesDocAccessFields_layout_mainColumn_threeSectionGrid_left_Create {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_layout_mainColumn_threeSectionGrid_left_Read {
+type PagesDocAccessFields_layout_mainColumn_row1column2_Create {
   permission: Boolean!
 }
 
-type PagesDocAccessFields_layout_mainColumn_threeSectionGrid_left_Update {
+type PagesDocAccessFields_layout_mainColumn_row1column2_Read {
   permission: Boolean!
 }
 
-type PagesDocAccessFields_layout_mainColumn_threeSectionGrid_left_Delete {
+type PagesDocAccessFields_layout_mainColumn_row1column2_Update {
   permission: Boolean!
 }
 
-type PagesDocAccessFields_layout_mainColumn_threeSectionGrid_right {
-  create: PagesDocAccessFields_layout_mainColumn_threeSectionGrid_right_Create
-  read: PagesDocAccessFields_layout_mainColumn_threeSectionGrid_right_Read
-  update: PagesDocAccessFields_layout_mainColumn_threeSectionGrid_right_Update
-  delete: PagesDocAccessFields_layout_mainColumn_threeSectionGrid_right_Delete
-  fields: PagesDocAccessFields_layout_mainColumn_threeSectionGrid_right_Fields
-}
-
-type PagesDocAccessFields_layout_mainColumn_threeSectionGrid_right_Create {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_layout_mainColumn_threeSectionGrid_right_Read {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_layout_mainColumn_threeSectionGrid_right_Update {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_layout_mainColumn_threeSectionGrid_right_Delete {
+type PagesDocAccessFields_layout_mainColumn_row1column2_Delete {
   permission: Boolean!
-}
-
-type PagesDocAccessFields_layout_mainColumn_threeSectionGrid_right_Fields {
-  rightTop: PagesDocAccessFields_layout_mainColumn_threeSectionGrid_right_rightTop
-  rightBottom: PagesDocAccessFields_layout_mainColumn_threeSectionGrid_right_rightBottom
 }
 
-type PagesDocAccessFields_layout_mainColumn_threeSectionGrid_right_rightTop {
-  create: PagesDocAccessFields_layout_mainColumn_threeSectionGrid_right_rightTop_Create
-  read: PagesDocAccessFields_layout_mainColumn_threeSectionGrid_right_rightTop_Read
-  update: PagesDocAccessFields_layout_mainColumn_threeSectionGrid_right_rightTop_Update
-  delete: PagesDocAccessFields_layout_mainColumn_threeSectionGrid_right_rightTop_Delete
+type PagesDocAccessFields_layout_mainColumn_row2column1 {
+  create: PagesDocAccessFields_layout_mainColumn_row2column1_Create
+  read: PagesDocAccessFields_layout_mainColumn_row2column1_Read
+  update: PagesDocAccessFields_layout_mainColumn_row2column1_Update
+  delete: PagesDocAccessFields_layout_mainColumn_row2column1_Delete
 }
 
-type PagesDocAccessFields_layout_mainColumn_threeSectionGrid_right_rightTop_Create {
+type PagesDocAccessFields_layout_mainColumn_row2column1_Create {
   permission: Boolean!
 }
 
-type PagesDocAccessFields_layout_mainColumn_threeSectionGrid_right_rightTop_Read {
+type PagesDocAccessFields_layout_mainColumn_row2column1_Read {
   permission: Boolean!
 }
 
-type PagesDocAccessFields_layout_mainColumn_threeSectionGrid_right_rightTop_Update {
+type PagesDocAccessFields_layout_mainColumn_row2column1_Update {
   permission: Boolean!
 }
 
-type PagesDocAccessFields_layout_mainColumn_threeSectionGrid_right_rightTop_Delete {
+type PagesDocAccessFields_layout_mainColumn_row2column1_Delete {
   permission: Boolean!
 }
 
-type PagesDocAccessFields_layout_mainColumn_threeSectionGrid_right_rightBottom {
-  create: PagesDocAccessFields_layout_mainColumn_threeSectionGrid_right_rightBottom_Create
-  read: PagesDocAccessFields_layout_mainColumn_threeSectionGrid_right_rightBottom_Read
-  update: PagesDocAccessFields_layout_mainColumn_threeSectionGrid_right_rightBottom_Update
-  delete: PagesDocAccessFields_layout_mainColumn_threeSectionGrid_right_rightBottom_Delete
+type PagesDocAccessFields_layout_mainColumn_row2column2 {
+  create: PagesDocAccessFields_layout_mainColumn_row2column2_Create
+  read: PagesDocAccessFields_layout_mainColumn_row2column2_Read
+  update: PagesDocAccessFields_layout_mainColumn_row2column2_Update
+  delete: PagesDocAccessFields_layout_mainColumn_row2column2_Delete
 }
 
-type PagesDocAccessFields_layout_mainColumn_threeSectionGrid_right_rightBottom_Create {
+type PagesDocAccessFields_layout_mainColumn_row2column2_Create {
   permission: Boolean!
 }
 
-type PagesDocAccessFields_layout_mainColumn_threeSectionGrid_right_rightBottom_Read {
+type PagesDocAccessFields_layout_mainColumn_row2column2_Read {
   permission: Boolean!
 }
 
-type PagesDocAccessFields_layout_mainColumn_threeSectionGrid_right_rightBottom_Update {
+type PagesDocAccessFields_layout_mainColumn_row2column2_Update {
   permission: Boolean!
 }
 
-type PagesDocAccessFields_layout_mainColumn_threeSectionGrid_right_rightBottom_Delete {
+type PagesDocAccessFields_layout_mainColumn_row2column2_Delete {
   permission: Boolean!
 }
 
@@ -2003,34 +2176,9 @@ type PagesDocAccessFields_meta_Delete {
 }
 
 type PagesDocAccessFields_meta_Fields {
-  overview: PagesDocAccessFields_meta_overview
   title: PagesDocAccessFields_meta_title
   description: PagesDocAccessFields_meta_description
   image: PagesDocAccessFields_meta_image
-  preview: PagesDocAccessFields_meta_preview
-}
-
-type PagesDocAccessFields_meta_overview {
-  create: PagesDocAccessFields_meta_overview_Create
-  read: PagesDocAccessFields_meta_overview_Read
-  update: PagesDocAccessFields_meta_overview_Update
-  delete: PagesDocAccessFields_meta_overview_Delete
-}
-
-type PagesDocAccessFields_meta_overview_Create {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_meta_overview_Read {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_meta_overview_Update {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_meta_overview_Delete {
-  permission: Boolean!
 }
 
 type PagesDocAccessFields_meta_title {
@@ -2099,29 +2247,6 @@ type PagesDocAccessFields_meta_image_Update {
 }
 
 type PagesDocAccessFields_meta_image_Delete {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_meta_preview {
-  create: PagesDocAccessFields_meta_preview_Create
-  read: PagesDocAccessFields_meta_preview_Read
-  update: PagesDocAccessFields_meta_preview_Update
-  delete: PagesDocAccessFields_meta_preview_Delete
-}
-
-type PagesDocAccessFields_meta_preview_Create {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_meta_preview_Read {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_meta_preview_Update {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_meta_preview_Delete {
   permission: Boolean!
 }
 
@@ -2237,7 +2362,6 @@ type PageVersion_Version {
   title: String
   publishedAt: DateTime
   slug: String
-  hero: HeroField
   layout: [Layout!]
   meta: PageVersion_Version_Meta
   updatedAt: DateTime
@@ -2451,33 +2575,35 @@ input versionsPage_where {
   version__title: versionsPage_version__title_operator
   version__publishedAt: versionsPage_version__publishedAt_operator
   version__slug: versionsPage_version__slug_operator
-  version__hero__type: versionsPage_version__hero__type_operator
-  version__hero__description: versionsPage_version__hero__description_operator
-  version__hero__links__link__type: versionsPage_version__hero__links__link__type_operator
-  version__hero__links__link__newTab: versionsPage_version__hero__links__link__newTab_operator
-  version__hero__links__link__reference: versionsPage_version__hero__links__link__reference_Relation
-  version__hero__links__link__url: versionsPage_version__hero__links__link__url_operator
-  version__hero__links__link__label: versionsPage_version__hero__links__link__label_operator
-  version__hero__links__link__appearance: versionsPage_version__hero__links__link__appearance_operator
-  version__hero__links__id: versionsPage_version__hero__links__id_operator
-  version__layout__fixedSideContent: versionsPage_version__layout__fixedSideContent_operator
+  version__layout__sideContentPosition: versionsPage_version__layout__sideContentPosition_operator
   version__layout__scrollSnap: versionsPage_version__layout__scrollSnap_operator
   version__layout__fullPageHeight: versionsPage_version__layout__fullPageHeight_operator
-  version__layout__sideColumn__sideStyle: versionsPage_version__layout__sideColumn__sideStyle_operator
+  version__layout__sideColumn__style: versionsPage_version__layout__sideColumn__style_operator
+  version__layout__sideColumn__hero__media: versionsPage_version__layout__sideColumn__hero__media_operator
+  version__layout__sideColumn__hero__description: versionsPage_version__layout__sideColumn__hero__description_operator
+  version__layout__sideColumn__hero__links__link__type: versionsPage_version__layout__sideColumn__hero__links__link__type_operator
+  version__layout__sideColumn__hero__links__link__newTab: versionsPage_version__layout__sideColumn__hero__links__link__newTab_operator
+  version__layout__sideColumn__hero__links__link__reference: versionsPage_version__layout__sideColumn__hero__links__link__reference_Relation
+  version__layout__sideColumn__hero__links__link__url: versionsPage_version__layout__sideColumn__hero__links__link__url_operator
+  version__layout__sideColumn__hero__links__link__label: versionsPage_version__layout__sideColumn__hero__links__link__label_operator
+  version__layout__sideColumn__hero__links__link__appearance: versionsPage_version__layout__sideColumn__hero__links__link__appearance_operator
+  version__layout__sideColumn__hero__links__id: versionsPage_version__layout__sideColumn__hero__links__id_operator
+  version__layout__sideColumn__projectHero__year: versionsPage_version__layout__sideColumn__projectHero__year_operator
+  version__layout__sideColumn__projectHero__client: versionsPage_version__layout__sideColumn__projectHero__client_operator
+  version__layout__sideColumn__projectHero__links__link__type: versionsPage_version__layout__sideColumn__projectHero__links__link__type_operator
+  version__layout__sideColumn__projectHero__links__link__newTab: versionsPage_version__layout__sideColumn__projectHero__links__link__newTab_operator
+  version__layout__sideColumn__projectHero__links__link__reference: versionsPage_version__layout__sideColumn__projectHero__links__link__reference_Relation
+  version__layout__sideColumn__projectHero__links__link__url: versionsPage_version__layout__sideColumn__projectHero__links__link__url_operator
+  version__layout__sideColumn__projectHero__links__link__label: versionsPage_version__layout__sideColumn__projectHero__links__link__label_operator
+  version__layout__sideColumn__projectHero__links__link__appearance: versionsPage_version__layout__sideColumn__projectHero__links__link__appearance_operator
+  version__layout__sideColumn__projectHero__links__id: versionsPage_version__layout__sideColumn__projectHero__links__id_operator
   version__layout__sideColumn__sideContent1: versionsPage_version__layout__sideColumn__sideContent1_operator
   version__layout__sideColumn__sideContent2: versionsPage_version__layout__sideColumn__sideContent2_operator
-  version__layout__mainColumn__layoutStyle: versionsPage_version__layout__mainColumn__layoutStyle_operator
-  version__layout__mainColumn__singleLayout__singleLayout1: versionsPage_version__layout__mainColumn__singleLayout__singleLayout1_operator
-  version__layout__mainColumn__twoRows__row1: versionsPage_version__layout__mainColumn__twoRows__row1_operator
-  version__layout__mainColumn__twoRows__row2: versionsPage_version__layout__mainColumn__twoRows__row2_operator
-  version__layout__mainColumn__twoColumns__col1: versionsPage_version__layout__mainColumn__twoColumns__col1_operator
-  version__layout__mainColumn__twoColumns__col2: versionsPage_version__layout__mainColumn__twoColumns__col2_operator
-  version__layout__mainColumn__threeColumns__col1: versionsPage_version__layout__mainColumn__threeColumns__col1_operator
-  version__layout__mainColumn__threeColumns__col2: versionsPage_version__layout__mainColumn__threeColumns__col2_operator
-  version__layout__mainColumn__threeColumns__col3: versionsPage_version__layout__mainColumn__threeColumns__col3_operator
-  version__layout__mainColumn__threeSectionGrid__left: versionsPage_version__layout__mainColumn__threeSectionGrid__left_operator
-  version__layout__mainColumn__threeSectionGrid__right__rightTop: versionsPage_version__layout__mainColumn__threeSectionGrid__right__rightTop_operator
-  version__layout__mainColumn__threeSectionGrid__right__rightBottom: versionsPage_version__layout__mainColumn__threeSectionGrid__right__rightBottom_operator
+  version__layout__mainColumn__style: versionsPage_version__layout__mainColumn__style_operator
+  version__layout__mainColumn__row1column1: versionsPage_version__layout__mainColumn__row1column1_operator
+  version__layout__mainColumn__row1column2: versionsPage_version__layout__mainColumn__row1column2_operator
+  version__layout__mainColumn__row2column1: versionsPage_version__layout__mainColumn__row2column1_operator
+  version__layout__mainColumn__row2column2: versionsPage_version__layout__mainColumn__row2column2_operator
   version__layout__id: versionsPage_version__layout__id_operator
   version__meta__title: versionsPage_version__meta__title_operator
   version__meta__description: versionsPage_version__meta__description_operator
@@ -2534,107 +2660,18 @@ input versionsPage_version__slug_operator {
   exists: Boolean
 }
 
-input versionsPage_version__hero__type_operator {
-  equals: versionsPage_version__hero__type_Input
-  not_equals: versionsPage_version__hero__type_Input
-  in: [versionsPage_version__hero__type_Input]
-  not_in: [versionsPage_version__hero__type_Input]
-  all: [versionsPage_version__hero__type_Input]
+input versionsPage_version__layout__sideContentPosition_operator {
+  equals: versionsPage_version__layout__sideContentPosition_Input
+  not_equals: versionsPage_version__layout__sideContentPosition_Input
+  in: [versionsPage_version__layout__sideContentPosition_Input]
+  not_in: [versionsPage_version__layout__sideContentPosition_Input]
+  all: [versionsPage_version__layout__sideContentPosition_Input]
 }
 
-enum versionsPage_version__hero__type_Input {
-  none
-  fixedSidePanel
-  halfPage
-  fullPage
-}
-
-input versionsPage_version__hero__description_operator {
-  equals: JSON
-  not_equals: JSON
-  like: JSON
-  contains: JSON
-  exists: Boolean
-}
-
-input versionsPage_version__hero__links__link__type_operator {
-  equals: versionsPage_version__hero__links__link__type_Input
-  not_equals: versionsPage_version__hero__links__link__type_Input
-  like: versionsPage_version__hero__links__link__type_Input
-  contains: versionsPage_version__hero__links__link__type_Input
-  exists: Boolean
-}
-
-enum versionsPage_version__hero__links__link__type_Input {
-  reference
-  custom
-}
-
-input versionsPage_version__hero__links__link__newTab_operator {
-  equals: Boolean
-  not_equals: Boolean
-  exists: Boolean
-}
-
-input versionsPage_version__hero__links__link__reference_Relation {
-  relationTo: versionsPage_version__hero__links__link__reference_Relation_RelationTo
-  value: JSON
-}
-
-enum versionsPage_version__hero__links__link__reference_Relation_RelationTo {
-  pages
-}
-
-input versionsPage_version__hero__links__link__url_operator {
-  equals: String
-  not_equals: String
-  like: String
-  contains: String
-  in: [String]
-  not_in: [String]
-  all: [String]
-}
-
-input versionsPage_version__hero__links__link__label_operator {
-  equals: String
-  not_equals: String
-  like: String
-  contains: String
-  in: [String]
-  not_in: [String]
-  all: [String]
-}
-
-input versionsPage_version__hero__links__link__appearance_operator {
-  equals: versionsPage_version__hero__links__link__appearance_Input
-  not_equals: versionsPage_version__hero__links__link__appearance_Input
-  in: [versionsPage_version__hero__links__link__appearance_Input]
-  not_in: [versionsPage_version__hero__links__link__appearance_Input]
-  all: [versionsPage_version__hero__links__link__appearance_Input]
-  exists: Boolean
-}
-
-enum versionsPage_version__hero__links__link__appearance_Input {
-  default
-  primary
-  secondary
-}
-
-input versionsPage_version__hero__links__id_operator {
-  equals: String
-  not_equals: String
-  like: String
-  contains: String
-  in: [String]
-  not_in: [String]
-  all: [String]
-  exists: Boolean
-}
-
-input versionsPage_version__layout__fixedSideContent_operator {
-  equals: Boolean
-  not_equals: Boolean
-  exists: Boolean
+enum versionsPage_version__layout__sideContentPosition_Input {
+  scrollSideContent
+  fixedSideContentWhenVisible
+  fixedSideContentAlways
 }
 
 input versionsPage_version__layout__scrollSnap_operator {
@@ -2649,18 +2686,202 @@ input versionsPage_version__layout__fullPageHeight_operator {
   exists: Boolean
 }
 
-input versionsPage_version__layout__sideColumn__sideStyle_operator {
-  equals: versionsPage_version__layout__sideColumn__sideStyle_Input
-  not_equals: versionsPage_version__layout__sideColumn__sideStyle_Input
-  in: [versionsPage_version__layout__sideColumn__sideStyle_Input]
-  not_in: [versionsPage_version__layout__sideColumn__sideStyle_Input]
-  all: [versionsPage_version__layout__sideColumn__sideStyle_Input]
+input versionsPage_version__layout__sideColumn__style_operator {
+  equals: versionsPage_version__layout__sideColumn__style_Input
+  not_equals: versionsPage_version__layout__sideColumn__style_Input
+  in: [versionsPage_version__layout__sideColumn__style_Input]
+  not_in: [versionsPage_version__layout__sideColumn__style_Input]
+  all: [versionsPage_version__layout__sideColumn__style_Input]
 }
 
-enum versionsPage_version__layout__sideColumn__sideStyle_Input {
+enum versionsPage_version__layout__sideColumn__style_Input {
   none
+  hero
+  postHero
+  projectHero
   singleLayout
   twoRows
+}
+
+input versionsPage_version__layout__sideColumn__hero__media_operator {
+  equals: String
+  not_equals: String
+  exists: Boolean
+}
+
+input versionsPage_version__layout__sideColumn__hero__description_operator {
+  equals: JSON
+  not_equals: JSON
+  like: JSON
+  contains: JSON
+  exists: Boolean
+}
+
+input versionsPage_version__layout__sideColumn__hero__links__link__type_operator {
+  equals: versionsPage_version__layout__sideColumn__hero__links__link__type_Input
+  not_equals: versionsPage_version__layout__sideColumn__hero__links__link__type_Input
+  like: versionsPage_version__layout__sideColumn__hero__links__link__type_Input
+  contains: versionsPage_version__layout__sideColumn__hero__links__link__type_Input
+  exists: Boolean
+}
+
+enum versionsPage_version__layout__sideColumn__hero__links__link__type_Input {
+  reference
+  custom
+}
+
+input versionsPage_version__layout__sideColumn__hero__links__link__newTab_operator {
+  equals: Boolean
+  not_equals: Boolean
+  exists: Boolean
+}
+
+input versionsPage_version__layout__sideColumn__hero__links__link__reference_Relation {
+  relationTo: versionsPage_version__layout__sideColumn__hero__links__link__reference_Relation_RelationTo
+  value: JSON
+}
+
+enum versionsPage_version__layout__sideColumn__hero__links__link__reference_Relation_RelationTo {
+  pages
+}
+
+input versionsPage_version__layout__sideColumn__hero__links__link__url_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+}
+
+input versionsPage_version__layout__sideColumn__hero__links__link__label_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+}
+
+input versionsPage_version__layout__sideColumn__hero__links__link__appearance_operator {
+  equals: versionsPage_version__layout__sideColumn__hero__links__link__appearance_Input
+  not_equals: versionsPage_version__layout__sideColumn__hero__links__link__appearance_Input
+  in: [versionsPage_version__layout__sideColumn__hero__links__link__appearance_Input]
+  not_in: [versionsPage_version__layout__sideColumn__hero__links__link__appearance_Input]
+  all: [versionsPage_version__layout__sideColumn__hero__links__link__appearance_Input]
+  exists: Boolean
+}
+
+enum versionsPage_version__layout__sideColumn__hero__links__link__appearance_Input {
+  default
+  primary
+  secondary
+}
+
+input versionsPage_version__layout__sideColumn__hero__links__id_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input versionsPage_version__layout__sideColumn__projectHero__year_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input versionsPage_version__layout__sideColumn__projectHero__client_operator {
+  equals: JSON
+  not_equals: JSON
+  in: [JSON]
+  not_in: [JSON]
+  all: [JSON]
+  exists: Boolean
+}
+
+input versionsPage_version__layout__sideColumn__projectHero__links__link__type_operator {
+  equals: versionsPage_version__layout__sideColumn__projectHero__links__link__type_Input
+  not_equals: versionsPage_version__layout__sideColumn__projectHero__links__link__type_Input
+  like: versionsPage_version__layout__sideColumn__projectHero__links__link__type_Input
+  contains: versionsPage_version__layout__sideColumn__projectHero__links__link__type_Input
+  exists: Boolean
+}
+
+enum versionsPage_version__layout__sideColumn__projectHero__links__link__type_Input {
+  reference
+  custom
+}
+
+input versionsPage_version__layout__sideColumn__projectHero__links__link__newTab_operator {
+  equals: Boolean
+  not_equals: Boolean
+  exists: Boolean
+}
+
+input versionsPage_version__layout__sideColumn__projectHero__links__link__reference_Relation {
+  relationTo: versionsPage_version__layout__sideColumn__projectHero__links__link__reference_Relation_RelationTo
+  value: JSON
+}
+
+enum versionsPage_version__layout__sideColumn__projectHero__links__link__reference_Relation_RelationTo {
+  pages
+}
+
+input versionsPage_version__layout__sideColumn__projectHero__links__link__url_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+}
+
+input versionsPage_version__layout__sideColumn__projectHero__links__link__label_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+}
+
+input versionsPage_version__layout__sideColumn__projectHero__links__link__appearance_operator {
+  equals: versionsPage_version__layout__sideColumn__projectHero__links__link__appearance_Input
+  not_equals: versionsPage_version__layout__sideColumn__projectHero__links__link__appearance_Input
+  in: [versionsPage_version__layout__sideColumn__projectHero__links__link__appearance_Input]
+  not_in: [versionsPage_version__layout__sideColumn__projectHero__links__link__appearance_Input]
+  all: [versionsPage_version__layout__sideColumn__projectHero__links__link__appearance_Input]
+  exists: Boolean
+}
+
+enum versionsPage_version__layout__sideColumn__projectHero__links__link__appearance_Input {
+  default
+  primary
+  secondary
+}
+
+input versionsPage_version__layout__sideColumn__projectHero__links__id_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
 }
 
 input versionsPage_version__layout__sideColumn__sideContent1_operator {
@@ -2679,22 +2900,22 @@ input versionsPage_version__layout__sideColumn__sideContent2_operator {
   exists: Boolean
 }
 
-input versionsPage_version__layout__mainColumn__layoutStyle_operator {
-  equals: versionsPage_version__layout__mainColumn__layoutStyle_Input
-  not_equals: versionsPage_version__layout__mainColumn__layoutStyle_Input
-  in: [versionsPage_version__layout__mainColumn__layoutStyle_Input]
-  not_in: [versionsPage_version__layout__mainColumn__layoutStyle_Input]
-  all: [versionsPage_version__layout__mainColumn__layoutStyle_Input]
+input versionsPage_version__layout__mainColumn__style_operator {
+  equals: versionsPage_version__layout__mainColumn__style_Input
+  not_equals: versionsPage_version__layout__mainColumn__style_Input
+  in: [versionsPage_version__layout__mainColumn__style_Input]
+  not_in: [versionsPage_version__layout__mainColumn__style_Input]
+  all: [versionsPage_version__layout__mainColumn__style_Input]
 }
 
-enum versionsPage_version__layout__mainColumn__layoutStyle_Input {
+enum versionsPage_version__layout__mainColumn__style_Input {
   singleLayout
   twoRows
   twoColumns
   threeSectionGrid
 }
 
-input versionsPage_version__layout__mainColumn__singleLayout__singleLayout1_operator {
+input versionsPage_version__layout__mainColumn__row1column1_operator {
   equals: JSON
   not_equals: JSON
   like: JSON
@@ -2702,7 +2923,7 @@ input versionsPage_version__layout__mainColumn__singleLayout__singleLayout1_oper
   exists: Boolean
 }
 
-input versionsPage_version__layout__mainColumn__twoRows__row1_operator {
+input versionsPage_version__layout__mainColumn__row1column2_operator {
   equals: JSON
   not_equals: JSON
   like: JSON
@@ -2710,7 +2931,7 @@ input versionsPage_version__layout__mainColumn__twoRows__row1_operator {
   exists: Boolean
 }
 
-input versionsPage_version__layout__mainColumn__twoRows__row2_operator {
+input versionsPage_version__layout__mainColumn__row2column1_operator {
   equals: JSON
   not_equals: JSON
   like: JSON
@@ -2718,63 +2939,7 @@ input versionsPage_version__layout__mainColumn__twoRows__row2_operator {
   exists: Boolean
 }
 
-input versionsPage_version__layout__mainColumn__twoColumns__col1_operator {
-  equals: JSON
-  not_equals: JSON
-  like: JSON
-  contains: JSON
-  exists: Boolean
-}
-
-input versionsPage_version__layout__mainColumn__twoColumns__col2_operator {
-  equals: JSON
-  not_equals: JSON
-  like: JSON
-  contains: JSON
-  exists: Boolean
-}
-
-input versionsPage_version__layout__mainColumn__threeColumns__col1_operator {
-  equals: JSON
-  not_equals: JSON
-  like: JSON
-  contains: JSON
-  exists: Boolean
-}
-
-input versionsPage_version__layout__mainColumn__threeColumns__col2_operator {
-  equals: JSON
-  not_equals: JSON
-  like: JSON
-  contains: JSON
-  exists: Boolean
-}
-
-input versionsPage_version__layout__mainColumn__threeColumns__col3_operator {
-  equals: JSON
-  not_equals: JSON
-  like: JSON
-  contains: JSON
-  exists: Boolean
-}
-
-input versionsPage_version__layout__mainColumn__threeSectionGrid__left_operator {
-  equals: JSON
-  not_equals: JSON
-  like: JSON
-  contains: JSON
-  exists: Boolean
-}
-
-input versionsPage_version__layout__mainColumn__threeSectionGrid__right__rightTop_operator {
-  equals: JSON
-  not_equals: JSON
-  like: JSON
-  contains: JSON
-  exists: Boolean
-}
-
-input versionsPage_version__layout__mainColumn__threeSectionGrid__right__rightBottom_operator {
+input versionsPage_version__layout__mainColumn__row2column2_operator {
   equals: JSON
   not_equals: JSON
   like: JSON
@@ -2897,33 +3062,35 @@ input versionsPage_where_and {
   version__title: versionsPage_version__title_operator
   version__publishedAt: versionsPage_version__publishedAt_operator
   version__slug: versionsPage_version__slug_operator
-  version__hero__type: versionsPage_version__hero__type_operator
-  version__hero__description: versionsPage_version__hero__description_operator
-  version__hero__links__link__type: versionsPage_version__hero__links__link__type_operator
-  version__hero__links__link__newTab: versionsPage_version__hero__links__link__newTab_operator
-  version__hero__links__link__reference: versionsPage_version__hero__links__link__reference_Relation
-  version__hero__links__link__url: versionsPage_version__hero__links__link__url_operator
-  version__hero__links__link__label: versionsPage_version__hero__links__link__label_operator
-  version__hero__links__link__appearance: versionsPage_version__hero__links__link__appearance_operator
-  version__hero__links__id: versionsPage_version__hero__links__id_operator
-  version__layout__fixedSideContent: versionsPage_version__layout__fixedSideContent_operator
+  version__layout__sideContentPosition: versionsPage_version__layout__sideContentPosition_operator
   version__layout__scrollSnap: versionsPage_version__layout__scrollSnap_operator
   version__layout__fullPageHeight: versionsPage_version__layout__fullPageHeight_operator
-  version__layout__sideColumn__sideStyle: versionsPage_version__layout__sideColumn__sideStyle_operator
+  version__layout__sideColumn__style: versionsPage_version__layout__sideColumn__style_operator
+  version__layout__sideColumn__hero__media: versionsPage_version__layout__sideColumn__hero__media_operator
+  version__layout__sideColumn__hero__description: versionsPage_version__layout__sideColumn__hero__description_operator
+  version__layout__sideColumn__hero__links__link__type: versionsPage_version__layout__sideColumn__hero__links__link__type_operator
+  version__layout__sideColumn__hero__links__link__newTab: versionsPage_version__layout__sideColumn__hero__links__link__newTab_operator
+  version__layout__sideColumn__hero__links__link__reference: versionsPage_version__layout__sideColumn__hero__links__link__reference_Relation
+  version__layout__sideColumn__hero__links__link__url: versionsPage_version__layout__sideColumn__hero__links__link__url_operator
+  version__layout__sideColumn__hero__links__link__label: versionsPage_version__layout__sideColumn__hero__links__link__label_operator
+  version__layout__sideColumn__hero__links__link__appearance: versionsPage_version__layout__sideColumn__hero__links__link__appearance_operator
+  version__layout__sideColumn__hero__links__id: versionsPage_version__layout__sideColumn__hero__links__id_operator
+  version__layout__sideColumn__projectHero__year: versionsPage_version__layout__sideColumn__projectHero__year_operator
+  version__layout__sideColumn__projectHero__client: versionsPage_version__layout__sideColumn__projectHero__client_operator
+  version__layout__sideColumn__projectHero__links__link__type: versionsPage_version__layout__sideColumn__projectHero__links__link__type_operator
+  version__layout__sideColumn__projectHero__links__link__newTab: versionsPage_version__layout__sideColumn__projectHero__links__link__newTab_operator
+  version__layout__sideColumn__projectHero__links__link__reference: versionsPage_version__layout__sideColumn__projectHero__links__link__reference_Relation
+  version__layout__sideColumn__projectHero__links__link__url: versionsPage_version__layout__sideColumn__projectHero__links__link__url_operator
+  version__layout__sideColumn__projectHero__links__link__label: versionsPage_version__layout__sideColumn__projectHero__links__link__label_operator
+  version__layout__sideColumn__projectHero__links__link__appearance: versionsPage_version__layout__sideColumn__projectHero__links__link__appearance_operator
+  version__layout__sideColumn__projectHero__links__id: versionsPage_version__layout__sideColumn__projectHero__links__id_operator
   version__layout__sideColumn__sideContent1: versionsPage_version__layout__sideColumn__sideContent1_operator
   version__layout__sideColumn__sideContent2: versionsPage_version__layout__sideColumn__sideContent2_operator
-  version__layout__mainColumn__layoutStyle: versionsPage_version__layout__mainColumn__layoutStyle_operator
-  version__layout__mainColumn__singleLayout__singleLayout1: versionsPage_version__layout__mainColumn__singleLayout__singleLayout1_operator
-  version__layout__mainColumn__twoRows__row1: versionsPage_version__layout__mainColumn__twoRows__row1_operator
-  version__layout__mainColumn__twoRows__row2: versionsPage_version__layout__mainColumn__twoRows__row2_operator
-  version__layout__mainColumn__twoColumns__col1: versionsPage_version__layout__mainColumn__twoColumns__col1_operator
-  version__layout__mainColumn__twoColumns__col2: versionsPage_version__layout__mainColumn__twoColumns__col2_operator
-  version__layout__mainColumn__threeColumns__col1: versionsPage_version__layout__mainColumn__threeColumns__col1_operator
-  version__layout__mainColumn__threeColumns__col2: versionsPage_version__layout__mainColumn__threeColumns__col2_operator
-  version__layout__mainColumn__threeColumns__col3: versionsPage_version__layout__mainColumn__threeColumns__col3_operator
-  version__layout__mainColumn__threeSectionGrid__left: versionsPage_version__layout__mainColumn__threeSectionGrid__left_operator
-  version__layout__mainColumn__threeSectionGrid__right__rightTop: versionsPage_version__layout__mainColumn__threeSectionGrid__right__rightTop_operator
-  version__layout__mainColumn__threeSectionGrid__right__rightBottom: versionsPage_version__layout__mainColumn__threeSectionGrid__right__rightBottom_operator
+  version__layout__mainColumn__style: versionsPage_version__layout__mainColumn__style_operator
+  version__layout__mainColumn__row1column1: versionsPage_version__layout__mainColumn__row1column1_operator
+  version__layout__mainColumn__row1column2: versionsPage_version__layout__mainColumn__row1column2_operator
+  version__layout__mainColumn__row2column1: versionsPage_version__layout__mainColumn__row2column1_operator
+  version__layout__mainColumn__row2column2: versionsPage_version__layout__mainColumn__row2column2_operator
   version__layout__id: versionsPage_version__layout__id_operator
   version__meta__title: versionsPage_version__meta__title_operator
   version__meta__description: versionsPage_version__meta__description_operator
@@ -2944,33 +3111,35 @@ input versionsPage_where_or {
   version__title: versionsPage_version__title_operator
   version__publishedAt: versionsPage_version__publishedAt_operator
   version__slug: versionsPage_version__slug_operator
-  version__hero__type: versionsPage_version__hero__type_operator
-  version__hero__description: versionsPage_version__hero__description_operator
-  version__hero__links__link__type: versionsPage_version__hero__links__link__type_operator
-  version__hero__links__link__newTab: versionsPage_version__hero__links__link__newTab_operator
-  version__hero__links__link__reference: versionsPage_version__hero__links__link__reference_Relation
-  version__hero__links__link__url: versionsPage_version__hero__links__link__url_operator
-  version__hero__links__link__label: versionsPage_version__hero__links__link__label_operator
-  version__hero__links__link__appearance: versionsPage_version__hero__links__link__appearance_operator
-  version__hero__links__id: versionsPage_version__hero__links__id_operator
-  version__layout__fixedSideContent: versionsPage_version__layout__fixedSideContent_operator
+  version__layout__sideContentPosition: versionsPage_version__layout__sideContentPosition_operator
   version__layout__scrollSnap: versionsPage_version__layout__scrollSnap_operator
   version__layout__fullPageHeight: versionsPage_version__layout__fullPageHeight_operator
-  version__layout__sideColumn__sideStyle: versionsPage_version__layout__sideColumn__sideStyle_operator
+  version__layout__sideColumn__style: versionsPage_version__layout__sideColumn__style_operator
+  version__layout__sideColumn__hero__media: versionsPage_version__layout__sideColumn__hero__media_operator
+  version__layout__sideColumn__hero__description: versionsPage_version__layout__sideColumn__hero__description_operator
+  version__layout__sideColumn__hero__links__link__type: versionsPage_version__layout__sideColumn__hero__links__link__type_operator
+  version__layout__sideColumn__hero__links__link__newTab: versionsPage_version__layout__sideColumn__hero__links__link__newTab_operator
+  version__layout__sideColumn__hero__links__link__reference: versionsPage_version__layout__sideColumn__hero__links__link__reference_Relation
+  version__layout__sideColumn__hero__links__link__url: versionsPage_version__layout__sideColumn__hero__links__link__url_operator
+  version__layout__sideColumn__hero__links__link__label: versionsPage_version__layout__sideColumn__hero__links__link__label_operator
+  version__layout__sideColumn__hero__links__link__appearance: versionsPage_version__layout__sideColumn__hero__links__link__appearance_operator
+  version__layout__sideColumn__hero__links__id: versionsPage_version__layout__sideColumn__hero__links__id_operator
+  version__layout__sideColumn__projectHero__year: versionsPage_version__layout__sideColumn__projectHero__year_operator
+  version__layout__sideColumn__projectHero__client: versionsPage_version__layout__sideColumn__projectHero__client_operator
+  version__layout__sideColumn__projectHero__links__link__type: versionsPage_version__layout__sideColumn__projectHero__links__link__type_operator
+  version__layout__sideColumn__projectHero__links__link__newTab: versionsPage_version__layout__sideColumn__projectHero__links__link__newTab_operator
+  version__layout__sideColumn__projectHero__links__link__reference: versionsPage_version__layout__sideColumn__projectHero__links__link__reference_Relation
+  version__layout__sideColumn__projectHero__links__link__url: versionsPage_version__layout__sideColumn__projectHero__links__link__url_operator
+  version__layout__sideColumn__projectHero__links__link__label: versionsPage_version__layout__sideColumn__projectHero__links__link__label_operator
+  version__layout__sideColumn__projectHero__links__link__appearance: versionsPage_version__layout__sideColumn__projectHero__links__link__appearance_operator
+  version__layout__sideColumn__projectHero__links__id: versionsPage_version__layout__sideColumn__projectHero__links__id_operator
   version__layout__sideColumn__sideContent1: versionsPage_version__layout__sideColumn__sideContent1_operator
   version__layout__sideColumn__sideContent2: versionsPage_version__layout__sideColumn__sideContent2_operator
-  version__layout__mainColumn__layoutStyle: versionsPage_version__layout__mainColumn__layoutStyle_operator
-  version__layout__mainColumn__singleLayout__singleLayout1: versionsPage_version__layout__mainColumn__singleLayout__singleLayout1_operator
-  version__layout__mainColumn__twoRows__row1: versionsPage_version__layout__mainColumn__twoRows__row1_operator
-  version__layout__mainColumn__twoRows__row2: versionsPage_version__layout__mainColumn__twoRows__row2_operator
-  version__layout__mainColumn__twoColumns__col1: versionsPage_version__layout__mainColumn__twoColumns__col1_operator
-  version__layout__mainColumn__twoColumns__col2: versionsPage_version__layout__mainColumn__twoColumns__col2_operator
-  version__layout__mainColumn__threeColumns__col1: versionsPage_version__layout__mainColumn__threeColumns__col1_operator
-  version__layout__mainColumn__threeColumns__col2: versionsPage_version__layout__mainColumn__threeColumns__col2_operator
-  version__layout__mainColumn__threeColumns__col3: versionsPage_version__layout__mainColumn__threeColumns__col3_operator
-  version__layout__mainColumn__threeSectionGrid__left: versionsPage_version__layout__mainColumn__threeSectionGrid__left_operator
-  version__layout__mainColumn__threeSectionGrid__right__rightTop: versionsPage_version__layout__mainColumn__threeSectionGrid__right__rightTop_operator
-  version__layout__mainColumn__threeSectionGrid__right__rightBottom: versionsPage_version__layout__mainColumn__threeSectionGrid__right__rightBottom_operator
+  version__layout__mainColumn__style: versionsPage_version__layout__mainColumn__style_operator
+  version__layout__mainColumn__row1column1: versionsPage_version__layout__mainColumn__row1column1_operator
+  version__layout__mainColumn__row1column2: versionsPage_version__layout__mainColumn__row1column2_operator
+  version__layout__mainColumn__row2column1: versionsPage_version__layout__mainColumn__row2column1_operator
+  version__layout__mainColumn__row2column2: versionsPage_version__layout__mainColumn__row2column2_operator
   version__layout__id: versionsPage_version__layout__id_operator
   version__meta__title: versionsPage_version__meta__title_operator
   version__meta__description: versionsPage_version__meta__description_operator
@@ -2989,15 +3158,16 @@ input versionsPage_where_or {
 type Post {
   id: Int
   title: String
-  categories: Category
+  description: String
+  category: Category
   keywords: [Keyword!]
+  slug: String
   publishedAt: DateTime
   authors: [User!]
   populatedAuthors: [Post_PopulatedAuthors!]
-  hero: HeroField
+  card: Post_Card
   layout: [Layout!]
   relatedPosts: [Post!]
-  slug: String
   meta: Post_Meta
   updatedAt: DateTime
   createdAt: DateTime
@@ -3056,6 +3226,189 @@ scalar EmailAddress @specifiedBy(url: "https://html.spec.whatwg.org/multipage/in
 type Post_PopulatedAuthors {
   id: String
   name: String
+}
+
+type Post_Card {
+  media(where: Post_Card_Media_where): Media
+  backgroundColour: String
+  overlayImage: Boolean
+  showDate: Boolean
+}
+
+input Post_Card_Media_where {
+  alt: Post_Card_Media_alt_operator
+  caption: Post_Card_Media_caption_operator
+  blurhash: Post_Card_Media_blurhash_operator
+  updatedAt: Post_Card_Media_updatedAt_operator
+  createdAt: Post_Card_Media_createdAt_operator
+  url: Post_Card_Media_url_operator
+  filename: Post_Card_Media_filename_operator
+  mimeType: Post_Card_Media_mimeType_operator
+  filesize: Post_Card_Media_filesize_operator
+  width: Post_Card_Media_width_operator
+  height: Post_Card_Media_height_operator
+  id: Post_Card_Media_id_operator
+  AND: [Post_Card_Media_where_and]
+  OR: [Post_Card_Media_where_or]
+}
+
+input Post_Card_Media_alt_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+}
+
+input Post_Card_Media_caption_operator {
+  equals: JSON
+  not_equals: JSON
+  like: JSON
+  contains: JSON
+  exists: Boolean
+}
+
+input Post_Card_Media_blurhash_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Post_Card_Media_updatedAt_operator {
+  equals: DateTime
+  not_equals: DateTime
+  greater_than_equal: DateTime
+  greater_than: DateTime
+  less_than_equal: DateTime
+  less_than: DateTime
+  like: DateTime
+  exists: Boolean
+}
+
+input Post_Card_Media_createdAt_operator {
+  equals: DateTime
+  not_equals: DateTime
+  greater_than_equal: DateTime
+  greater_than: DateTime
+  less_than_equal: DateTime
+  less_than: DateTime
+  like: DateTime
+  exists: Boolean
+}
+
+input Post_Card_Media_url_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Post_Card_Media_filename_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Post_Card_Media_mimeType_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Post_Card_Media_filesize_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Post_Card_Media_width_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Post_Card_Media_height_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Post_Card_Media_id_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Post_Card_Media_where_and {
+  alt: Post_Card_Media_alt_operator
+  caption: Post_Card_Media_caption_operator
+  blurhash: Post_Card_Media_blurhash_operator
+  updatedAt: Post_Card_Media_updatedAt_operator
+  createdAt: Post_Card_Media_createdAt_operator
+  url: Post_Card_Media_url_operator
+  filename: Post_Card_Media_filename_operator
+  mimeType: Post_Card_Media_mimeType_operator
+  filesize: Post_Card_Media_filesize_operator
+  width: Post_Card_Media_width_operator
+  height: Post_Card_Media_height_operator
+  id: Post_Card_Media_id_operator
+  AND: [Post_Card_Media_where_and]
+  OR: [Post_Card_Media_where_or]
+}
+
+input Post_Card_Media_where_or {
+  alt: Post_Card_Media_alt_operator
+  caption: Post_Card_Media_caption_operator
+  blurhash: Post_Card_Media_blurhash_operator
+  updatedAt: Post_Card_Media_updatedAt_operator
+  createdAt: Post_Card_Media_createdAt_operator
+  url: Post_Card_Media_url_operator
+  filename: Post_Card_Media_filename_operator
+  mimeType: Post_Card_Media_mimeType_operator
+  filesize: Post_Card_Media_filesize_operator
+  width: Post_Card_Media_width_operator
+  height: Post_Card_Media_height_operator
+  id: Post_Card_Media_id_operator
+  AND: [Post_Card_Media_where_and]
+  OR: [Post_Card_Media_where_or]
 }
 
 type Post_Meta {
@@ -3261,42 +3614,49 @@ type Posts {
 
 input Post_where {
   title: Post_title_operator
-  categories: Post_categories_operator
+  description: Post_description_operator
+  category: Post_category_operator
   keywords: Post_keywords_operator
+  slug: Post_slug_operator
   publishedAt: Post_publishedAt_operator
   authors: Post_authors_operator
   populatedAuthors__id: Post_populatedAuthors__id_operator
   populatedAuthors__name: Post_populatedAuthors__name_operator
-  hero__type: Post_hero__type_operator
-  hero__description: Post_hero__description_operator
-  hero__links__link__type: Post_hero__links__link__type_operator
-  hero__links__link__newTab: Post_hero__links__link__newTab_operator
-  hero__links__link__reference: Post_hero__links__link__reference_Relation
-  hero__links__link__url: Post_hero__links__link__url_operator
-  hero__links__link__label: Post_hero__links__link__label_operator
-  hero__links__link__appearance: Post_hero__links__link__appearance_operator
-  hero__links__id: Post_hero__links__id_operator
-  layout__fixedSideContent: Post_layout__fixedSideContent_operator
+  card__media: Post_card__media_operator
+  card__backgroundColour: Post_card__backgroundColour_operator
+  card__overlayImage: Post_card__overlayImage_operator
+  card__showDate: Post_card__showDate_operator
+  layout__sideContentPosition: Post_layout__sideContentPosition_operator
   layout__scrollSnap: Post_layout__scrollSnap_operator
   layout__fullPageHeight: Post_layout__fullPageHeight_operator
-  layout__sideColumn__sideStyle: Post_layout__sideColumn__sideStyle_operator
+  layout__sideColumn__style: Post_layout__sideColumn__style_operator
+  layout__sideColumn__hero__media: Post_layout__sideColumn__hero__media_operator
+  layout__sideColumn__hero__description: Post_layout__sideColumn__hero__description_operator
+  layout__sideColumn__hero__links__link__type: Post_layout__sideColumn__hero__links__link__type_operator
+  layout__sideColumn__hero__links__link__newTab: Post_layout__sideColumn__hero__links__link__newTab_operator
+  layout__sideColumn__hero__links__link__reference: Post_layout__sideColumn__hero__links__link__reference_Relation
+  layout__sideColumn__hero__links__link__url: Post_layout__sideColumn__hero__links__link__url_operator
+  layout__sideColumn__hero__links__link__label: Post_layout__sideColumn__hero__links__link__label_operator
+  layout__sideColumn__hero__links__link__appearance: Post_layout__sideColumn__hero__links__link__appearance_operator
+  layout__sideColumn__hero__links__id: Post_layout__sideColumn__hero__links__id_operator
+  layout__sideColumn__projectHero__year: Post_layout__sideColumn__projectHero__year_operator
+  layout__sideColumn__projectHero__client: Post_layout__sideColumn__projectHero__client_operator
+  layout__sideColumn__projectHero__links__link__type: Post_layout__sideColumn__projectHero__links__link__type_operator
+  layout__sideColumn__projectHero__links__link__newTab: Post_layout__sideColumn__projectHero__links__link__newTab_operator
+  layout__sideColumn__projectHero__links__link__reference: Post_layout__sideColumn__projectHero__links__link__reference_Relation
+  layout__sideColumn__projectHero__links__link__url: Post_layout__sideColumn__projectHero__links__link__url_operator
+  layout__sideColumn__projectHero__links__link__label: Post_layout__sideColumn__projectHero__links__link__label_operator
+  layout__sideColumn__projectHero__links__link__appearance: Post_layout__sideColumn__projectHero__links__link__appearance_operator
+  layout__sideColumn__projectHero__links__id: Post_layout__sideColumn__projectHero__links__id_operator
   layout__sideColumn__sideContent1: Post_layout__sideColumn__sideContent1_operator
   layout__sideColumn__sideContent2: Post_layout__sideColumn__sideContent2_operator
-  layout__mainColumn__layoutStyle: Post_layout__mainColumn__layoutStyle_operator
-  layout__mainColumn__singleLayout__singleLayout1: Post_layout__mainColumn__singleLayout__singleLayout1_operator
-  layout__mainColumn__twoRows__row1: Post_layout__mainColumn__twoRows__row1_operator
-  layout__mainColumn__twoRows__row2: Post_layout__mainColumn__twoRows__row2_operator
-  layout__mainColumn__twoColumns__col1: Post_layout__mainColumn__twoColumns__col1_operator
-  layout__mainColumn__twoColumns__col2: Post_layout__mainColumn__twoColumns__col2_operator
-  layout__mainColumn__threeColumns__col1: Post_layout__mainColumn__threeColumns__col1_operator
-  layout__mainColumn__threeColumns__col2: Post_layout__mainColumn__threeColumns__col2_operator
-  layout__mainColumn__threeColumns__col3: Post_layout__mainColumn__threeColumns__col3_operator
-  layout__mainColumn__threeSectionGrid__left: Post_layout__mainColumn__threeSectionGrid__left_operator
-  layout__mainColumn__threeSectionGrid__right__rightTop: Post_layout__mainColumn__threeSectionGrid__right__rightTop_operator
-  layout__mainColumn__threeSectionGrid__right__rightBottom: Post_layout__mainColumn__threeSectionGrid__right__rightBottom_operator
+  layout__mainColumn__style: Post_layout__mainColumn__style_operator
+  layout__mainColumn__row1column1: Post_layout__mainColumn__row1column1_operator
+  layout__mainColumn__row1column2: Post_layout__mainColumn__row1column2_operator
+  layout__mainColumn__row2column1: Post_layout__mainColumn__row2column1_operator
+  layout__mainColumn__row2column2: Post_layout__mainColumn__row2column2_operator
   layout__id: Post_layout__id_operator
   relatedPosts: Post_relatedPosts_operator
-  slug: Post_slug_operator
   meta__title: Post_meta__title_operator
   meta__description: Post_meta__description_operator
   meta__image: Post_meta__image_operator
@@ -3318,7 +3678,17 @@ input Post_title_operator {
   all: [String]
 }
 
-input Post_categories_operator {
+input Post_description_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+}
+
+input Post_category_operator {
   equals: JSON
   not_equals: JSON
   in: [JSON]
@@ -3332,6 +3702,17 @@ input Post_keywords_operator {
   in: [JSON]
   not_in: [JSON]
   all: [JSON]
+  exists: Boolean
+}
+
+input Post_slug_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
   exists: Boolean
 }
 
@@ -3377,107 +3758,47 @@ input Post_populatedAuthors__name_operator {
   exists: Boolean
 }
 
-input Post_hero__type_operator {
-  equals: Post_hero__type_Input
-  not_equals: Post_hero__type_Input
-  in: [Post_hero__type_Input]
-  not_in: [Post_hero__type_Input]
-  all: [Post_hero__type_Input]
-}
-
-enum Post_hero__type_Input {
-  none
-  fixedSidePanel
-  halfPage
-  fullPage
-}
-
-input Post_hero__description_operator {
-  equals: JSON
-  not_equals: JSON
-  like: JSON
-  contains: JSON
+input Post_card__media_operator {
+  equals: String
+  not_equals: String
   exists: Boolean
 }
 
-input Post_hero__links__link__type_operator {
-  equals: Post_hero__links__link__type_Input
-  not_equals: Post_hero__links__link__type_Input
-  like: Post_hero__links__link__type_Input
-  contains: Post_hero__links__link__type_Input
+input Post_card__backgroundColour_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
   exists: Boolean
 }
 
-enum Post_hero__links__link__type_Input {
-  reference
-  custom
-}
-
-input Post_hero__links__link__newTab_operator {
+input Post_card__overlayImage_operator {
   equals: Boolean
   not_equals: Boolean
   exists: Boolean
 }
 
-input Post_hero__links__link__reference_Relation {
-  relationTo: Post_hero__links__link__reference_Relation_RelationTo
-  value: JSON
-}
-
-enum Post_hero__links__link__reference_Relation_RelationTo {
-  pages
-}
-
-input Post_hero__links__link__url_operator {
-  equals: String
-  not_equals: String
-  like: String
-  contains: String
-  in: [String]
-  not_in: [String]
-  all: [String]
-}
-
-input Post_hero__links__link__label_operator {
-  equals: String
-  not_equals: String
-  like: String
-  contains: String
-  in: [String]
-  not_in: [String]
-  all: [String]
-}
-
-input Post_hero__links__link__appearance_operator {
-  equals: Post_hero__links__link__appearance_Input
-  not_equals: Post_hero__links__link__appearance_Input
-  in: [Post_hero__links__link__appearance_Input]
-  not_in: [Post_hero__links__link__appearance_Input]
-  all: [Post_hero__links__link__appearance_Input]
-  exists: Boolean
-}
-
-enum Post_hero__links__link__appearance_Input {
-  default
-  primary
-  secondary
-}
-
-input Post_hero__links__id_operator {
-  equals: String
-  not_equals: String
-  like: String
-  contains: String
-  in: [String]
-  not_in: [String]
-  all: [String]
-  exists: Boolean
-}
-
-input Post_layout__fixedSideContent_operator {
+input Post_card__showDate_operator {
   equals: Boolean
   not_equals: Boolean
   exists: Boolean
+}
+
+input Post_layout__sideContentPosition_operator {
+  equals: Post_layout__sideContentPosition_Input
+  not_equals: Post_layout__sideContentPosition_Input
+  in: [Post_layout__sideContentPosition_Input]
+  not_in: [Post_layout__sideContentPosition_Input]
+  all: [Post_layout__sideContentPosition_Input]
+}
+
+enum Post_layout__sideContentPosition_Input {
+  scrollSideContent
+  fixedSideContentWhenVisible
+  fixedSideContentAlways
 }
 
 input Post_layout__scrollSnap_operator {
@@ -3492,18 +3813,202 @@ input Post_layout__fullPageHeight_operator {
   exists: Boolean
 }
 
-input Post_layout__sideColumn__sideStyle_operator {
-  equals: Post_layout__sideColumn__sideStyle_Input
-  not_equals: Post_layout__sideColumn__sideStyle_Input
-  in: [Post_layout__sideColumn__sideStyle_Input]
-  not_in: [Post_layout__sideColumn__sideStyle_Input]
-  all: [Post_layout__sideColumn__sideStyle_Input]
+input Post_layout__sideColumn__style_operator {
+  equals: Post_layout__sideColumn__style_Input
+  not_equals: Post_layout__sideColumn__style_Input
+  in: [Post_layout__sideColumn__style_Input]
+  not_in: [Post_layout__sideColumn__style_Input]
+  all: [Post_layout__sideColumn__style_Input]
 }
 
-enum Post_layout__sideColumn__sideStyle_Input {
+enum Post_layout__sideColumn__style_Input {
   none
+  hero
+  postHero
+  projectHero
   singleLayout
   twoRows
+}
+
+input Post_layout__sideColumn__hero__media_operator {
+  equals: String
+  not_equals: String
+  exists: Boolean
+}
+
+input Post_layout__sideColumn__hero__description_operator {
+  equals: JSON
+  not_equals: JSON
+  like: JSON
+  contains: JSON
+  exists: Boolean
+}
+
+input Post_layout__sideColumn__hero__links__link__type_operator {
+  equals: Post_layout__sideColumn__hero__links__link__type_Input
+  not_equals: Post_layout__sideColumn__hero__links__link__type_Input
+  like: Post_layout__sideColumn__hero__links__link__type_Input
+  contains: Post_layout__sideColumn__hero__links__link__type_Input
+  exists: Boolean
+}
+
+enum Post_layout__sideColumn__hero__links__link__type_Input {
+  reference
+  custom
+}
+
+input Post_layout__sideColumn__hero__links__link__newTab_operator {
+  equals: Boolean
+  not_equals: Boolean
+  exists: Boolean
+}
+
+input Post_layout__sideColumn__hero__links__link__reference_Relation {
+  relationTo: Post_layout__sideColumn__hero__links__link__reference_Relation_RelationTo
+  value: JSON
+}
+
+enum Post_layout__sideColumn__hero__links__link__reference_Relation_RelationTo {
+  pages
+}
+
+input Post_layout__sideColumn__hero__links__link__url_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+}
+
+input Post_layout__sideColumn__hero__links__link__label_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+}
+
+input Post_layout__sideColumn__hero__links__link__appearance_operator {
+  equals: Post_layout__sideColumn__hero__links__link__appearance_Input
+  not_equals: Post_layout__sideColumn__hero__links__link__appearance_Input
+  in: [Post_layout__sideColumn__hero__links__link__appearance_Input]
+  not_in: [Post_layout__sideColumn__hero__links__link__appearance_Input]
+  all: [Post_layout__sideColumn__hero__links__link__appearance_Input]
+  exists: Boolean
+}
+
+enum Post_layout__sideColumn__hero__links__link__appearance_Input {
+  default
+  primary
+  secondary
+}
+
+input Post_layout__sideColumn__hero__links__id_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Post_layout__sideColumn__projectHero__year_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Post_layout__sideColumn__projectHero__client_operator {
+  equals: JSON
+  not_equals: JSON
+  in: [JSON]
+  not_in: [JSON]
+  all: [JSON]
+  exists: Boolean
+}
+
+input Post_layout__sideColumn__projectHero__links__link__type_operator {
+  equals: Post_layout__sideColumn__projectHero__links__link__type_Input
+  not_equals: Post_layout__sideColumn__projectHero__links__link__type_Input
+  like: Post_layout__sideColumn__projectHero__links__link__type_Input
+  contains: Post_layout__sideColumn__projectHero__links__link__type_Input
+  exists: Boolean
+}
+
+enum Post_layout__sideColumn__projectHero__links__link__type_Input {
+  reference
+  custom
+}
+
+input Post_layout__sideColumn__projectHero__links__link__newTab_operator {
+  equals: Boolean
+  not_equals: Boolean
+  exists: Boolean
+}
+
+input Post_layout__sideColumn__projectHero__links__link__reference_Relation {
+  relationTo: Post_layout__sideColumn__projectHero__links__link__reference_Relation_RelationTo
+  value: JSON
+}
+
+enum Post_layout__sideColumn__projectHero__links__link__reference_Relation_RelationTo {
+  pages
+}
+
+input Post_layout__sideColumn__projectHero__links__link__url_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+}
+
+input Post_layout__sideColumn__projectHero__links__link__label_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+}
+
+input Post_layout__sideColumn__projectHero__links__link__appearance_operator {
+  equals: Post_layout__sideColumn__projectHero__links__link__appearance_Input
+  not_equals: Post_layout__sideColumn__projectHero__links__link__appearance_Input
+  in: [Post_layout__sideColumn__projectHero__links__link__appearance_Input]
+  not_in: [Post_layout__sideColumn__projectHero__links__link__appearance_Input]
+  all: [Post_layout__sideColumn__projectHero__links__link__appearance_Input]
+  exists: Boolean
+}
+
+enum Post_layout__sideColumn__projectHero__links__link__appearance_Input {
+  default
+  primary
+  secondary
+}
+
+input Post_layout__sideColumn__projectHero__links__id_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
 }
 
 input Post_layout__sideColumn__sideContent1_operator {
@@ -3522,22 +4027,22 @@ input Post_layout__sideColumn__sideContent2_operator {
   exists: Boolean
 }
 
-input Post_layout__mainColumn__layoutStyle_operator {
-  equals: Post_layout__mainColumn__layoutStyle_Input
-  not_equals: Post_layout__mainColumn__layoutStyle_Input
-  in: [Post_layout__mainColumn__layoutStyle_Input]
-  not_in: [Post_layout__mainColumn__layoutStyle_Input]
-  all: [Post_layout__mainColumn__layoutStyle_Input]
+input Post_layout__mainColumn__style_operator {
+  equals: Post_layout__mainColumn__style_Input
+  not_equals: Post_layout__mainColumn__style_Input
+  in: [Post_layout__mainColumn__style_Input]
+  not_in: [Post_layout__mainColumn__style_Input]
+  all: [Post_layout__mainColumn__style_Input]
 }
 
-enum Post_layout__mainColumn__layoutStyle_Input {
+enum Post_layout__mainColumn__style_Input {
   singleLayout
   twoRows
   twoColumns
   threeSectionGrid
 }
 
-input Post_layout__mainColumn__singleLayout__singleLayout1_operator {
+input Post_layout__mainColumn__row1column1_operator {
   equals: JSON
   not_equals: JSON
   like: JSON
@@ -3545,7 +4050,7 @@ input Post_layout__mainColumn__singleLayout__singleLayout1_operator {
   exists: Boolean
 }
 
-input Post_layout__mainColumn__twoRows__row1_operator {
+input Post_layout__mainColumn__row1column2_operator {
   equals: JSON
   not_equals: JSON
   like: JSON
@@ -3553,7 +4058,7 @@ input Post_layout__mainColumn__twoRows__row1_operator {
   exists: Boolean
 }
 
-input Post_layout__mainColumn__twoRows__row2_operator {
+input Post_layout__mainColumn__row2column1_operator {
   equals: JSON
   not_equals: JSON
   like: JSON
@@ -3561,63 +4066,7 @@ input Post_layout__mainColumn__twoRows__row2_operator {
   exists: Boolean
 }
 
-input Post_layout__mainColumn__twoColumns__col1_operator {
-  equals: JSON
-  not_equals: JSON
-  like: JSON
-  contains: JSON
-  exists: Boolean
-}
-
-input Post_layout__mainColumn__twoColumns__col2_operator {
-  equals: JSON
-  not_equals: JSON
-  like: JSON
-  contains: JSON
-  exists: Boolean
-}
-
-input Post_layout__mainColumn__threeColumns__col1_operator {
-  equals: JSON
-  not_equals: JSON
-  like: JSON
-  contains: JSON
-  exists: Boolean
-}
-
-input Post_layout__mainColumn__threeColumns__col2_operator {
-  equals: JSON
-  not_equals: JSON
-  like: JSON
-  contains: JSON
-  exists: Boolean
-}
-
-input Post_layout__mainColumn__threeColumns__col3_operator {
-  equals: JSON
-  not_equals: JSON
-  like: JSON
-  contains: JSON
-  exists: Boolean
-}
-
-input Post_layout__mainColumn__threeSectionGrid__left_operator {
-  equals: JSON
-  not_equals: JSON
-  like: JSON
-  contains: JSON
-  exists: Boolean
-}
-
-input Post_layout__mainColumn__threeSectionGrid__right__rightTop_operator {
-  equals: JSON
-  not_equals: JSON
-  like: JSON
-  contains: JSON
-  exists: Boolean
-}
-
-input Post_layout__mainColumn__threeSectionGrid__right__rightBottom_operator {
+input Post_layout__mainColumn__row2column2_operator {
   equals: JSON
   not_equals: JSON
   like: JSON
@@ -3642,17 +4091,6 @@ input Post_relatedPosts_operator {
   in: [JSON]
   not_in: [JSON]
   all: [JSON]
-  exists: Boolean
-}
-
-input Post_slug_operator {
-  equals: String
-  not_equals: String
-  like: String
-  contains: String
-  in: [String]
-  not_in: [String]
-  all: [String]
   exists: Boolean
 }
 
@@ -3729,42 +4167,49 @@ input Post_id_operator {
 
 input Post_where_and {
   title: Post_title_operator
-  categories: Post_categories_operator
+  description: Post_description_operator
+  category: Post_category_operator
   keywords: Post_keywords_operator
+  slug: Post_slug_operator
   publishedAt: Post_publishedAt_operator
   authors: Post_authors_operator
   populatedAuthors__id: Post_populatedAuthors__id_operator
   populatedAuthors__name: Post_populatedAuthors__name_operator
-  hero__type: Post_hero__type_operator
-  hero__description: Post_hero__description_operator
-  hero__links__link__type: Post_hero__links__link__type_operator
-  hero__links__link__newTab: Post_hero__links__link__newTab_operator
-  hero__links__link__reference: Post_hero__links__link__reference_Relation
-  hero__links__link__url: Post_hero__links__link__url_operator
-  hero__links__link__label: Post_hero__links__link__label_operator
-  hero__links__link__appearance: Post_hero__links__link__appearance_operator
-  hero__links__id: Post_hero__links__id_operator
-  layout__fixedSideContent: Post_layout__fixedSideContent_operator
+  card__media: Post_card__media_operator
+  card__backgroundColour: Post_card__backgroundColour_operator
+  card__overlayImage: Post_card__overlayImage_operator
+  card__showDate: Post_card__showDate_operator
+  layout__sideContentPosition: Post_layout__sideContentPosition_operator
   layout__scrollSnap: Post_layout__scrollSnap_operator
   layout__fullPageHeight: Post_layout__fullPageHeight_operator
-  layout__sideColumn__sideStyle: Post_layout__sideColumn__sideStyle_operator
+  layout__sideColumn__style: Post_layout__sideColumn__style_operator
+  layout__sideColumn__hero__media: Post_layout__sideColumn__hero__media_operator
+  layout__sideColumn__hero__description: Post_layout__sideColumn__hero__description_operator
+  layout__sideColumn__hero__links__link__type: Post_layout__sideColumn__hero__links__link__type_operator
+  layout__sideColumn__hero__links__link__newTab: Post_layout__sideColumn__hero__links__link__newTab_operator
+  layout__sideColumn__hero__links__link__reference: Post_layout__sideColumn__hero__links__link__reference_Relation
+  layout__sideColumn__hero__links__link__url: Post_layout__sideColumn__hero__links__link__url_operator
+  layout__sideColumn__hero__links__link__label: Post_layout__sideColumn__hero__links__link__label_operator
+  layout__sideColumn__hero__links__link__appearance: Post_layout__sideColumn__hero__links__link__appearance_operator
+  layout__sideColumn__hero__links__id: Post_layout__sideColumn__hero__links__id_operator
+  layout__sideColumn__projectHero__year: Post_layout__sideColumn__projectHero__year_operator
+  layout__sideColumn__projectHero__client: Post_layout__sideColumn__projectHero__client_operator
+  layout__sideColumn__projectHero__links__link__type: Post_layout__sideColumn__projectHero__links__link__type_operator
+  layout__sideColumn__projectHero__links__link__newTab: Post_layout__sideColumn__projectHero__links__link__newTab_operator
+  layout__sideColumn__projectHero__links__link__reference: Post_layout__sideColumn__projectHero__links__link__reference_Relation
+  layout__sideColumn__projectHero__links__link__url: Post_layout__sideColumn__projectHero__links__link__url_operator
+  layout__sideColumn__projectHero__links__link__label: Post_layout__sideColumn__projectHero__links__link__label_operator
+  layout__sideColumn__projectHero__links__link__appearance: Post_layout__sideColumn__projectHero__links__link__appearance_operator
+  layout__sideColumn__projectHero__links__id: Post_layout__sideColumn__projectHero__links__id_operator
   layout__sideColumn__sideContent1: Post_layout__sideColumn__sideContent1_operator
   layout__sideColumn__sideContent2: Post_layout__sideColumn__sideContent2_operator
-  layout__mainColumn__layoutStyle: Post_layout__mainColumn__layoutStyle_operator
-  layout__mainColumn__singleLayout__singleLayout1: Post_layout__mainColumn__singleLayout__singleLayout1_operator
-  layout__mainColumn__twoRows__row1: Post_layout__mainColumn__twoRows__row1_operator
-  layout__mainColumn__twoRows__row2: Post_layout__mainColumn__twoRows__row2_operator
-  layout__mainColumn__twoColumns__col1: Post_layout__mainColumn__twoColumns__col1_operator
-  layout__mainColumn__twoColumns__col2: Post_layout__mainColumn__twoColumns__col2_operator
-  layout__mainColumn__threeColumns__col1: Post_layout__mainColumn__threeColumns__col1_operator
-  layout__mainColumn__threeColumns__col2: Post_layout__mainColumn__threeColumns__col2_operator
-  layout__mainColumn__threeColumns__col3: Post_layout__mainColumn__threeColumns__col3_operator
-  layout__mainColumn__threeSectionGrid__left: Post_layout__mainColumn__threeSectionGrid__left_operator
-  layout__mainColumn__threeSectionGrid__right__rightTop: Post_layout__mainColumn__threeSectionGrid__right__rightTop_operator
-  layout__mainColumn__threeSectionGrid__right__rightBottom: Post_layout__mainColumn__threeSectionGrid__right__rightBottom_operator
+  layout__mainColumn__style: Post_layout__mainColumn__style_operator
+  layout__mainColumn__row1column1: Post_layout__mainColumn__row1column1_operator
+  layout__mainColumn__row1column2: Post_layout__mainColumn__row1column2_operator
+  layout__mainColumn__row2column1: Post_layout__mainColumn__row2column1_operator
+  layout__mainColumn__row2column2: Post_layout__mainColumn__row2column2_operator
   layout__id: Post_layout__id_operator
   relatedPosts: Post_relatedPosts_operator
-  slug: Post_slug_operator
   meta__title: Post_meta__title_operator
   meta__description: Post_meta__description_operator
   meta__image: Post_meta__image_operator
@@ -3778,42 +4223,49 @@ input Post_where_and {
 
 input Post_where_or {
   title: Post_title_operator
-  categories: Post_categories_operator
+  description: Post_description_operator
+  category: Post_category_operator
   keywords: Post_keywords_operator
+  slug: Post_slug_operator
   publishedAt: Post_publishedAt_operator
   authors: Post_authors_operator
   populatedAuthors__id: Post_populatedAuthors__id_operator
   populatedAuthors__name: Post_populatedAuthors__name_operator
-  hero__type: Post_hero__type_operator
-  hero__description: Post_hero__description_operator
-  hero__links__link__type: Post_hero__links__link__type_operator
-  hero__links__link__newTab: Post_hero__links__link__newTab_operator
-  hero__links__link__reference: Post_hero__links__link__reference_Relation
-  hero__links__link__url: Post_hero__links__link__url_operator
-  hero__links__link__label: Post_hero__links__link__label_operator
-  hero__links__link__appearance: Post_hero__links__link__appearance_operator
-  hero__links__id: Post_hero__links__id_operator
-  layout__fixedSideContent: Post_layout__fixedSideContent_operator
+  card__media: Post_card__media_operator
+  card__backgroundColour: Post_card__backgroundColour_operator
+  card__overlayImage: Post_card__overlayImage_operator
+  card__showDate: Post_card__showDate_operator
+  layout__sideContentPosition: Post_layout__sideContentPosition_operator
   layout__scrollSnap: Post_layout__scrollSnap_operator
   layout__fullPageHeight: Post_layout__fullPageHeight_operator
-  layout__sideColumn__sideStyle: Post_layout__sideColumn__sideStyle_operator
+  layout__sideColumn__style: Post_layout__sideColumn__style_operator
+  layout__sideColumn__hero__media: Post_layout__sideColumn__hero__media_operator
+  layout__sideColumn__hero__description: Post_layout__sideColumn__hero__description_operator
+  layout__sideColumn__hero__links__link__type: Post_layout__sideColumn__hero__links__link__type_operator
+  layout__sideColumn__hero__links__link__newTab: Post_layout__sideColumn__hero__links__link__newTab_operator
+  layout__sideColumn__hero__links__link__reference: Post_layout__sideColumn__hero__links__link__reference_Relation
+  layout__sideColumn__hero__links__link__url: Post_layout__sideColumn__hero__links__link__url_operator
+  layout__sideColumn__hero__links__link__label: Post_layout__sideColumn__hero__links__link__label_operator
+  layout__sideColumn__hero__links__link__appearance: Post_layout__sideColumn__hero__links__link__appearance_operator
+  layout__sideColumn__hero__links__id: Post_layout__sideColumn__hero__links__id_operator
+  layout__sideColumn__projectHero__year: Post_layout__sideColumn__projectHero__year_operator
+  layout__sideColumn__projectHero__client: Post_layout__sideColumn__projectHero__client_operator
+  layout__sideColumn__projectHero__links__link__type: Post_layout__sideColumn__projectHero__links__link__type_operator
+  layout__sideColumn__projectHero__links__link__newTab: Post_layout__sideColumn__projectHero__links__link__newTab_operator
+  layout__sideColumn__projectHero__links__link__reference: Post_layout__sideColumn__projectHero__links__link__reference_Relation
+  layout__sideColumn__projectHero__links__link__url: Post_layout__sideColumn__projectHero__links__link__url_operator
+  layout__sideColumn__projectHero__links__link__label: Post_layout__sideColumn__projectHero__links__link__label_operator
+  layout__sideColumn__projectHero__links__link__appearance: Post_layout__sideColumn__projectHero__links__link__appearance_operator
+  layout__sideColumn__projectHero__links__id: Post_layout__sideColumn__projectHero__links__id_operator
   layout__sideColumn__sideContent1: Post_layout__sideColumn__sideContent1_operator
   layout__sideColumn__sideContent2: Post_layout__sideColumn__sideContent2_operator
-  layout__mainColumn__layoutStyle: Post_layout__mainColumn__layoutStyle_operator
-  layout__mainColumn__singleLayout__singleLayout1: Post_layout__mainColumn__singleLayout__singleLayout1_operator
-  layout__mainColumn__twoRows__row1: Post_layout__mainColumn__twoRows__row1_operator
-  layout__mainColumn__twoRows__row2: Post_layout__mainColumn__twoRows__row2_operator
-  layout__mainColumn__twoColumns__col1: Post_layout__mainColumn__twoColumns__col1_operator
-  layout__mainColumn__twoColumns__col2: Post_layout__mainColumn__twoColumns__col2_operator
-  layout__mainColumn__threeColumns__col1: Post_layout__mainColumn__threeColumns__col1_operator
-  layout__mainColumn__threeColumns__col2: Post_layout__mainColumn__threeColumns__col2_operator
-  layout__mainColumn__threeColumns__col3: Post_layout__mainColumn__threeColumns__col3_operator
-  layout__mainColumn__threeSectionGrid__left: Post_layout__mainColumn__threeSectionGrid__left_operator
-  layout__mainColumn__threeSectionGrid__right__rightTop: Post_layout__mainColumn__threeSectionGrid__right__rightTop_operator
-  layout__mainColumn__threeSectionGrid__right__rightBottom: Post_layout__mainColumn__threeSectionGrid__right__rightBottom_operator
+  layout__mainColumn__style: Post_layout__mainColumn__style_operator
+  layout__mainColumn__row1column1: Post_layout__mainColumn__row1column1_operator
+  layout__mainColumn__row1column2: Post_layout__mainColumn__row1column2_operator
+  layout__mainColumn__row2column1: Post_layout__mainColumn__row2column1_operator
+  layout__mainColumn__row2column2: Post_layout__mainColumn__row2column2_operator
   layout__id: Post_layout__id_operator
   relatedPosts: Post_relatedPosts_operator
-  slug: Post_slug_operator
   meta__title: Post_meta__title_operator
   meta__description: Post_meta__description_operator
   meta__image: Post_meta__image_operator
@@ -3836,15 +4288,16 @@ type postsDocAccess {
 
 type PostsDocAccessFields {
   title: PostsDocAccessFields_title
-  categories: PostsDocAccessFields_categories
+  description: PostsDocAccessFields_description
+  category: PostsDocAccessFields_category
   keywords: PostsDocAccessFields_keywords
+  slug: PostsDocAccessFields_slug
   publishedAt: PostsDocAccessFields_publishedAt
   authors: PostsDocAccessFields_authors
   populatedAuthors: PostsDocAccessFields_populatedAuthors
-  hero: PostsDocAccessFields_hero
+  card: PostsDocAccessFields_card
   layout: PostsDocAccessFields_layout
   relatedPosts: PostsDocAccessFields_relatedPosts
-  slug: PostsDocAccessFields_slug
   meta: PostsDocAccessFields_meta
   updatedAt: PostsDocAccessFields_updatedAt
   createdAt: PostsDocAccessFields_createdAt
@@ -3874,26 +4327,49 @@ type PostsDocAccessFields_title_Delete {
   permission: Boolean!
 }
 
-type PostsDocAccessFields_categories {
-  create: PostsDocAccessFields_categories_Create
-  read: PostsDocAccessFields_categories_Read
-  update: PostsDocAccessFields_categories_Update
-  delete: PostsDocAccessFields_categories_Delete
+type PostsDocAccessFields_description {
+  create: PostsDocAccessFields_description_Create
+  read: PostsDocAccessFields_description_Read
+  update: PostsDocAccessFields_description_Update
+  delete: PostsDocAccessFields_description_Delete
 }
 
-type PostsDocAccessFields_categories_Create {
+type PostsDocAccessFields_description_Create {
   permission: Boolean!
 }
 
-type PostsDocAccessFields_categories_Read {
+type PostsDocAccessFields_description_Read {
   permission: Boolean!
 }
 
-type PostsDocAccessFields_categories_Update {
+type PostsDocAccessFields_description_Update {
   permission: Boolean!
 }
 
-type PostsDocAccessFields_categories_Delete {
+type PostsDocAccessFields_description_Delete {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_category {
+  create: PostsDocAccessFields_category_Create
+  read: PostsDocAccessFields_category_Read
+  update: PostsDocAccessFields_category_Update
+  delete: PostsDocAccessFields_category_Delete
+}
+
+type PostsDocAccessFields_category_Create {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_category_Read {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_category_Update {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_category_Delete {
   permission: Boolean!
 }
 
@@ -3917,6 +4393,29 @@ type PostsDocAccessFields_keywords_Update {
 }
 
 type PostsDocAccessFields_keywords_Delete {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_slug {
+  create: PostsDocAccessFields_slug_Create
+  read: PostsDocAccessFields_slug_Read
+  update: PostsDocAccessFields_slug_Update
+  delete: PostsDocAccessFields_slug_Delete
+}
+
+type PostsDocAccessFields_slug_Create {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_slug_Read {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_slug_Update {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_slug_Delete {
   permission: Boolean!
 }
 
@@ -4041,302 +4540,126 @@ type PostsDocAccessFields_populatedAuthors_name_Delete {
   permission: Boolean!
 }
 
-type PostsDocAccessFields_hero {
-  create: PostsDocAccessFields_hero_Create
-  read: PostsDocAccessFields_hero_Read
-  update: PostsDocAccessFields_hero_Update
-  delete: PostsDocAccessFields_hero_Delete
-  fields: PostsDocAccessFields_hero_Fields
+type PostsDocAccessFields_card {
+  create: PostsDocAccessFields_card_Create
+  read: PostsDocAccessFields_card_Read
+  update: PostsDocAccessFields_card_Update
+  delete: PostsDocAccessFields_card_Delete
+  fields: PostsDocAccessFields_card_Fields
 }
 
-type PostsDocAccessFields_hero_Create {
+type PostsDocAccessFields_card_Create {
   permission: Boolean!
 }
 
-type PostsDocAccessFields_hero_Read {
+type PostsDocAccessFields_card_Read {
   permission: Boolean!
 }
 
-type PostsDocAccessFields_hero_Update {
+type PostsDocAccessFields_card_Update {
   permission: Boolean!
 }
 
-type PostsDocAccessFields_hero_Delete {
+type PostsDocAccessFields_card_Delete {
   permission: Boolean!
 }
 
-type PostsDocAccessFields_hero_Fields {
-  type: PostsDocAccessFields_hero_type
-  description: PostsDocAccessFields_hero_description
-  links: PostsDocAccessFields_hero_links
+type PostsDocAccessFields_card_Fields {
+  media: PostsDocAccessFields_card_media
+  backgroundColour: PostsDocAccessFields_card_backgroundColour
+  overlayImage: PostsDocAccessFields_card_overlayImage
+  showDate: PostsDocAccessFields_card_showDate
 }
 
-type PostsDocAccessFields_hero_type {
-  create: PostsDocAccessFields_hero_type_Create
-  read: PostsDocAccessFields_hero_type_Read
-  update: PostsDocAccessFields_hero_type_Update
-  delete: PostsDocAccessFields_hero_type_Delete
+type PostsDocAccessFields_card_media {
+  create: PostsDocAccessFields_card_media_Create
+  read: PostsDocAccessFields_card_media_Read
+  update: PostsDocAccessFields_card_media_Update
+  delete: PostsDocAccessFields_card_media_Delete
 }
 
-type PostsDocAccessFields_hero_type_Create {
+type PostsDocAccessFields_card_media_Create {
   permission: Boolean!
 }
 
-type PostsDocAccessFields_hero_type_Read {
+type PostsDocAccessFields_card_media_Read {
   permission: Boolean!
 }
 
-type PostsDocAccessFields_hero_type_Update {
+type PostsDocAccessFields_card_media_Update {
   permission: Boolean!
 }
 
-type PostsDocAccessFields_hero_type_Delete {
+type PostsDocAccessFields_card_media_Delete {
   permission: Boolean!
 }
 
-type PostsDocAccessFields_hero_description {
-  create: PostsDocAccessFields_hero_description_Create
-  read: PostsDocAccessFields_hero_description_Read
-  update: PostsDocAccessFields_hero_description_Update
-  delete: PostsDocAccessFields_hero_description_Delete
+type PostsDocAccessFields_card_backgroundColour {
+  create: PostsDocAccessFields_card_backgroundColour_Create
+  read: PostsDocAccessFields_card_backgroundColour_Read
+  update: PostsDocAccessFields_card_backgroundColour_Update
+  delete: PostsDocAccessFields_card_backgroundColour_Delete
 }
 
-type PostsDocAccessFields_hero_description_Create {
+type PostsDocAccessFields_card_backgroundColour_Create {
   permission: Boolean!
 }
 
-type PostsDocAccessFields_hero_description_Read {
+type PostsDocAccessFields_card_backgroundColour_Read {
   permission: Boolean!
 }
 
-type PostsDocAccessFields_hero_description_Update {
+type PostsDocAccessFields_card_backgroundColour_Update {
   permission: Boolean!
 }
 
-type PostsDocAccessFields_hero_description_Delete {
+type PostsDocAccessFields_card_backgroundColour_Delete {
   permission: Boolean!
 }
 
-type PostsDocAccessFields_hero_links {
-  create: PostsDocAccessFields_hero_links_Create
-  read: PostsDocAccessFields_hero_links_Read
-  update: PostsDocAccessFields_hero_links_Update
-  delete: PostsDocAccessFields_hero_links_Delete
-  fields: PostsDocAccessFields_hero_links_Fields
+type PostsDocAccessFields_card_overlayImage {
+  create: PostsDocAccessFields_card_overlayImage_Create
+  read: PostsDocAccessFields_card_overlayImage_Read
+  update: PostsDocAccessFields_card_overlayImage_Update
+  delete: PostsDocAccessFields_card_overlayImage_Delete
 }
 
-type PostsDocAccessFields_hero_links_Create {
+type PostsDocAccessFields_card_overlayImage_Create {
   permission: Boolean!
 }
 
-type PostsDocAccessFields_hero_links_Read {
+type PostsDocAccessFields_card_overlayImage_Read {
   permission: Boolean!
 }
 
-type PostsDocAccessFields_hero_links_Update {
+type PostsDocAccessFields_card_overlayImage_Update {
   permission: Boolean!
 }
 
-type PostsDocAccessFields_hero_links_Delete {
+type PostsDocAccessFields_card_overlayImage_Delete {
   permission: Boolean!
 }
 
-type PostsDocAccessFields_hero_links_Fields {
-  link: PostsDocAccessFields_hero_links_link
-  id: PostsDocAccessFields_hero_links_id
+type PostsDocAccessFields_card_showDate {
+  create: PostsDocAccessFields_card_showDate_Create
+  read: PostsDocAccessFields_card_showDate_Read
+  update: PostsDocAccessFields_card_showDate_Update
+  delete: PostsDocAccessFields_card_showDate_Delete
 }
 
-type PostsDocAccessFields_hero_links_link {
-  create: PostsDocAccessFields_hero_links_link_Create
-  read: PostsDocAccessFields_hero_links_link_Read
-  update: PostsDocAccessFields_hero_links_link_Update
-  delete: PostsDocAccessFields_hero_links_link_Delete
-  fields: PostsDocAccessFields_hero_links_link_Fields
-}
-
-type PostsDocAccessFields_hero_links_link_Create {
+type PostsDocAccessFields_card_showDate_Create {
   permission: Boolean!
 }
 
-type PostsDocAccessFields_hero_links_link_Read {
+type PostsDocAccessFields_card_showDate_Read {
   permission: Boolean!
 }
 
-type PostsDocAccessFields_hero_links_link_Update {
+type PostsDocAccessFields_card_showDate_Update {
   permission: Boolean!
 }
 
-type PostsDocAccessFields_hero_links_link_Delete {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_hero_links_link_Fields {
-  type: PostsDocAccessFields_hero_links_link_type
-  newTab: PostsDocAccessFields_hero_links_link_newTab
-  reference: PostsDocAccessFields_hero_links_link_reference
-  url: PostsDocAccessFields_hero_links_link_url
-  label: PostsDocAccessFields_hero_links_link_label
-  appearance: PostsDocAccessFields_hero_links_link_appearance
-}
-
-type PostsDocAccessFields_hero_links_link_type {
-  create: PostsDocAccessFields_hero_links_link_type_Create
-  read: PostsDocAccessFields_hero_links_link_type_Read
-  update: PostsDocAccessFields_hero_links_link_type_Update
-  delete: PostsDocAccessFields_hero_links_link_type_Delete
-}
-
-type PostsDocAccessFields_hero_links_link_type_Create {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_hero_links_link_type_Read {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_hero_links_link_type_Update {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_hero_links_link_type_Delete {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_hero_links_link_newTab {
-  create: PostsDocAccessFields_hero_links_link_newTab_Create
-  read: PostsDocAccessFields_hero_links_link_newTab_Read
-  update: PostsDocAccessFields_hero_links_link_newTab_Update
-  delete: PostsDocAccessFields_hero_links_link_newTab_Delete
-}
-
-type PostsDocAccessFields_hero_links_link_newTab_Create {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_hero_links_link_newTab_Read {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_hero_links_link_newTab_Update {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_hero_links_link_newTab_Delete {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_hero_links_link_reference {
-  create: PostsDocAccessFields_hero_links_link_reference_Create
-  read: PostsDocAccessFields_hero_links_link_reference_Read
-  update: PostsDocAccessFields_hero_links_link_reference_Update
-  delete: PostsDocAccessFields_hero_links_link_reference_Delete
-}
-
-type PostsDocAccessFields_hero_links_link_reference_Create {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_hero_links_link_reference_Read {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_hero_links_link_reference_Update {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_hero_links_link_reference_Delete {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_hero_links_link_url {
-  create: PostsDocAccessFields_hero_links_link_url_Create
-  read: PostsDocAccessFields_hero_links_link_url_Read
-  update: PostsDocAccessFields_hero_links_link_url_Update
-  delete: PostsDocAccessFields_hero_links_link_url_Delete
-}
-
-type PostsDocAccessFields_hero_links_link_url_Create {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_hero_links_link_url_Read {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_hero_links_link_url_Update {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_hero_links_link_url_Delete {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_hero_links_link_label {
-  create: PostsDocAccessFields_hero_links_link_label_Create
-  read: PostsDocAccessFields_hero_links_link_label_Read
-  update: PostsDocAccessFields_hero_links_link_label_Update
-  delete: PostsDocAccessFields_hero_links_link_label_Delete
-}
-
-type PostsDocAccessFields_hero_links_link_label_Create {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_hero_links_link_label_Read {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_hero_links_link_label_Update {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_hero_links_link_label_Delete {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_hero_links_link_appearance {
-  create: PostsDocAccessFields_hero_links_link_appearance_Create
-  read: PostsDocAccessFields_hero_links_link_appearance_Read
-  update: PostsDocAccessFields_hero_links_link_appearance_Update
-  delete: PostsDocAccessFields_hero_links_link_appearance_Delete
-}
-
-type PostsDocAccessFields_hero_links_link_appearance_Create {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_hero_links_link_appearance_Read {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_hero_links_link_appearance_Update {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_hero_links_link_appearance_Delete {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_hero_links_id {
-  create: PostsDocAccessFields_hero_links_id_Create
-  read: PostsDocAccessFields_hero_links_id_Read
-  update: PostsDocAccessFields_hero_links_id_Update
-  delete: PostsDocAccessFields_hero_links_id_Delete
-}
-
-type PostsDocAccessFields_hero_links_id_Create {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_hero_links_id_Read {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_hero_links_id_Update {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_hero_links_id_Delete {
+type PostsDocAccessFields_card_showDate_Delete {
   permission: Boolean!
 }
 
@@ -4365,7 +4688,7 @@ type PostsDocAccessFields_layout_Delete {
 }
 
 type PostsDocAccessFields_layout_Fields {
-  fixedSideContent: PostsDocAccessFields_layout_fixedSideContent
+  sideContentPosition: PostsDocAccessFields_layout_sideContentPosition
   scrollSnap: PostsDocAccessFields_layout_scrollSnap
   fullPageHeight: PostsDocAccessFields_layout_fullPageHeight
   sideColumn: PostsDocAccessFields_layout_sideColumn
@@ -4373,26 +4696,26 @@ type PostsDocAccessFields_layout_Fields {
   id: PostsDocAccessFields_layout_id
 }
 
-type PostsDocAccessFields_layout_fixedSideContent {
-  create: PostsDocAccessFields_layout_fixedSideContent_Create
-  read: PostsDocAccessFields_layout_fixedSideContent_Read
-  update: PostsDocAccessFields_layout_fixedSideContent_Update
-  delete: PostsDocAccessFields_layout_fixedSideContent_Delete
+type PostsDocAccessFields_layout_sideContentPosition {
+  create: PostsDocAccessFields_layout_sideContentPosition_Create
+  read: PostsDocAccessFields_layout_sideContentPosition_Read
+  update: PostsDocAccessFields_layout_sideContentPosition_Update
+  delete: PostsDocAccessFields_layout_sideContentPosition_Delete
 }
 
-type PostsDocAccessFields_layout_fixedSideContent_Create {
+type PostsDocAccessFields_layout_sideContentPosition_Create {
   permission: Boolean!
 }
 
-type PostsDocAccessFields_layout_fixedSideContent_Read {
+type PostsDocAccessFields_layout_sideContentPosition_Read {
   permission: Boolean!
 }
 
-type PostsDocAccessFields_layout_fixedSideContent_Update {
+type PostsDocAccessFields_layout_sideContentPosition_Update {
   permission: Boolean!
 }
 
-type PostsDocAccessFields_layout_fixedSideContent_Delete {
+type PostsDocAccessFields_layout_sideContentPosition_Delete {
   permission: Boolean!
 }
 
@@ -4467,31 +4790,631 @@ type PostsDocAccessFields_layout_sideColumn_Delete {
 }
 
 type PostsDocAccessFields_layout_sideColumn_Fields {
-  sideStyle: PostsDocAccessFields_layout_sideColumn_sideStyle
+  style: PostsDocAccessFields_layout_sideColumn_style
+  hero: PostsDocAccessFields_layout_sideColumn_hero
+  projectHero: PostsDocAccessFields_layout_sideColumn_projectHero
   sideContent1: PostsDocAccessFields_layout_sideColumn_sideContent1
   sideContent2: PostsDocAccessFields_layout_sideColumn_sideContent2
 }
 
-type PostsDocAccessFields_layout_sideColumn_sideStyle {
-  create: PostsDocAccessFields_layout_sideColumn_sideStyle_Create
-  read: PostsDocAccessFields_layout_sideColumn_sideStyle_Read
-  update: PostsDocAccessFields_layout_sideColumn_sideStyle_Update
-  delete: PostsDocAccessFields_layout_sideColumn_sideStyle_Delete
+type PostsDocAccessFields_layout_sideColumn_style {
+  create: PostsDocAccessFields_layout_sideColumn_style_Create
+  read: PostsDocAccessFields_layout_sideColumn_style_Read
+  update: PostsDocAccessFields_layout_sideColumn_style_Update
+  delete: PostsDocAccessFields_layout_sideColumn_style_Delete
 }
 
-type PostsDocAccessFields_layout_sideColumn_sideStyle_Create {
+type PostsDocAccessFields_layout_sideColumn_style_Create {
   permission: Boolean!
 }
 
-type PostsDocAccessFields_layout_sideColumn_sideStyle_Read {
+type PostsDocAccessFields_layout_sideColumn_style_Read {
   permission: Boolean!
 }
 
-type PostsDocAccessFields_layout_sideColumn_sideStyle_Update {
+type PostsDocAccessFields_layout_sideColumn_style_Update {
   permission: Boolean!
 }
 
-type PostsDocAccessFields_layout_sideColumn_sideStyle_Delete {
+type PostsDocAccessFields_layout_sideColumn_style_Delete {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_hero {
+  create: PostsDocAccessFields_layout_sideColumn_hero_Create
+  read: PostsDocAccessFields_layout_sideColumn_hero_Read
+  update: PostsDocAccessFields_layout_sideColumn_hero_Update
+  delete: PostsDocAccessFields_layout_sideColumn_hero_Delete
+  fields: PostsDocAccessFields_layout_sideColumn_hero_Fields
+}
+
+type PostsDocAccessFields_layout_sideColumn_hero_Create {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_hero_Read {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_hero_Update {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_hero_Delete {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_hero_Fields {
+  media: PostsDocAccessFields_layout_sideColumn_hero_media
+  description: PostsDocAccessFields_layout_sideColumn_hero_description
+  links: PostsDocAccessFields_layout_sideColumn_hero_links
+}
+
+type PostsDocAccessFields_layout_sideColumn_hero_media {
+  create: PostsDocAccessFields_layout_sideColumn_hero_media_Create
+  read: PostsDocAccessFields_layout_sideColumn_hero_media_Read
+  update: PostsDocAccessFields_layout_sideColumn_hero_media_Update
+  delete: PostsDocAccessFields_layout_sideColumn_hero_media_Delete
+}
+
+type PostsDocAccessFields_layout_sideColumn_hero_media_Create {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_hero_media_Read {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_hero_media_Update {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_hero_media_Delete {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_hero_description {
+  create: PostsDocAccessFields_layout_sideColumn_hero_description_Create
+  read: PostsDocAccessFields_layout_sideColumn_hero_description_Read
+  update: PostsDocAccessFields_layout_sideColumn_hero_description_Update
+  delete: PostsDocAccessFields_layout_sideColumn_hero_description_Delete
+}
+
+type PostsDocAccessFields_layout_sideColumn_hero_description_Create {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_hero_description_Read {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_hero_description_Update {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_hero_description_Delete {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_hero_links {
+  create: PostsDocAccessFields_layout_sideColumn_hero_links_Create
+  read: PostsDocAccessFields_layout_sideColumn_hero_links_Read
+  update: PostsDocAccessFields_layout_sideColumn_hero_links_Update
+  delete: PostsDocAccessFields_layout_sideColumn_hero_links_Delete
+  fields: PostsDocAccessFields_layout_sideColumn_hero_links_Fields
+}
+
+type PostsDocAccessFields_layout_sideColumn_hero_links_Create {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_hero_links_Read {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_hero_links_Update {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_hero_links_Delete {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_hero_links_Fields {
+  link: PostsDocAccessFields_layout_sideColumn_hero_links_link
+  id: PostsDocAccessFields_layout_sideColumn_hero_links_id
+}
+
+type PostsDocAccessFields_layout_sideColumn_hero_links_link {
+  create: PostsDocAccessFields_layout_sideColumn_hero_links_link_Create
+  read: PostsDocAccessFields_layout_sideColumn_hero_links_link_Read
+  update: PostsDocAccessFields_layout_sideColumn_hero_links_link_Update
+  delete: PostsDocAccessFields_layout_sideColumn_hero_links_link_Delete
+  fields: PostsDocAccessFields_layout_sideColumn_hero_links_link_Fields
+}
+
+type PostsDocAccessFields_layout_sideColumn_hero_links_link_Create {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_hero_links_link_Read {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_hero_links_link_Update {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_hero_links_link_Delete {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_hero_links_link_Fields {
+  type: PostsDocAccessFields_layout_sideColumn_hero_links_link_type
+  newTab: PostsDocAccessFields_layout_sideColumn_hero_links_link_newTab
+  reference: PostsDocAccessFields_layout_sideColumn_hero_links_link_reference
+  url: PostsDocAccessFields_layout_sideColumn_hero_links_link_url
+  label: PostsDocAccessFields_layout_sideColumn_hero_links_link_label
+  appearance: PostsDocAccessFields_layout_sideColumn_hero_links_link_appearance
+}
+
+type PostsDocAccessFields_layout_sideColumn_hero_links_link_type {
+  create: PostsDocAccessFields_layout_sideColumn_hero_links_link_type_Create
+  read: PostsDocAccessFields_layout_sideColumn_hero_links_link_type_Read
+  update: PostsDocAccessFields_layout_sideColumn_hero_links_link_type_Update
+  delete: PostsDocAccessFields_layout_sideColumn_hero_links_link_type_Delete
+}
+
+type PostsDocAccessFields_layout_sideColumn_hero_links_link_type_Create {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_hero_links_link_type_Read {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_hero_links_link_type_Update {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_hero_links_link_type_Delete {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_hero_links_link_newTab {
+  create: PostsDocAccessFields_layout_sideColumn_hero_links_link_newTab_Create
+  read: PostsDocAccessFields_layout_sideColumn_hero_links_link_newTab_Read
+  update: PostsDocAccessFields_layout_sideColumn_hero_links_link_newTab_Update
+  delete: PostsDocAccessFields_layout_sideColumn_hero_links_link_newTab_Delete
+}
+
+type PostsDocAccessFields_layout_sideColumn_hero_links_link_newTab_Create {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_hero_links_link_newTab_Read {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_hero_links_link_newTab_Update {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_hero_links_link_newTab_Delete {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_hero_links_link_reference {
+  create: PostsDocAccessFields_layout_sideColumn_hero_links_link_reference_Create
+  read: PostsDocAccessFields_layout_sideColumn_hero_links_link_reference_Read
+  update: PostsDocAccessFields_layout_sideColumn_hero_links_link_reference_Update
+  delete: PostsDocAccessFields_layout_sideColumn_hero_links_link_reference_Delete
+}
+
+type PostsDocAccessFields_layout_sideColumn_hero_links_link_reference_Create {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_hero_links_link_reference_Read {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_hero_links_link_reference_Update {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_hero_links_link_reference_Delete {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_hero_links_link_url {
+  create: PostsDocAccessFields_layout_sideColumn_hero_links_link_url_Create
+  read: PostsDocAccessFields_layout_sideColumn_hero_links_link_url_Read
+  update: PostsDocAccessFields_layout_sideColumn_hero_links_link_url_Update
+  delete: PostsDocAccessFields_layout_sideColumn_hero_links_link_url_Delete
+}
+
+type PostsDocAccessFields_layout_sideColumn_hero_links_link_url_Create {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_hero_links_link_url_Read {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_hero_links_link_url_Update {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_hero_links_link_url_Delete {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_hero_links_link_label {
+  create: PostsDocAccessFields_layout_sideColumn_hero_links_link_label_Create
+  read: PostsDocAccessFields_layout_sideColumn_hero_links_link_label_Read
+  update: PostsDocAccessFields_layout_sideColumn_hero_links_link_label_Update
+  delete: PostsDocAccessFields_layout_sideColumn_hero_links_link_label_Delete
+}
+
+type PostsDocAccessFields_layout_sideColumn_hero_links_link_label_Create {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_hero_links_link_label_Read {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_hero_links_link_label_Update {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_hero_links_link_label_Delete {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_hero_links_link_appearance {
+  create: PostsDocAccessFields_layout_sideColumn_hero_links_link_appearance_Create
+  read: PostsDocAccessFields_layout_sideColumn_hero_links_link_appearance_Read
+  update: PostsDocAccessFields_layout_sideColumn_hero_links_link_appearance_Update
+  delete: PostsDocAccessFields_layout_sideColumn_hero_links_link_appearance_Delete
+}
+
+type PostsDocAccessFields_layout_sideColumn_hero_links_link_appearance_Create {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_hero_links_link_appearance_Read {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_hero_links_link_appearance_Update {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_hero_links_link_appearance_Delete {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_hero_links_id {
+  create: PostsDocAccessFields_layout_sideColumn_hero_links_id_Create
+  read: PostsDocAccessFields_layout_sideColumn_hero_links_id_Read
+  update: PostsDocAccessFields_layout_sideColumn_hero_links_id_Update
+  delete: PostsDocAccessFields_layout_sideColumn_hero_links_id_Delete
+}
+
+type PostsDocAccessFields_layout_sideColumn_hero_links_id_Create {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_hero_links_id_Read {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_hero_links_id_Update {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_hero_links_id_Delete {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_projectHero {
+  create: PostsDocAccessFields_layout_sideColumn_projectHero_Create
+  read: PostsDocAccessFields_layout_sideColumn_projectHero_Read
+  update: PostsDocAccessFields_layout_sideColumn_projectHero_Update
+  delete: PostsDocAccessFields_layout_sideColumn_projectHero_Delete
+  fields: PostsDocAccessFields_layout_sideColumn_projectHero_Fields
+}
+
+type PostsDocAccessFields_layout_sideColumn_projectHero_Create {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_projectHero_Read {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_projectHero_Update {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_projectHero_Delete {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_projectHero_Fields {
+  year: PostsDocAccessFields_layout_sideColumn_projectHero_year
+  client: PostsDocAccessFields_layout_sideColumn_projectHero_client
+  links: PostsDocAccessFields_layout_sideColumn_projectHero_links
+}
+
+type PostsDocAccessFields_layout_sideColumn_projectHero_year {
+  create: PostsDocAccessFields_layout_sideColumn_projectHero_year_Create
+  read: PostsDocAccessFields_layout_sideColumn_projectHero_year_Read
+  update: PostsDocAccessFields_layout_sideColumn_projectHero_year_Update
+  delete: PostsDocAccessFields_layout_sideColumn_projectHero_year_Delete
+}
+
+type PostsDocAccessFields_layout_sideColumn_projectHero_year_Create {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_projectHero_year_Read {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_projectHero_year_Update {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_projectHero_year_Delete {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_projectHero_client {
+  create: PostsDocAccessFields_layout_sideColumn_projectHero_client_Create
+  read: PostsDocAccessFields_layout_sideColumn_projectHero_client_Read
+  update: PostsDocAccessFields_layout_sideColumn_projectHero_client_Update
+  delete: PostsDocAccessFields_layout_sideColumn_projectHero_client_Delete
+}
+
+type PostsDocAccessFields_layout_sideColumn_projectHero_client_Create {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_projectHero_client_Read {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_projectHero_client_Update {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_projectHero_client_Delete {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_projectHero_links {
+  create: PostsDocAccessFields_layout_sideColumn_projectHero_links_Create
+  read: PostsDocAccessFields_layout_sideColumn_projectHero_links_Read
+  update: PostsDocAccessFields_layout_sideColumn_projectHero_links_Update
+  delete: PostsDocAccessFields_layout_sideColumn_projectHero_links_Delete
+  fields: PostsDocAccessFields_layout_sideColumn_projectHero_links_Fields
+}
+
+type PostsDocAccessFields_layout_sideColumn_projectHero_links_Create {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_projectHero_links_Read {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_projectHero_links_Update {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_projectHero_links_Delete {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_projectHero_links_Fields {
+  link: PostsDocAccessFields_layout_sideColumn_projectHero_links_link
+  id: PostsDocAccessFields_layout_sideColumn_projectHero_links_id
+}
+
+type PostsDocAccessFields_layout_sideColumn_projectHero_links_link {
+  create: PostsDocAccessFields_layout_sideColumn_projectHero_links_link_Create
+  read: PostsDocAccessFields_layout_sideColumn_projectHero_links_link_Read
+  update: PostsDocAccessFields_layout_sideColumn_projectHero_links_link_Update
+  delete: PostsDocAccessFields_layout_sideColumn_projectHero_links_link_Delete
+  fields: PostsDocAccessFields_layout_sideColumn_projectHero_links_link_Fields
+}
+
+type PostsDocAccessFields_layout_sideColumn_projectHero_links_link_Create {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_projectHero_links_link_Read {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_projectHero_links_link_Update {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_projectHero_links_link_Delete {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_projectHero_links_link_Fields {
+  type: PostsDocAccessFields_layout_sideColumn_projectHero_links_link_type
+  newTab: PostsDocAccessFields_layout_sideColumn_projectHero_links_link_newTab
+  reference: PostsDocAccessFields_layout_sideColumn_projectHero_links_link_reference
+  url: PostsDocAccessFields_layout_sideColumn_projectHero_links_link_url
+  label: PostsDocAccessFields_layout_sideColumn_projectHero_links_link_label
+  appearance: PostsDocAccessFields_layout_sideColumn_projectHero_links_link_appearance
+}
+
+type PostsDocAccessFields_layout_sideColumn_projectHero_links_link_type {
+  create: PostsDocAccessFields_layout_sideColumn_projectHero_links_link_type_Create
+  read: PostsDocAccessFields_layout_sideColumn_projectHero_links_link_type_Read
+  update: PostsDocAccessFields_layout_sideColumn_projectHero_links_link_type_Update
+  delete: PostsDocAccessFields_layout_sideColumn_projectHero_links_link_type_Delete
+}
+
+type PostsDocAccessFields_layout_sideColumn_projectHero_links_link_type_Create {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_projectHero_links_link_type_Read {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_projectHero_links_link_type_Update {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_projectHero_links_link_type_Delete {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_projectHero_links_link_newTab {
+  create: PostsDocAccessFields_layout_sideColumn_projectHero_links_link_newTab_Create
+  read: PostsDocAccessFields_layout_sideColumn_projectHero_links_link_newTab_Read
+  update: PostsDocAccessFields_layout_sideColumn_projectHero_links_link_newTab_Update
+  delete: PostsDocAccessFields_layout_sideColumn_projectHero_links_link_newTab_Delete
+}
+
+type PostsDocAccessFields_layout_sideColumn_projectHero_links_link_newTab_Create {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_projectHero_links_link_newTab_Read {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_projectHero_links_link_newTab_Update {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_projectHero_links_link_newTab_Delete {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_projectHero_links_link_reference {
+  create: PostsDocAccessFields_layout_sideColumn_projectHero_links_link_reference_Create
+  read: PostsDocAccessFields_layout_sideColumn_projectHero_links_link_reference_Read
+  update: PostsDocAccessFields_layout_sideColumn_projectHero_links_link_reference_Update
+  delete: PostsDocAccessFields_layout_sideColumn_projectHero_links_link_reference_Delete
+}
+
+type PostsDocAccessFields_layout_sideColumn_projectHero_links_link_reference_Create {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_projectHero_links_link_reference_Read {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_projectHero_links_link_reference_Update {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_projectHero_links_link_reference_Delete {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_projectHero_links_link_url {
+  create: PostsDocAccessFields_layout_sideColumn_projectHero_links_link_url_Create
+  read: PostsDocAccessFields_layout_sideColumn_projectHero_links_link_url_Read
+  update: PostsDocAccessFields_layout_sideColumn_projectHero_links_link_url_Update
+  delete: PostsDocAccessFields_layout_sideColumn_projectHero_links_link_url_Delete
+}
+
+type PostsDocAccessFields_layout_sideColumn_projectHero_links_link_url_Create {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_projectHero_links_link_url_Read {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_projectHero_links_link_url_Update {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_projectHero_links_link_url_Delete {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_projectHero_links_link_label {
+  create: PostsDocAccessFields_layout_sideColumn_projectHero_links_link_label_Create
+  read: PostsDocAccessFields_layout_sideColumn_projectHero_links_link_label_Read
+  update: PostsDocAccessFields_layout_sideColumn_projectHero_links_link_label_Update
+  delete: PostsDocAccessFields_layout_sideColumn_projectHero_links_link_label_Delete
+}
+
+type PostsDocAccessFields_layout_sideColumn_projectHero_links_link_label_Create {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_projectHero_links_link_label_Read {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_projectHero_links_link_label_Update {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_projectHero_links_link_label_Delete {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_projectHero_links_link_appearance {
+  create: PostsDocAccessFields_layout_sideColumn_projectHero_links_link_appearance_Create
+  read: PostsDocAccessFields_layout_sideColumn_projectHero_links_link_appearance_Read
+  update: PostsDocAccessFields_layout_sideColumn_projectHero_links_link_appearance_Update
+  delete: PostsDocAccessFields_layout_sideColumn_projectHero_links_link_appearance_Delete
+}
+
+type PostsDocAccessFields_layout_sideColumn_projectHero_links_link_appearance_Create {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_projectHero_links_link_appearance_Read {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_projectHero_links_link_appearance_Update {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_projectHero_links_link_appearance_Delete {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_projectHero_links_id {
+  create: PostsDocAccessFields_layout_sideColumn_projectHero_links_id_Create
+  read: PostsDocAccessFields_layout_sideColumn_projectHero_links_id_Read
+  update: PostsDocAccessFields_layout_sideColumn_projectHero_links_id_Update
+  delete: PostsDocAccessFields_layout_sideColumn_projectHero_links_id_Delete
+}
+
+type PostsDocAccessFields_layout_sideColumn_projectHero_links_id_Create {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_projectHero_links_id_Read {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_projectHero_links_id_Update {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_projectHero_links_id_Delete {
   permission: Boolean!
 }
 
@@ -4566,461 +5489,125 @@ type PostsDocAccessFields_layout_mainColumn_Delete {
 }
 
 type PostsDocAccessFields_layout_mainColumn_Fields {
-  layoutStyle: PostsDocAccessFields_layout_mainColumn_layoutStyle
-  singleLayout: PostsDocAccessFields_layout_mainColumn_singleLayout
-  twoRows: PostsDocAccessFields_layout_mainColumn_twoRows
-  twoColumns: PostsDocAccessFields_layout_mainColumn_twoColumns
-  threeColumns: PostsDocAccessFields_layout_mainColumn_threeColumns
-  threeSectionGrid: PostsDocAccessFields_layout_mainColumn_threeSectionGrid
+  style: PostsDocAccessFields_layout_mainColumn_style
+  row1column1: PostsDocAccessFields_layout_mainColumn_row1column1
+  row1column2: PostsDocAccessFields_layout_mainColumn_row1column2
+  row2column1: PostsDocAccessFields_layout_mainColumn_row2column1
+  row2column2: PostsDocAccessFields_layout_mainColumn_row2column2
 }
 
-type PostsDocAccessFields_layout_mainColumn_layoutStyle {
-  create: PostsDocAccessFields_layout_mainColumn_layoutStyle_Create
-  read: PostsDocAccessFields_layout_mainColumn_layoutStyle_Read
-  update: PostsDocAccessFields_layout_mainColumn_layoutStyle_Update
-  delete: PostsDocAccessFields_layout_mainColumn_layoutStyle_Delete
+type PostsDocAccessFields_layout_mainColumn_style {
+  create: PostsDocAccessFields_layout_mainColumn_style_Create
+  read: PostsDocAccessFields_layout_mainColumn_style_Read
+  update: PostsDocAccessFields_layout_mainColumn_style_Update
+  delete: PostsDocAccessFields_layout_mainColumn_style_Delete
 }
 
-type PostsDocAccessFields_layout_mainColumn_layoutStyle_Create {
+type PostsDocAccessFields_layout_mainColumn_style_Create {
   permission: Boolean!
 }
 
-type PostsDocAccessFields_layout_mainColumn_layoutStyle_Read {
+type PostsDocAccessFields_layout_mainColumn_style_Read {
   permission: Boolean!
 }
 
-type PostsDocAccessFields_layout_mainColumn_layoutStyle_Update {
+type PostsDocAccessFields_layout_mainColumn_style_Update {
   permission: Boolean!
 }
 
-type PostsDocAccessFields_layout_mainColumn_layoutStyle_Delete {
+type PostsDocAccessFields_layout_mainColumn_style_Delete {
   permission: Boolean!
 }
 
-type PostsDocAccessFields_layout_mainColumn_singleLayout {
-  create: PostsDocAccessFields_layout_mainColumn_singleLayout_Create
-  read: PostsDocAccessFields_layout_mainColumn_singleLayout_Read
-  update: PostsDocAccessFields_layout_mainColumn_singleLayout_Update
-  delete: PostsDocAccessFields_layout_mainColumn_singleLayout_Delete
-  fields: PostsDocAccessFields_layout_mainColumn_singleLayout_Fields
+type PostsDocAccessFields_layout_mainColumn_row1column1 {
+  create: PostsDocAccessFields_layout_mainColumn_row1column1_Create
+  read: PostsDocAccessFields_layout_mainColumn_row1column1_Read
+  update: PostsDocAccessFields_layout_mainColumn_row1column1_Update
+  delete: PostsDocAccessFields_layout_mainColumn_row1column1_Delete
 }
 
-type PostsDocAccessFields_layout_mainColumn_singleLayout_Create {
+type PostsDocAccessFields_layout_mainColumn_row1column1_Create {
   permission: Boolean!
 }
 
-type PostsDocAccessFields_layout_mainColumn_singleLayout_Read {
+type PostsDocAccessFields_layout_mainColumn_row1column1_Read {
   permission: Boolean!
 }
 
-type PostsDocAccessFields_layout_mainColumn_singleLayout_Update {
+type PostsDocAccessFields_layout_mainColumn_row1column1_Update {
   permission: Boolean!
 }
 
-type PostsDocAccessFields_layout_mainColumn_singleLayout_Delete {
+type PostsDocAccessFields_layout_mainColumn_row1column1_Delete {
   permission: Boolean!
 }
 
-type PostsDocAccessFields_layout_mainColumn_singleLayout_Fields {
-  singleLayout1: PostsDocAccessFields_layout_mainColumn_singleLayout_singleLayout1
+type PostsDocAccessFields_layout_mainColumn_row1column2 {
+  create: PostsDocAccessFields_layout_mainColumn_row1column2_Create
+  read: PostsDocAccessFields_layout_mainColumn_row1column2_Read
+  update: PostsDocAccessFields_layout_mainColumn_row1column2_Update
+  delete: PostsDocAccessFields_layout_mainColumn_row1column2_Delete
 }
 
-type PostsDocAccessFields_layout_mainColumn_singleLayout_singleLayout1 {
-  create: PostsDocAccessFields_layout_mainColumn_singleLayout_singleLayout1_Create
-  read: PostsDocAccessFields_layout_mainColumn_singleLayout_singleLayout1_Read
-  update: PostsDocAccessFields_layout_mainColumn_singleLayout_singleLayout1_Update
-  delete: PostsDocAccessFields_layout_mainColumn_singleLayout_singleLayout1_Delete
-}
-
-type PostsDocAccessFields_layout_mainColumn_singleLayout_singleLayout1_Create {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_layout_mainColumn_singleLayout_singleLayout1_Read {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_layout_mainColumn_singleLayout_singleLayout1_Update {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_layout_mainColumn_singleLayout_singleLayout1_Delete {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_layout_mainColumn_twoRows {
-  create: PostsDocAccessFields_layout_mainColumn_twoRows_Create
-  read: PostsDocAccessFields_layout_mainColumn_twoRows_Read
-  update: PostsDocAccessFields_layout_mainColumn_twoRows_Update
-  delete: PostsDocAccessFields_layout_mainColumn_twoRows_Delete
-  fields: PostsDocAccessFields_layout_mainColumn_twoRows_Fields
-}
-
-type PostsDocAccessFields_layout_mainColumn_twoRows_Create {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_layout_mainColumn_twoRows_Read {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_layout_mainColumn_twoRows_Update {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_layout_mainColumn_twoRows_Delete {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_layout_mainColumn_twoRows_Fields {
-  row1: PostsDocAccessFields_layout_mainColumn_twoRows_row1
-  row2: PostsDocAccessFields_layout_mainColumn_twoRows_row2
-}
-
-type PostsDocAccessFields_layout_mainColumn_twoRows_row1 {
-  create: PostsDocAccessFields_layout_mainColumn_twoRows_row1_Create
-  read: PostsDocAccessFields_layout_mainColumn_twoRows_row1_Read
-  update: PostsDocAccessFields_layout_mainColumn_twoRows_row1_Update
-  delete: PostsDocAccessFields_layout_mainColumn_twoRows_row1_Delete
-}
-
-type PostsDocAccessFields_layout_mainColumn_twoRows_row1_Create {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_layout_mainColumn_twoRows_row1_Read {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_layout_mainColumn_twoRows_row1_Update {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_layout_mainColumn_twoRows_row1_Delete {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_layout_mainColumn_twoRows_row2 {
-  create: PostsDocAccessFields_layout_mainColumn_twoRows_row2_Create
-  read: PostsDocAccessFields_layout_mainColumn_twoRows_row2_Read
-  update: PostsDocAccessFields_layout_mainColumn_twoRows_row2_Update
-  delete: PostsDocAccessFields_layout_mainColumn_twoRows_row2_Delete
-}
-
-type PostsDocAccessFields_layout_mainColumn_twoRows_row2_Create {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_layout_mainColumn_twoRows_row2_Read {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_layout_mainColumn_twoRows_row2_Update {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_layout_mainColumn_twoRows_row2_Delete {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_layout_mainColumn_twoColumns {
-  create: PostsDocAccessFields_layout_mainColumn_twoColumns_Create
-  read: PostsDocAccessFields_layout_mainColumn_twoColumns_Read
-  update: PostsDocAccessFields_layout_mainColumn_twoColumns_Update
-  delete: PostsDocAccessFields_layout_mainColumn_twoColumns_Delete
-  fields: PostsDocAccessFields_layout_mainColumn_twoColumns_Fields
-}
-
-type PostsDocAccessFields_layout_mainColumn_twoColumns_Create {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_layout_mainColumn_twoColumns_Read {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_layout_mainColumn_twoColumns_Update {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_layout_mainColumn_twoColumns_Delete {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_layout_mainColumn_twoColumns_Fields {
-  col1: PostsDocAccessFields_layout_mainColumn_twoColumns_col1
-  col2: PostsDocAccessFields_layout_mainColumn_twoColumns_col2
-}
-
-type PostsDocAccessFields_layout_mainColumn_twoColumns_col1 {
-  create: PostsDocAccessFields_layout_mainColumn_twoColumns_col1_Create
-  read: PostsDocAccessFields_layout_mainColumn_twoColumns_col1_Read
-  update: PostsDocAccessFields_layout_mainColumn_twoColumns_col1_Update
-  delete: PostsDocAccessFields_layout_mainColumn_twoColumns_col1_Delete
-}
-
-type PostsDocAccessFields_layout_mainColumn_twoColumns_col1_Create {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_layout_mainColumn_twoColumns_col1_Read {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_layout_mainColumn_twoColumns_col1_Update {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_layout_mainColumn_twoColumns_col1_Delete {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_layout_mainColumn_twoColumns_col2 {
-  create: PostsDocAccessFields_layout_mainColumn_twoColumns_col2_Create
-  read: PostsDocAccessFields_layout_mainColumn_twoColumns_col2_Read
-  update: PostsDocAccessFields_layout_mainColumn_twoColumns_col2_Update
-  delete: PostsDocAccessFields_layout_mainColumn_twoColumns_col2_Delete
-}
-
-type PostsDocAccessFields_layout_mainColumn_twoColumns_col2_Create {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_layout_mainColumn_twoColumns_col2_Read {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_layout_mainColumn_twoColumns_col2_Update {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_layout_mainColumn_twoColumns_col2_Delete {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_layout_mainColumn_threeColumns {
-  create: PostsDocAccessFields_layout_mainColumn_threeColumns_Create
-  read: PostsDocAccessFields_layout_mainColumn_threeColumns_Read
-  update: PostsDocAccessFields_layout_mainColumn_threeColumns_Update
-  delete: PostsDocAccessFields_layout_mainColumn_threeColumns_Delete
-  fields: PostsDocAccessFields_layout_mainColumn_threeColumns_Fields
-}
-
-type PostsDocAccessFields_layout_mainColumn_threeColumns_Create {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_layout_mainColumn_threeColumns_Read {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_layout_mainColumn_threeColumns_Update {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_layout_mainColumn_threeColumns_Delete {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_layout_mainColumn_threeColumns_Fields {
-  col1: PostsDocAccessFields_layout_mainColumn_threeColumns_col1
-  col2: PostsDocAccessFields_layout_mainColumn_threeColumns_col2
-  col3: PostsDocAccessFields_layout_mainColumn_threeColumns_col3
-}
-
-type PostsDocAccessFields_layout_mainColumn_threeColumns_col1 {
-  create: PostsDocAccessFields_layout_mainColumn_threeColumns_col1_Create
-  read: PostsDocAccessFields_layout_mainColumn_threeColumns_col1_Read
-  update: PostsDocAccessFields_layout_mainColumn_threeColumns_col1_Update
-  delete: PostsDocAccessFields_layout_mainColumn_threeColumns_col1_Delete
-}
-
-type PostsDocAccessFields_layout_mainColumn_threeColumns_col1_Create {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_layout_mainColumn_threeColumns_col1_Read {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_layout_mainColumn_threeColumns_col1_Update {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_layout_mainColumn_threeColumns_col1_Delete {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_layout_mainColumn_threeColumns_col2 {
-  create: PostsDocAccessFields_layout_mainColumn_threeColumns_col2_Create
-  read: PostsDocAccessFields_layout_mainColumn_threeColumns_col2_Read
-  update: PostsDocAccessFields_layout_mainColumn_threeColumns_col2_Update
-  delete: PostsDocAccessFields_layout_mainColumn_threeColumns_col2_Delete
-}
-
-type PostsDocAccessFields_layout_mainColumn_threeColumns_col2_Create {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_layout_mainColumn_threeColumns_col2_Read {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_layout_mainColumn_threeColumns_col2_Update {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_layout_mainColumn_threeColumns_col2_Delete {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_layout_mainColumn_threeColumns_col3 {
-  create: PostsDocAccessFields_layout_mainColumn_threeColumns_col3_Create
-  read: PostsDocAccessFields_layout_mainColumn_threeColumns_col3_Read
-  update: PostsDocAccessFields_layout_mainColumn_threeColumns_col3_Update
-  delete: PostsDocAccessFields_layout_mainColumn_threeColumns_col3_Delete
-}
-
-type PostsDocAccessFields_layout_mainColumn_threeColumns_col3_Create {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_layout_mainColumn_threeColumns_col3_Read {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_layout_mainColumn_threeColumns_col3_Update {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_layout_mainColumn_threeColumns_col3_Delete {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_layout_mainColumn_threeSectionGrid {
-  create: PostsDocAccessFields_layout_mainColumn_threeSectionGrid_Create
-  read: PostsDocAccessFields_layout_mainColumn_threeSectionGrid_Read
-  update: PostsDocAccessFields_layout_mainColumn_threeSectionGrid_Update
-  delete: PostsDocAccessFields_layout_mainColumn_threeSectionGrid_Delete
-  fields: PostsDocAccessFields_layout_mainColumn_threeSectionGrid_Fields
-}
-
-type PostsDocAccessFields_layout_mainColumn_threeSectionGrid_Create {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_layout_mainColumn_threeSectionGrid_Read {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_layout_mainColumn_threeSectionGrid_Update {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_layout_mainColumn_threeSectionGrid_Delete {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_layout_mainColumn_threeSectionGrid_Fields {
-  left: PostsDocAccessFields_layout_mainColumn_threeSectionGrid_left
-  right: PostsDocAccessFields_layout_mainColumn_threeSectionGrid_right
-}
-
-type PostsDocAccessFields_layout_mainColumn_threeSectionGrid_left {
-  create: PostsDocAccessFields_layout_mainColumn_threeSectionGrid_left_Create
-  read: PostsDocAccessFields_layout_mainColumn_threeSectionGrid_left_Read
-  update: PostsDocAccessFields_layout_mainColumn_threeSectionGrid_left_Update
-  delete: PostsDocAccessFields_layout_mainColumn_threeSectionGrid_left_Delete
-}
-
-type PostsDocAccessFields_layout_mainColumn_threeSectionGrid_left_Create {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_layout_mainColumn_threeSectionGrid_left_Read {
+type PostsDocAccessFields_layout_mainColumn_row1column2_Create {
   permission: Boolean!
 }
 
-type PostsDocAccessFields_layout_mainColumn_threeSectionGrid_left_Update {
+type PostsDocAccessFields_layout_mainColumn_row1column2_Read {
   permission: Boolean!
 }
 
-type PostsDocAccessFields_layout_mainColumn_threeSectionGrid_left_Delete {
+type PostsDocAccessFields_layout_mainColumn_row1column2_Update {
   permission: Boolean!
 }
 
-type PostsDocAccessFields_layout_mainColumn_threeSectionGrid_right {
-  create: PostsDocAccessFields_layout_mainColumn_threeSectionGrid_right_Create
-  read: PostsDocAccessFields_layout_mainColumn_threeSectionGrid_right_Read
-  update: PostsDocAccessFields_layout_mainColumn_threeSectionGrid_right_Update
-  delete: PostsDocAccessFields_layout_mainColumn_threeSectionGrid_right_Delete
-  fields: PostsDocAccessFields_layout_mainColumn_threeSectionGrid_right_Fields
-}
-
-type PostsDocAccessFields_layout_mainColumn_threeSectionGrid_right_Create {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_layout_mainColumn_threeSectionGrid_right_Read {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_layout_mainColumn_threeSectionGrid_right_Update {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_layout_mainColumn_threeSectionGrid_right_Delete {
+type PostsDocAccessFields_layout_mainColumn_row1column2_Delete {
   permission: Boolean!
-}
-
-type PostsDocAccessFields_layout_mainColumn_threeSectionGrid_right_Fields {
-  rightTop: PostsDocAccessFields_layout_mainColumn_threeSectionGrid_right_rightTop
-  rightBottom: PostsDocAccessFields_layout_mainColumn_threeSectionGrid_right_rightBottom
 }
 
-type PostsDocAccessFields_layout_mainColumn_threeSectionGrid_right_rightTop {
-  create: PostsDocAccessFields_layout_mainColumn_threeSectionGrid_right_rightTop_Create
-  read: PostsDocAccessFields_layout_mainColumn_threeSectionGrid_right_rightTop_Read
-  update: PostsDocAccessFields_layout_mainColumn_threeSectionGrid_right_rightTop_Update
-  delete: PostsDocAccessFields_layout_mainColumn_threeSectionGrid_right_rightTop_Delete
+type PostsDocAccessFields_layout_mainColumn_row2column1 {
+  create: PostsDocAccessFields_layout_mainColumn_row2column1_Create
+  read: PostsDocAccessFields_layout_mainColumn_row2column1_Read
+  update: PostsDocAccessFields_layout_mainColumn_row2column1_Update
+  delete: PostsDocAccessFields_layout_mainColumn_row2column1_Delete
 }
 
-type PostsDocAccessFields_layout_mainColumn_threeSectionGrid_right_rightTop_Create {
+type PostsDocAccessFields_layout_mainColumn_row2column1_Create {
   permission: Boolean!
 }
 
-type PostsDocAccessFields_layout_mainColumn_threeSectionGrid_right_rightTop_Read {
+type PostsDocAccessFields_layout_mainColumn_row2column1_Read {
   permission: Boolean!
 }
 
-type PostsDocAccessFields_layout_mainColumn_threeSectionGrid_right_rightTop_Update {
+type PostsDocAccessFields_layout_mainColumn_row2column1_Update {
   permission: Boolean!
 }
 
-type PostsDocAccessFields_layout_mainColumn_threeSectionGrid_right_rightTop_Delete {
+type PostsDocAccessFields_layout_mainColumn_row2column1_Delete {
   permission: Boolean!
 }
 
-type PostsDocAccessFields_layout_mainColumn_threeSectionGrid_right_rightBottom {
-  create: PostsDocAccessFields_layout_mainColumn_threeSectionGrid_right_rightBottom_Create
-  read: PostsDocAccessFields_layout_mainColumn_threeSectionGrid_right_rightBottom_Read
-  update: PostsDocAccessFields_layout_mainColumn_threeSectionGrid_right_rightBottom_Update
-  delete: PostsDocAccessFields_layout_mainColumn_threeSectionGrid_right_rightBottom_Delete
+type PostsDocAccessFields_layout_mainColumn_row2column2 {
+  create: PostsDocAccessFields_layout_mainColumn_row2column2_Create
+  read: PostsDocAccessFields_layout_mainColumn_row2column2_Read
+  update: PostsDocAccessFields_layout_mainColumn_row2column2_Update
+  delete: PostsDocAccessFields_layout_mainColumn_row2column2_Delete
 }
 
-type PostsDocAccessFields_layout_mainColumn_threeSectionGrid_right_rightBottom_Create {
+type PostsDocAccessFields_layout_mainColumn_row2column2_Create {
   permission: Boolean!
 }
 
-type PostsDocAccessFields_layout_mainColumn_threeSectionGrid_right_rightBottom_Read {
+type PostsDocAccessFields_layout_mainColumn_row2column2_Read {
   permission: Boolean!
 }
 
-type PostsDocAccessFields_layout_mainColumn_threeSectionGrid_right_rightBottom_Update {
+type PostsDocAccessFields_layout_mainColumn_row2column2_Update {
   permission: Boolean!
 }
 
-type PostsDocAccessFields_layout_mainColumn_threeSectionGrid_right_rightBottom_Delete {
+type PostsDocAccessFields_layout_mainColumn_row2column2_Delete {
   permission: Boolean!
 }
 
@@ -5070,29 +5657,6 @@ type PostsDocAccessFields_relatedPosts_Delete {
   permission: Boolean!
 }
 
-type PostsDocAccessFields_slug {
-  create: PostsDocAccessFields_slug_Create
-  read: PostsDocAccessFields_slug_Read
-  update: PostsDocAccessFields_slug_Update
-  delete: PostsDocAccessFields_slug_Delete
-}
-
-type PostsDocAccessFields_slug_Create {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_slug_Read {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_slug_Update {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_slug_Delete {
-  permission: Boolean!
-}
-
 type PostsDocAccessFields_meta {
   create: PostsDocAccessFields_meta_Create
   read: PostsDocAccessFields_meta_Read
@@ -5118,34 +5682,9 @@ type PostsDocAccessFields_meta_Delete {
 }
 
 type PostsDocAccessFields_meta_Fields {
-  overview: PostsDocAccessFields_meta_overview
   title: PostsDocAccessFields_meta_title
   description: PostsDocAccessFields_meta_description
   image: PostsDocAccessFields_meta_image
-  preview: PostsDocAccessFields_meta_preview
-}
-
-type PostsDocAccessFields_meta_overview {
-  create: PostsDocAccessFields_meta_overview_Create
-  read: PostsDocAccessFields_meta_overview_Read
-  update: PostsDocAccessFields_meta_overview_Update
-  delete: PostsDocAccessFields_meta_overview_Delete
-}
-
-type PostsDocAccessFields_meta_overview_Create {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_meta_overview_Read {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_meta_overview_Update {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_meta_overview_Delete {
-  permission: Boolean!
 }
 
 type PostsDocAccessFields_meta_title {
@@ -5214,29 +5753,6 @@ type PostsDocAccessFields_meta_image_Update {
 }
 
 type PostsDocAccessFields_meta_image_Delete {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_meta_preview {
-  create: PostsDocAccessFields_meta_preview_Create
-  read: PostsDocAccessFields_meta_preview_Read
-  update: PostsDocAccessFields_meta_preview_Update
-  delete: PostsDocAccessFields_meta_preview_Delete
-}
-
-type PostsDocAccessFields_meta_preview_Create {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_meta_preview_Read {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_meta_preview_Update {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_meta_preview_Delete {
   permission: Boolean!
 }
 
@@ -5345,15 +5861,16 @@ type PostVersion {
 
 type PostVersion_Version {
   title: String
-  categories: Category
+  description: String
+  category: Category
   keywords: [Keyword!]
+  slug: String
   publishedAt: DateTime
   authors: [User!]
   populatedAuthors: [PostVersion_Version_PopulatedAuthors!]
-  hero: HeroField
+  card: PostVersion_Version_Card
   layout: [Layout!]
   relatedPosts: [Post!]
-  slug: String
   meta: PostVersion_Version_Meta
   updatedAt: DateTime
   createdAt: DateTime
@@ -5363,6 +5880,189 @@ type PostVersion_Version {
 type PostVersion_Version_PopulatedAuthors {
   id: String
   name: String
+}
+
+type PostVersion_Version_Card {
+  media(where: PostVersion_Version_Card_Media_where): Media
+  backgroundColour: String
+  overlayImage: Boolean
+  showDate: Boolean
+}
+
+input PostVersion_Version_Card_Media_where {
+  alt: PostVersion_Version_Card_Media_alt_operator
+  caption: PostVersion_Version_Card_Media_caption_operator
+  blurhash: PostVersion_Version_Card_Media_blurhash_operator
+  updatedAt: PostVersion_Version_Card_Media_updatedAt_operator
+  createdAt: PostVersion_Version_Card_Media_createdAt_operator
+  url: PostVersion_Version_Card_Media_url_operator
+  filename: PostVersion_Version_Card_Media_filename_operator
+  mimeType: PostVersion_Version_Card_Media_mimeType_operator
+  filesize: PostVersion_Version_Card_Media_filesize_operator
+  width: PostVersion_Version_Card_Media_width_operator
+  height: PostVersion_Version_Card_Media_height_operator
+  id: PostVersion_Version_Card_Media_id_operator
+  AND: [PostVersion_Version_Card_Media_where_and]
+  OR: [PostVersion_Version_Card_Media_where_or]
+}
+
+input PostVersion_Version_Card_Media_alt_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+}
+
+input PostVersion_Version_Card_Media_caption_operator {
+  equals: JSON
+  not_equals: JSON
+  like: JSON
+  contains: JSON
+  exists: Boolean
+}
+
+input PostVersion_Version_Card_Media_blurhash_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input PostVersion_Version_Card_Media_updatedAt_operator {
+  equals: DateTime
+  not_equals: DateTime
+  greater_than_equal: DateTime
+  greater_than: DateTime
+  less_than_equal: DateTime
+  less_than: DateTime
+  like: DateTime
+  exists: Boolean
+}
+
+input PostVersion_Version_Card_Media_createdAt_operator {
+  equals: DateTime
+  not_equals: DateTime
+  greater_than_equal: DateTime
+  greater_than: DateTime
+  less_than_equal: DateTime
+  less_than: DateTime
+  like: DateTime
+  exists: Boolean
+}
+
+input PostVersion_Version_Card_Media_url_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input PostVersion_Version_Card_Media_filename_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input PostVersion_Version_Card_Media_mimeType_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input PostVersion_Version_Card_Media_filesize_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input PostVersion_Version_Card_Media_width_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input PostVersion_Version_Card_Media_height_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input PostVersion_Version_Card_Media_id_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input PostVersion_Version_Card_Media_where_and {
+  alt: PostVersion_Version_Card_Media_alt_operator
+  caption: PostVersion_Version_Card_Media_caption_operator
+  blurhash: PostVersion_Version_Card_Media_blurhash_operator
+  updatedAt: PostVersion_Version_Card_Media_updatedAt_operator
+  createdAt: PostVersion_Version_Card_Media_createdAt_operator
+  url: PostVersion_Version_Card_Media_url_operator
+  filename: PostVersion_Version_Card_Media_filename_operator
+  mimeType: PostVersion_Version_Card_Media_mimeType_operator
+  filesize: PostVersion_Version_Card_Media_filesize_operator
+  width: PostVersion_Version_Card_Media_width_operator
+  height: PostVersion_Version_Card_Media_height_operator
+  id: PostVersion_Version_Card_Media_id_operator
+  AND: [PostVersion_Version_Card_Media_where_and]
+  OR: [PostVersion_Version_Card_Media_where_or]
+}
+
+input PostVersion_Version_Card_Media_where_or {
+  alt: PostVersion_Version_Card_Media_alt_operator
+  caption: PostVersion_Version_Card_Media_caption_operator
+  blurhash: PostVersion_Version_Card_Media_blurhash_operator
+  updatedAt: PostVersion_Version_Card_Media_updatedAt_operator
+  createdAt: PostVersion_Version_Card_Media_createdAt_operator
+  url: PostVersion_Version_Card_Media_url_operator
+  filename: PostVersion_Version_Card_Media_filename_operator
+  mimeType: PostVersion_Version_Card_Media_mimeType_operator
+  filesize: PostVersion_Version_Card_Media_filesize_operator
+  width: PostVersion_Version_Card_Media_width_operator
+  height: PostVersion_Version_Card_Media_height_operator
+  id: PostVersion_Version_Card_Media_id_operator
+  AND: [PostVersion_Version_Card_Media_where_and]
+  OR: [PostVersion_Version_Card_Media_where_or]
 }
 
 type PostVersion_Version_Meta {
@@ -5569,42 +6269,49 @@ type versionsPosts {
 input versionsPost_where {
   parent: versionsPost_parent_operator
   version__title: versionsPost_version__title_operator
-  version__categories: versionsPost_version__categories_operator
+  version__description: versionsPost_version__description_operator
+  version__category: versionsPost_version__category_operator
   version__keywords: versionsPost_version__keywords_operator
+  version__slug: versionsPost_version__slug_operator
   version__publishedAt: versionsPost_version__publishedAt_operator
   version__authors: versionsPost_version__authors_operator
   version__populatedAuthors__id: versionsPost_version__populatedAuthors__id_operator
   version__populatedAuthors__name: versionsPost_version__populatedAuthors__name_operator
-  version__hero__type: versionsPost_version__hero__type_operator
-  version__hero__description: versionsPost_version__hero__description_operator
-  version__hero__links__link__type: versionsPost_version__hero__links__link__type_operator
-  version__hero__links__link__newTab: versionsPost_version__hero__links__link__newTab_operator
-  version__hero__links__link__reference: versionsPost_version__hero__links__link__reference_Relation
-  version__hero__links__link__url: versionsPost_version__hero__links__link__url_operator
-  version__hero__links__link__label: versionsPost_version__hero__links__link__label_operator
-  version__hero__links__link__appearance: versionsPost_version__hero__links__link__appearance_operator
-  version__hero__links__id: versionsPost_version__hero__links__id_operator
-  version__layout__fixedSideContent: versionsPost_version__layout__fixedSideContent_operator
+  version__card__media: versionsPost_version__card__media_operator
+  version__card__backgroundColour: versionsPost_version__card__backgroundColour_operator
+  version__card__overlayImage: versionsPost_version__card__overlayImage_operator
+  version__card__showDate: versionsPost_version__card__showDate_operator
+  version__layout__sideContentPosition: versionsPost_version__layout__sideContentPosition_operator
   version__layout__scrollSnap: versionsPost_version__layout__scrollSnap_operator
   version__layout__fullPageHeight: versionsPost_version__layout__fullPageHeight_operator
-  version__layout__sideColumn__sideStyle: versionsPost_version__layout__sideColumn__sideStyle_operator
+  version__layout__sideColumn__style: versionsPost_version__layout__sideColumn__style_operator
+  version__layout__sideColumn__hero__media: versionsPost_version__layout__sideColumn__hero__media_operator
+  version__layout__sideColumn__hero__description: versionsPost_version__layout__sideColumn__hero__description_operator
+  version__layout__sideColumn__hero__links__link__type: versionsPost_version__layout__sideColumn__hero__links__link__type_operator
+  version__layout__sideColumn__hero__links__link__newTab: versionsPost_version__layout__sideColumn__hero__links__link__newTab_operator
+  version__layout__sideColumn__hero__links__link__reference: versionsPost_version__layout__sideColumn__hero__links__link__reference_Relation
+  version__layout__sideColumn__hero__links__link__url: versionsPost_version__layout__sideColumn__hero__links__link__url_operator
+  version__layout__sideColumn__hero__links__link__label: versionsPost_version__layout__sideColumn__hero__links__link__label_operator
+  version__layout__sideColumn__hero__links__link__appearance: versionsPost_version__layout__sideColumn__hero__links__link__appearance_operator
+  version__layout__sideColumn__hero__links__id: versionsPost_version__layout__sideColumn__hero__links__id_operator
+  version__layout__sideColumn__projectHero__year: versionsPost_version__layout__sideColumn__projectHero__year_operator
+  version__layout__sideColumn__projectHero__client: versionsPost_version__layout__sideColumn__projectHero__client_operator
+  version__layout__sideColumn__projectHero__links__link__type: versionsPost_version__layout__sideColumn__projectHero__links__link__type_operator
+  version__layout__sideColumn__projectHero__links__link__newTab: versionsPost_version__layout__sideColumn__projectHero__links__link__newTab_operator
+  version__layout__sideColumn__projectHero__links__link__reference: versionsPost_version__layout__sideColumn__projectHero__links__link__reference_Relation
+  version__layout__sideColumn__projectHero__links__link__url: versionsPost_version__layout__sideColumn__projectHero__links__link__url_operator
+  version__layout__sideColumn__projectHero__links__link__label: versionsPost_version__layout__sideColumn__projectHero__links__link__label_operator
+  version__layout__sideColumn__projectHero__links__link__appearance: versionsPost_version__layout__sideColumn__projectHero__links__link__appearance_operator
+  version__layout__sideColumn__projectHero__links__id: versionsPost_version__layout__sideColumn__projectHero__links__id_operator
   version__layout__sideColumn__sideContent1: versionsPost_version__layout__sideColumn__sideContent1_operator
   version__layout__sideColumn__sideContent2: versionsPost_version__layout__sideColumn__sideContent2_operator
-  version__layout__mainColumn__layoutStyle: versionsPost_version__layout__mainColumn__layoutStyle_operator
-  version__layout__mainColumn__singleLayout__singleLayout1: versionsPost_version__layout__mainColumn__singleLayout__singleLayout1_operator
-  version__layout__mainColumn__twoRows__row1: versionsPost_version__layout__mainColumn__twoRows__row1_operator
-  version__layout__mainColumn__twoRows__row2: versionsPost_version__layout__mainColumn__twoRows__row2_operator
-  version__layout__mainColumn__twoColumns__col1: versionsPost_version__layout__mainColumn__twoColumns__col1_operator
-  version__layout__mainColumn__twoColumns__col2: versionsPost_version__layout__mainColumn__twoColumns__col2_operator
-  version__layout__mainColumn__threeColumns__col1: versionsPost_version__layout__mainColumn__threeColumns__col1_operator
-  version__layout__mainColumn__threeColumns__col2: versionsPost_version__layout__mainColumn__threeColumns__col2_operator
-  version__layout__mainColumn__threeColumns__col3: versionsPost_version__layout__mainColumn__threeColumns__col3_operator
-  version__layout__mainColumn__threeSectionGrid__left: versionsPost_version__layout__mainColumn__threeSectionGrid__left_operator
-  version__layout__mainColumn__threeSectionGrid__right__rightTop: versionsPost_version__layout__mainColumn__threeSectionGrid__right__rightTop_operator
-  version__layout__mainColumn__threeSectionGrid__right__rightBottom: versionsPost_version__layout__mainColumn__threeSectionGrid__right__rightBottom_operator
+  version__layout__mainColumn__style: versionsPost_version__layout__mainColumn__style_operator
+  version__layout__mainColumn__row1column1: versionsPost_version__layout__mainColumn__row1column1_operator
+  version__layout__mainColumn__row1column2: versionsPost_version__layout__mainColumn__row1column2_operator
+  version__layout__mainColumn__row2column1: versionsPost_version__layout__mainColumn__row2column1_operator
+  version__layout__mainColumn__row2column2: versionsPost_version__layout__mainColumn__row2column2_operator
   version__layout__id: versionsPost_version__layout__id_operator
   version__relatedPosts: versionsPost_version__relatedPosts_operator
-  version__slug: versionsPost_version__slug_operator
   version__meta__title: versionsPost_version__meta__title_operator
   version__meta__description: versionsPost_version__meta__description_operator
   version__meta__image: versionsPost_version__meta__image_operator
@@ -5638,7 +6345,17 @@ input versionsPost_version__title_operator {
   all: [String]
 }
 
-input versionsPost_version__categories_operator {
+input versionsPost_version__description_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+}
+
+input versionsPost_version__category_operator {
   equals: JSON
   not_equals: JSON
   in: [JSON]
@@ -5652,6 +6369,17 @@ input versionsPost_version__keywords_operator {
   in: [JSON]
   not_in: [JSON]
   all: [JSON]
+  exists: Boolean
+}
+
+input versionsPost_version__slug_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
   exists: Boolean
 }
 
@@ -5697,107 +6425,47 @@ input versionsPost_version__populatedAuthors__name_operator {
   exists: Boolean
 }
 
-input versionsPost_version__hero__type_operator {
-  equals: versionsPost_version__hero__type_Input
-  not_equals: versionsPost_version__hero__type_Input
-  in: [versionsPost_version__hero__type_Input]
-  not_in: [versionsPost_version__hero__type_Input]
-  all: [versionsPost_version__hero__type_Input]
-}
-
-enum versionsPost_version__hero__type_Input {
-  none
-  fixedSidePanel
-  halfPage
-  fullPage
-}
-
-input versionsPost_version__hero__description_operator {
-  equals: JSON
-  not_equals: JSON
-  like: JSON
-  contains: JSON
+input versionsPost_version__card__media_operator {
+  equals: String
+  not_equals: String
   exists: Boolean
 }
 
-input versionsPost_version__hero__links__link__type_operator {
-  equals: versionsPost_version__hero__links__link__type_Input
-  not_equals: versionsPost_version__hero__links__link__type_Input
-  like: versionsPost_version__hero__links__link__type_Input
-  contains: versionsPost_version__hero__links__link__type_Input
+input versionsPost_version__card__backgroundColour_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
   exists: Boolean
 }
 
-enum versionsPost_version__hero__links__link__type_Input {
-  reference
-  custom
-}
-
-input versionsPost_version__hero__links__link__newTab_operator {
+input versionsPost_version__card__overlayImage_operator {
   equals: Boolean
   not_equals: Boolean
   exists: Boolean
 }
 
-input versionsPost_version__hero__links__link__reference_Relation {
-  relationTo: versionsPost_version__hero__links__link__reference_Relation_RelationTo
-  value: JSON
-}
-
-enum versionsPost_version__hero__links__link__reference_Relation_RelationTo {
-  pages
-}
-
-input versionsPost_version__hero__links__link__url_operator {
-  equals: String
-  not_equals: String
-  like: String
-  contains: String
-  in: [String]
-  not_in: [String]
-  all: [String]
-}
-
-input versionsPost_version__hero__links__link__label_operator {
-  equals: String
-  not_equals: String
-  like: String
-  contains: String
-  in: [String]
-  not_in: [String]
-  all: [String]
-}
-
-input versionsPost_version__hero__links__link__appearance_operator {
-  equals: versionsPost_version__hero__links__link__appearance_Input
-  not_equals: versionsPost_version__hero__links__link__appearance_Input
-  in: [versionsPost_version__hero__links__link__appearance_Input]
-  not_in: [versionsPost_version__hero__links__link__appearance_Input]
-  all: [versionsPost_version__hero__links__link__appearance_Input]
-  exists: Boolean
-}
-
-enum versionsPost_version__hero__links__link__appearance_Input {
-  default
-  primary
-  secondary
-}
-
-input versionsPost_version__hero__links__id_operator {
-  equals: String
-  not_equals: String
-  like: String
-  contains: String
-  in: [String]
-  not_in: [String]
-  all: [String]
-  exists: Boolean
-}
-
-input versionsPost_version__layout__fixedSideContent_operator {
+input versionsPost_version__card__showDate_operator {
   equals: Boolean
   not_equals: Boolean
   exists: Boolean
+}
+
+input versionsPost_version__layout__sideContentPosition_operator {
+  equals: versionsPost_version__layout__sideContentPosition_Input
+  not_equals: versionsPost_version__layout__sideContentPosition_Input
+  in: [versionsPost_version__layout__sideContentPosition_Input]
+  not_in: [versionsPost_version__layout__sideContentPosition_Input]
+  all: [versionsPost_version__layout__sideContentPosition_Input]
+}
+
+enum versionsPost_version__layout__sideContentPosition_Input {
+  scrollSideContent
+  fixedSideContentWhenVisible
+  fixedSideContentAlways
 }
 
 input versionsPost_version__layout__scrollSnap_operator {
@@ -5812,18 +6480,202 @@ input versionsPost_version__layout__fullPageHeight_operator {
   exists: Boolean
 }
 
-input versionsPost_version__layout__sideColumn__sideStyle_operator {
-  equals: versionsPost_version__layout__sideColumn__sideStyle_Input
-  not_equals: versionsPost_version__layout__sideColumn__sideStyle_Input
-  in: [versionsPost_version__layout__sideColumn__sideStyle_Input]
-  not_in: [versionsPost_version__layout__sideColumn__sideStyle_Input]
-  all: [versionsPost_version__layout__sideColumn__sideStyle_Input]
+input versionsPost_version__layout__sideColumn__style_operator {
+  equals: versionsPost_version__layout__sideColumn__style_Input
+  not_equals: versionsPost_version__layout__sideColumn__style_Input
+  in: [versionsPost_version__layout__sideColumn__style_Input]
+  not_in: [versionsPost_version__layout__sideColumn__style_Input]
+  all: [versionsPost_version__layout__sideColumn__style_Input]
 }
 
-enum versionsPost_version__layout__sideColumn__sideStyle_Input {
+enum versionsPost_version__layout__sideColumn__style_Input {
   none
+  hero
+  postHero
+  projectHero
   singleLayout
   twoRows
+}
+
+input versionsPost_version__layout__sideColumn__hero__media_operator {
+  equals: String
+  not_equals: String
+  exists: Boolean
+}
+
+input versionsPost_version__layout__sideColumn__hero__description_operator {
+  equals: JSON
+  not_equals: JSON
+  like: JSON
+  contains: JSON
+  exists: Boolean
+}
+
+input versionsPost_version__layout__sideColumn__hero__links__link__type_operator {
+  equals: versionsPost_version__layout__sideColumn__hero__links__link__type_Input
+  not_equals: versionsPost_version__layout__sideColumn__hero__links__link__type_Input
+  like: versionsPost_version__layout__sideColumn__hero__links__link__type_Input
+  contains: versionsPost_version__layout__sideColumn__hero__links__link__type_Input
+  exists: Boolean
+}
+
+enum versionsPost_version__layout__sideColumn__hero__links__link__type_Input {
+  reference
+  custom
+}
+
+input versionsPost_version__layout__sideColumn__hero__links__link__newTab_operator {
+  equals: Boolean
+  not_equals: Boolean
+  exists: Boolean
+}
+
+input versionsPost_version__layout__sideColumn__hero__links__link__reference_Relation {
+  relationTo: versionsPost_version__layout__sideColumn__hero__links__link__reference_Relation_RelationTo
+  value: JSON
+}
+
+enum versionsPost_version__layout__sideColumn__hero__links__link__reference_Relation_RelationTo {
+  pages
+}
+
+input versionsPost_version__layout__sideColumn__hero__links__link__url_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+}
+
+input versionsPost_version__layout__sideColumn__hero__links__link__label_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+}
+
+input versionsPost_version__layout__sideColumn__hero__links__link__appearance_operator {
+  equals: versionsPost_version__layout__sideColumn__hero__links__link__appearance_Input
+  not_equals: versionsPost_version__layout__sideColumn__hero__links__link__appearance_Input
+  in: [versionsPost_version__layout__sideColumn__hero__links__link__appearance_Input]
+  not_in: [versionsPost_version__layout__sideColumn__hero__links__link__appearance_Input]
+  all: [versionsPost_version__layout__sideColumn__hero__links__link__appearance_Input]
+  exists: Boolean
+}
+
+enum versionsPost_version__layout__sideColumn__hero__links__link__appearance_Input {
+  default
+  primary
+  secondary
+}
+
+input versionsPost_version__layout__sideColumn__hero__links__id_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input versionsPost_version__layout__sideColumn__projectHero__year_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input versionsPost_version__layout__sideColumn__projectHero__client_operator {
+  equals: JSON
+  not_equals: JSON
+  in: [JSON]
+  not_in: [JSON]
+  all: [JSON]
+  exists: Boolean
+}
+
+input versionsPost_version__layout__sideColumn__projectHero__links__link__type_operator {
+  equals: versionsPost_version__layout__sideColumn__projectHero__links__link__type_Input
+  not_equals: versionsPost_version__layout__sideColumn__projectHero__links__link__type_Input
+  like: versionsPost_version__layout__sideColumn__projectHero__links__link__type_Input
+  contains: versionsPost_version__layout__sideColumn__projectHero__links__link__type_Input
+  exists: Boolean
+}
+
+enum versionsPost_version__layout__sideColumn__projectHero__links__link__type_Input {
+  reference
+  custom
+}
+
+input versionsPost_version__layout__sideColumn__projectHero__links__link__newTab_operator {
+  equals: Boolean
+  not_equals: Boolean
+  exists: Boolean
+}
+
+input versionsPost_version__layout__sideColumn__projectHero__links__link__reference_Relation {
+  relationTo: versionsPost_version__layout__sideColumn__projectHero__links__link__reference_Relation_RelationTo
+  value: JSON
+}
+
+enum versionsPost_version__layout__sideColumn__projectHero__links__link__reference_Relation_RelationTo {
+  pages
+}
+
+input versionsPost_version__layout__sideColumn__projectHero__links__link__url_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+}
+
+input versionsPost_version__layout__sideColumn__projectHero__links__link__label_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+}
+
+input versionsPost_version__layout__sideColumn__projectHero__links__link__appearance_operator {
+  equals: versionsPost_version__layout__sideColumn__projectHero__links__link__appearance_Input
+  not_equals: versionsPost_version__layout__sideColumn__projectHero__links__link__appearance_Input
+  in: [versionsPost_version__layout__sideColumn__projectHero__links__link__appearance_Input]
+  not_in: [versionsPost_version__layout__sideColumn__projectHero__links__link__appearance_Input]
+  all: [versionsPost_version__layout__sideColumn__projectHero__links__link__appearance_Input]
+  exists: Boolean
+}
+
+enum versionsPost_version__layout__sideColumn__projectHero__links__link__appearance_Input {
+  default
+  primary
+  secondary
+}
+
+input versionsPost_version__layout__sideColumn__projectHero__links__id_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
 }
 
 input versionsPost_version__layout__sideColumn__sideContent1_operator {
@@ -5842,22 +6694,22 @@ input versionsPost_version__layout__sideColumn__sideContent2_operator {
   exists: Boolean
 }
 
-input versionsPost_version__layout__mainColumn__layoutStyle_operator {
-  equals: versionsPost_version__layout__mainColumn__layoutStyle_Input
-  not_equals: versionsPost_version__layout__mainColumn__layoutStyle_Input
-  in: [versionsPost_version__layout__mainColumn__layoutStyle_Input]
-  not_in: [versionsPost_version__layout__mainColumn__layoutStyle_Input]
-  all: [versionsPost_version__layout__mainColumn__layoutStyle_Input]
+input versionsPost_version__layout__mainColumn__style_operator {
+  equals: versionsPost_version__layout__mainColumn__style_Input
+  not_equals: versionsPost_version__layout__mainColumn__style_Input
+  in: [versionsPost_version__layout__mainColumn__style_Input]
+  not_in: [versionsPost_version__layout__mainColumn__style_Input]
+  all: [versionsPost_version__layout__mainColumn__style_Input]
 }
 
-enum versionsPost_version__layout__mainColumn__layoutStyle_Input {
+enum versionsPost_version__layout__mainColumn__style_Input {
   singleLayout
   twoRows
   twoColumns
   threeSectionGrid
 }
 
-input versionsPost_version__layout__mainColumn__singleLayout__singleLayout1_operator {
+input versionsPost_version__layout__mainColumn__row1column1_operator {
   equals: JSON
   not_equals: JSON
   like: JSON
@@ -5865,7 +6717,7 @@ input versionsPost_version__layout__mainColumn__singleLayout__singleLayout1_oper
   exists: Boolean
 }
 
-input versionsPost_version__layout__mainColumn__twoRows__row1_operator {
+input versionsPost_version__layout__mainColumn__row1column2_operator {
   equals: JSON
   not_equals: JSON
   like: JSON
@@ -5873,7 +6725,7 @@ input versionsPost_version__layout__mainColumn__twoRows__row1_operator {
   exists: Boolean
 }
 
-input versionsPost_version__layout__mainColumn__twoRows__row2_operator {
+input versionsPost_version__layout__mainColumn__row2column1_operator {
   equals: JSON
   not_equals: JSON
   like: JSON
@@ -5881,63 +6733,7 @@ input versionsPost_version__layout__mainColumn__twoRows__row2_operator {
   exists: Boolean
 }
 
-input versionsPost_version__layout__mainColumn__twoColumns__col1_operator {
-  equals: JSON
-  not_equals: JSON
-  like: JSON
-  contains: JSON
-  exists: Boolean
-}
-
-input versionsPost_version__layout__mainColumn__twoColumns__col2_operator {
-  equals: JSON
-  not_equals: JSON
-  like: JSON
-  contains: JSON
-  exists: Boolean
-}
-
-input versionsPost_version__layout__mainColumn__threeColumns__col1_operator {
-  equals: JSON
-  not_equals: JSON
-  like: JSON
-  contains: JSON
-  exists: Boolean
-}
-
-input versionsPost_version__layout__mainColumn__threeColumns__col2_operator {
-  equals: JSON
-  not_equals: JSON
-  like: JSON
-  contains: JSON
-  exists: Boolean
-}
-
-input versionsPost_version__layout__mainColumn__threeColumns__col3_operator {
-  equals: JSON
-  not_equals: JSON
-  like: JSON
-  contains: JSON
-  exists: Boolean
-}
-
-input versionsPost_version__layout__mainColumn__threeSectionGrid__left_operator {
-  equals: JSON
-  not_equals: JSON
-  like: JSON
-  contains: JSON
-  exists: Boolean
-}
-
-input versionsPost_version__layout__mainColumn__threeSectionGrid__right__rightTop_operator {
-  equals: JSON
-  not_equals: JSON
-  like: JSON
-  contains: JSON
-  exists: Boolean
-}
-
-input versionsPost_version__layout__mainColumn__threeSectionGrid__right__rightBottom_operator {
+input versionsPost_version__layout__mainColumn__row2column2_operator {
   equals: JSON
   not_equals: JSON
   like: JSON
@@ -5962,17 +6758,6 @@ input versionsPost_version__relatedPosts_operator {
   in: [JSON]
   not_in: [JSON]
   all: [JSON]
-  exists: Boolean
-}
-
-input versionsPost_version__slug_operator {
-  equals: String
-  not_equals: String
-  like: String
-  contains: String
-  in: [String]
-  not_in: [String]
-  all: [String]
   exists: Boolean
 }
 
@@ -6078,42 +6863,49 @@ input versionsPost_id_operator {
 input versionsPost_where_and {
   parent: versionsPost_parent_operator
   version__title: versionsPost_version__title_operator
-  version__categories: versionsPost_version__categories_operator
+  version__description: versionsPost_version__description_operator
+  version__category: versionsPost_version__category_operator
   version__keywords: versionsPost_version__keywords_operator
+  version__slug: versionsPost_version__slug_operator
   version__publishedAt: versionsPost_version__publishedAt_operator
   version__authors: versionsPost_version__authors_operator
   version__populatedAuthors__id: versionsPost_version__populatedAuthors__id_operator
   version__populatedAuthors__name: versionsPost_version__populatedAuthors__name_operator
-  version__hero__type: versionsPost_version__hero__type_operator
-  version__hero__description: versionsPost_version__hero__description_operator
-  version__hero__links__link__type: versionsPost_version__hero__links__link__type_operator
-  version__hero__links__link__newTab: versionsPost_version__hero__links__link__newTab_operator
-  version__hero__links__link__reference: versionsPost_version__hero__links__link__reference_Relation
-  version__hero__links__link__url: versionsPost_version__hero__links__link__url_operator
-  version__hero__links__link__label: versionsPost_version__hero__links__link__label_operator
-  version__hero__links__link__appearance: versionsPost_version__hero__links__link__appearance_operator
-  version__hero__links__id: versionsPost_version__hero__links__id_operator
-  version__layout__fixedSideContent: versionsPost_version__layout__fixedSideContent_operator
+  version__card__media: versionsPost_version__card__media_operator
+  version__card__backgroundColour: versionsPost_version__card__backgroundColour_operator
+  version__card__overlayImage: versionsPost_version__card__overlayImage_operator
+  version__card__showDate: versionsPost_version__card__showDate_operator
+  version__layout__sideContentPosition: versionsPost_version__layout__sideContentPosition_operator
   version__layout__scrollSnap: versionsPost_version__layout__scrollSnap_operator
   version__layout__fullPageHeight: versionsPost_version__layout__fullPageHeight_operator
-  version__layout__sideColumn__sideStyle: versionsPost_version__layout__sideColumn__sideStyle_operator
+  version__layout__sideColumn__style: versionsPost_version__layout__sideColumn__style_operator
+  version__layout__sideColumn__hero__media: versionsPost_version__layout__sideColumn__hero__media_operator
+  version__layout__sideColumn__hero__description: versionsPost_version__layout__sideColumn__hero__description_operator
+  version__layout__sideColumn__hero__links__link__type: versionsPost_version__layout__sideColumn__hero__links__link__type_operator
+  version__layout__sideColumn__hero__links__link__newTab: versionsPost_version__layout__sideColumn__hero__links__link__newTab_operator
+  version__layout__sideColumn__hero__links__link__reference: versionsPost_version__layout__sideColumn__hero__links__link__reference_Relation
+  version__layout__sideColumn__hero__links__link__url: versionsPost_version__layout__sideColumn__hero__links__link__url_operator
+  version__layout__sideColumn__hero__links__link__label: versionsPost_version__layout__sideColumn__hero__links__link__label_operator
+  version__layout__sideColumn__hero__links__link__appearance: versionsPost_version__layout__sideColumn__hero__links__link__appearance_operator
+  version__layout__sideColumn__hero__links__id: versionsPost_version__layout__sideColumn__hero__links__id_operator
+  version__layout__sideColumn__projectHero__year: versionsPost_version__layout__sideColumn__projectHero__year_operator
+  version__layout__sideColumn__projectHero__client: versionsPost_version__layout__sideColumn__projectHero__client_operator
+  version__layout__sideColumn__projectHero__links__link__type: versionsPost_version__layout__sideColumn__projectHero__links__link__type_operator
+  version__layout__sideColumn__projectHero__links__link__newTab: versionsPost_version__layout__sideColumn__projectHero__links__link__newTab_operator
+  version__layout__sideColumn__projectHero__links__link__reference: versionsPost_version__layout__sideColumn__projectHero__links__link__reference_Relation
+  version__layout__sideColumn__projectHero__links__link__url: versionsPost_version__layout__sideColumn__projectHero__links__link__url_operator
+  version__layout__sideColumn__projectHero__links__link__label: versionsPost_version__layout__sideColumn__projectHero__links__link__label_operator
+  version__layout__sideColumn__projectHero__links__link__appearance: versionsPost_version__layout__sideColumn__projectHero__links__link__appearance_operator
+  version__layout__sideColumn__projectHero__links__id: versionsPost_version__layout__sideColumn__projectHero__links__id_operator
   version__layout__sideColumn__sideContent1: versionsPost_version__layout__sideColumn__sideContent1_operator
   version__layout__sideColumn__sideContent2: versionsPost_version__layout__sideColumn__sideContent2_operator
-  version__layout__mainColumn__layoutStyle: versionsPost_version__layout__mainColumn__layoutStyle_operator
-  version__layout__mainColumn__singleLayout__singleLayout1: versionsPost_version__layout__mainColumn__singleLayout__singleLayout1_operator
-  version__layout__mainColumn__twoRows__row1: versionsPost_version__layout__mainColumn__twoRows__row1_operator
-  version__layout__mainColumn__twoRows__row2: versionsPost_version__layout__mainColumn__twoRows__row2_operator
-  version__layout__mainColumn__twoColumns__col1: versionsPost_version__layout__mainColumn__twoColumns__col1_operator
-  version__layout__mainColumn__twoColumns__col2: versionsPost_version__layout__mainColumn__twoColumns__col2_operator
-  version__layout__mainColumn__threeColumns__col1: versionsPost_version__layout__mainColumn__threeColumns__col1_operator
-  version__layout__mainColumn__threeColumns__col2: versionsPost_version__layout__mainColumn__threeColumns__col2_operator
-  version__layout__mainColumn__threeColumns__col3: versionsPost_version__layout__mainColumn__threeColumns__col3_operator
-  version__layout__mainColumn__threeSectionGrid__left: versionsPost_version__layout__mainColumn__threeSectionGrid__left_operator
-  version__layout__mainColumn__threeSectionGrid__right__rightTop: versionsPost_version__layout__mainColumn__threeSectionGrid__right__rightTop_operator
-  version__layout__mainColumn__threeSectionGrid__right__rightBottom: versionsPost_version__layout__mainColumn__threeSectionGrid__right__rightBottom_operator
+  version__layout__mainColumn__style: versionsPost_version__layout__mainColumn__style_operator
+  version__layout__mainColumn__row1column1: versionsPost_version__layout__mainColumn__row1column1_operator
+  version__layout__mainColumn__row1column2: versionsPost_version__layout__mainColumn__row1column2_operator
+  version__layout__mainColumn__row2column1: versionsPost_version__layout__mainColumn__row2column1_operator
+  version__layout__mainColumn__row2column2: versionsPost_version__layout__mainColumn__row2column2_operator
   version__layout__id: versionsPost_version__layout__id_operator
   version__relatedPosts: versionsPost_version__relatedPosts_operator
-  version__slug: versionsPost_version__slug_operator
   version__meta__title: versionsPost_version__meta__title_operator
   version__meta__description: versionsPost_version__meta__description_operator
   version__meta__image: versionsPost_version__meta__image_operator
@@ -6131,42 +6923,49 @@ input versionsPost_where_and {
 input versionsPost_where_or {
   parent: versionsPost_parent_operator
   version__title: versionsPost_version__title_operator
-  version__categories: versionsPost_version__categories_operator
+  version__description: versionsPost_version__description_operator
+  version__category: versionsPost_version__category_operator
   version__keywords: versionsPost_version__keywords_operator
+  version__slug: versionsPost_version__slug_operator
   version__publishedAt: versionsPost_version__publishedAt_operator
   version__authors: versionsPost_version__authors_operator
   version__populatedAuthors__id: versionsPost_version__populatedAuthors__id_operator
   version__populatedAuthors__name: versionsPost_version__populatedAuthors__name_operator
-  version__hero__type: versionsPost_version__hero__type_operator
-  version__hero__description: versionsPost_version__hero__description_operator
-  version__hero__links__link__type: versionsPost_version__hero__links__link__type_operator
-  version__hero__links__link__newTab: versionsPost_version__hero__links__link__newTab_operator
-  version__hero__links__link__reference: versionsPost_version__hero__links__link__reference_Relation
-  version__hero__links__link__url: versionsPost_version__hero__links__link__url_operator
-  version__hero__links__link__label: versionsPost_version__hero__links__link__label_operator
-  version__hero__links__link__appearance: versionsPost_version__hero__links__link__appearance_operator
-  version__hero__links__id: versionsPost_version__hero__links__id_operator
-  version__layout__fixedSideContent: versionsPost_version__layout__fixedSideContent_operator
+  version__card__media: versionsPost_version__card__media_operator
+  version__card__backgroundColour: versionsPost_version__card__backgroundColour_operator
+  version__card__overlayImage: versionsPost_version__card__overlayImage_operator
+  version__card__showDate: versionsPost_version__card__showDate_operator
+  version__layout__sideContentPosition: versionsPost_version__layout__sideContentPosition_operator
   version__layout__scrollSnap: versionsPost_version__layout__scrollSnap_operator
   version__layout__fullPageHeight: versionsPost_version__layout__fullPageHeight_operator
-  version__layout__sideColumn__sideStyle: versionsPost_version__layout__sideColumn__sideStyle_operator
+  version__layout__sideColumn__style: versionsPost_version__layout__sideColumn__style_operator
+  version__layout__sideColumn__hero__media: versionsPost_version__layout__sideColumn__hero__media_operator
+  version__layout__sideColumn__hero__description: versionsPost_version__layout__sideColumn__hero__description_operator
+  version__layout__sideColumn__hero__links__link__type: versionsPost_version__layout__sideColumn__hero__links__link__type_operator
+  version__layout__sideColumn__hero__links__link__newTab: versionsPost_version__layout__sideColumn__hero__links__link__newTab_operator
+  version__layout__sideColumn__hero__links__link__reference: versionsPost_version__layout__sideColumn__hero__links__link__reference_Relation
+  version__layout__sideColumn__hero__links__link__url: versionsPost_version__layout__sideColumn__hero__links__link__url_operator
+  version__layout__sideColumn__hero__links__link__label: versionsPost_version__layout__sideColumn__hero__links__link__label_operator
+  version__layout__sideColumn__hero__links__link__appearance: versionsPost_version__layout__sideColumn__hero__links__link__appearance_operator
+  version__layout__sideColumn__hero__links__id: versionsPost_version__layout__sideColumn__hero__links__id_operator
+  version__layout__sideColumn__projectHero__year: versionsPost_version__layout__sideColumn__projectHero__year_operator
+  version__layout__sideColumn__projectHero__client: versionsPost_version__layout__sideColumn__projectHero__client_operator
+  version__layout__sideColumn__projectHero__links__link__type: versionsPost_version__layout__sideColumn__projectHero__links__link__type_operator
+  version__layout__sideColumn__projectHero__links__link__newTab: versionsPost_version__layout__sideColumn__projectHero__links__link__newTab_operator
+  version__layout__sideColumn__projectHero__links__link__reference: versionsPost_version__layout__sideColumn__projectHero__links__link__reference_Relation
+  version__layout__sideColumn__projectHero__links__link__url: versionsPost_version__layout__sideColumn__projectHero__links__link__url_operator
+  version__layout__sideColumn__projectHero__links__link__label: versionsPost_version__layout__sideColumn__projectHero__links__link__label_operator
+  version__layout__sideColumn__projectHero__links__link__appearance: versionsPost_version__layout__sideColumn__projectHero__links__link__appearance_operator
+  version__layout__sideColumn__projectHero__links__id: versionsPost_version__layout__sideColumn__projectHero__links__id_operator
   version__layout__sideColumn__sideContent1: versionsPost_version__layout__sideColumn__sideContent1_operator
   version__layout__sideColumn__sideContent2: versionsPost_version__layout__sideColumn__sideContent2_operator
-  version__layout__mainColumn__layoutStyle: versionsPost_version__layout__mainColumn__layoutStyle_operator
-  version__layout__mainColumn__singleLayout__singleLayout1: versionsPost_version__layout__mainColumn__singleLayout__singleLayout1_operator
-  version__layout__mainColumn__twoRows__row1: versionsPost_version__layout__mainColumn__twoRows__row1_operator
-  version__layout__mainColumn__twoRows__row2: versionsPost_version__layout__mainColumn__twoRows__row2_operator
-  version__layout__mainColumn__twoColumns__col1: versionsPost_version__layout__mainColumn__twoColumns__col1_operator
-  version__layout__mainColumn__twoColumns__col2: versionsPost_version__layout__mainColumn__twoColumns__col2_operator
-  version__layout__mainColumn__threeColumns__col1: versionsPost_version__layout__mainColumn__threeColumns__col1_operator
-  version__layout__mainColumn__threeColumns__col2: versionsPost_version__layout__mainColumn__threeColumns__col2_operator
-  version__layout__mainColumn__threeColumns__col3: versionsPost_version__layout__mainColumn__threeColumns__col3_operator
-  version__layout__mainColumn__threeSectionGrid__left: versionsPost_version__layout__mainColumn__threeSectionGrid__left_operator
-  version__layout__mainColumn__threeSectionGrid__right__rightTop: versionsPost_version__layout__mainColumn__threeSectionGrid__right__rightTop_operator
-  version__layout__mainColumn__threeSectionGrid__right__rightBottom: versionsPost_version__layout__mainColumn__threeSectionGrid__right__rightBottom_operator
+  version__layout__mainColumn__style: versionsPost_version__layout__mainColumn__style_operator
+  version__layout__mainColumn__row1column1: versionsPost_version__layout__mainColumn__row1column1_operator
+  version__layout__mainColumn__row1column2: versionsPost_version__layout__mainColumn__row1column2_operator
+  version__layout__mainColumn__row2column1: versionsPost_version__layout__mainColumn__row2column1_operator
+  version__layout__mainColumn__row2column2: versionsPost_version__layout__mainColumn__row2column2_operator
   version__layout__id: versionsPost_version__layout__id_operator
   version__relatedPosts: versionsPost_version__relatedPosts_operator
-  version__slug: versionsPost_version__slug_operator
   version__meta__title: versionsPost_version__meta__title_operator
   version__meta__description: versionsPost_version__meta__description_operator
   version__meta__image: versionsPost_version__meta__image_operator
@@ -6749,105 +7548,105 @@ input Category_where_or {
   OR: [Category_where_or]
 }
 
-type categoriesDocAccess {
-  fields: CategoriesDocAccessFields
-  create: CategoriesCreateDocAccess
-  read: CategoriesReadDocAccess
-  update: CategoriesUpdateDocAccess
-  delete: CategoriesDeleteDocAccess
+type categoryDocAccess {
+  fields: CategoryDocAccessFields
+  create: CategoryCreateDocAccess
+  read: CategoryReadDocAccess
+  update: CategoryUpdateDocAccess
+  delete: CategoryDeleteDocAccess
 }
 
-type CategoriesDocAccessFields {
-  title: CategoriesDocAccessFields_title
-  updatedAt: CategoriesDocAccessFields_updatedAt
-  createdAt: CategoriesDocAccessFields_createdAt
+type CategoryDocAccessFields {
+  title: CategoryDocAccessFields_title
+  updatedAt: CategoryDocAccessFields_updatedAt
+  createdAt: CategoryDocAccessFields_createdAt
 }
 
-type CategoriesDocAccessFields_title {
-  create: CategoriesDocAccessFields_title_Create
-  read: CategoriesDocAccessFields_title_Read
-  update: CategoriesDocAccessFields_title_Update
-  delete: CategoriesDocAccessFields_title_Delete
+type CategoryDocAccessFields_title {
+  create: CategoryDocAccessFields_title_Create
+  read: CategoryDocAccessFields_title_Read
+  update: CategoryDocAccessFields_title_Update
+  delete: CategoryDocAccessFields_title_Delete
 }
 
-type CategoriesDocAccessFields_title_Create {
+type CategoryDocAccessFields_title_Create {
   permission: Boolean!
 }
 
-type CategoriesDocAccessFields_title_Read {
+type CategoryDocAccessFields_title_Read {
   permission: Boolean!
 }
 
-type CategoriesDocAccessFields_title_Update {
+type CategoryDocAccessFields_title_Update {
   permission: Boolean!
 }
 
-type CategoriesDocAccessFields_title_Delete {
+type CategoryDocAccessFields_title_Delete {
   permission: Boolean!
 }
 
-type CategoriesDocAccessFields_updatedAt {
-  create: CategoriesDocAccessFields_updatedAt_Create
-  read: CategoriesDocAccessFields_updatedAt_Read
-  update: CategoriesDocAccessFields_updatedAt_Update
-  delete: CategoriesDocAccessFields_updatedAt_Delete
+type CategoryDocAccessFields_updatedAt {
+  create: CategoryDocAccessFields_updatedAt_Create
+  read: CategoryDocAccessFields_updatedAt_Read
+  update: CategoryDocAccessFields_updatedAt_Update
+  delete: CategoryDocAccessFields_updatedAt_Delete
 }
 
-type CategoriesDocAccessFields_updatedAt_Create {
+type CategoryDocAccessFields_updatedAt_Create {
   permission: Boolean!
 }
 
-type CategoriesDocAccessFields_updatedAt_Read {
+type CategoryDocAccessFields_updatedAt_Read {
   permission: Boolean!
 }
 
-type CategoriesDocAccessFields_updatedAt_Update {
+type CategoryDocAccessFields_updatedAt_Update {
   permission: Boolean!
 }
 
-type CategoriesDocAccessFields_updatedAt_Delete {
+type CategoryDocAccessFields_updatedAt_Delete {
   permission: Boolean!
 }
 
-type CategoriesDocAccessFields_createdAt {
-  create: CategoriesDocAccessFields_createdAt_Create
-  read: CategoriesDocAccessFields_createdAt_Read
-  update: CategoriesDocAccessFields_createdAt_Update
-  delete: CategoriesDocAccessFields_createdAt_Delete
+type CategoryDocAccessFields_createdAt {
+  create: CategoryDocAccessFields_createdAt_Create
+  read: CategoryDocAccessFields_createdAt_Read
+  update: CategoryDocAccessFields_createdAt_Update
+  delete: CategoryDocAccessFields_createdAt_Delete
 }
 
-type CategoriesDocAccessFields_createdAt_Create {
+type CategoryDocAccessFields_createdAt_Create {
   permission: Boolean!
 }
 
-type CategoriesDocAccessFields_createdAt_Read {
+type CategoryDocAccessFields_createdAt_Read {
   permission: Boolean!
 }
 
-type CategoriesDocAccessFields_createdAt_Update {
+type CategoryDocAccessFields_createdAt_Update {
   permission: Boolean!
 }
 
-type CategoriesDocAccessFields_createdAt_Delete {
+type CategoryDocAccessFields_createdAt_Delete {
   permission: Boolean!
 }
 
-type CategoriesCreateDocAccess {
-  permission: Boolean!
-  where: JSONObject
-}
-
-type CategoriesReadDocAccess {
+type CategoryCreateDocAccess {
   permission: Boolean!
   where: JSONObject
 }
 
-type CategoriesUpdateDocAccess {
+type CategoryReadDocAccess {
   permission: Boolean!
   where: JSONObject
 }
 
-type CategoriesDeleteDocAccess {
+type CategoryUpdateDocAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type CategoryDeleteDocAccess {
   permission: Boolean!
   where: JSONObject
 }
@@ -7249,6 +8048,193 @@ type KeywordsUpdateDocAccess {
 }
 
 type KeywordsDeleteDocAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type Clients {
+  docs: [Client]
+  hasNextPage: Boolean
+  hasPrevPage: Boolean
+  limit: Int
+  nextPage: Int
+  offset: Int
+  page: Int
+  pagingCounter: Int
+  prevPage: Int
+  totalDocs: Int
+  totalPages: Int
+}
+
+input Client_where {
+  title: Client_title_operator
+  updatedAt: Client_updatedAt_operator
+  createdAt: Client_createdAt_operator
+  id: Client_id_operator
+  AND: [Client_where_and]
+  OR: [Client_where_or]
+}
+
+input Client_title_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Client_updatedAt_operator {
+  equals: DateTime
+  not_equals: DateTime
+  greater_than_equal: DateTime
+  greater_than: DateTime
+  less_than_equal: DateTime
+  less_than: DateTime
+  like: DateTime
+  exists: Boolean
+}
+
+input Client_createdAt_operator {
+  equals: DateTime
+  not_equals: DateTime
+  greater_than_equal: DateTime
+  greater_than: DateTime
+  less_than_equal: DateTime
+  less_than: DateTime
+  like: DateTime
+  exists: Boolean
+}
+
+input Client_id_operator {
+  equals: Int
+  not_equals: Int
+  greater_than_equal: Int
+  greater_than: Int
+  less_than_equal: Int
+  less_than: Int
+  exists: Boolean
+}
+
+input Client_where_and {
+  title: Client_title_operator
+  updatedAt: Client_updatedAt_operator
+  createdAt: Client_createdAt_operator
+  id: Client_id_operator
+  AND: [Client_where_and]
+  OR: [Client_where_or]
+}
+
+input Client_where_or {
+  title: Client_title_operator
+  updatedAt: Client_updatedAt_operator
+  createdAt: Client_createdAt_operator
+  id: Client_id_operator
+  AND: [Client_where_and]
+  OR: [Client_where_or]
+}
+
+type clientsDocAccess {
+  fields: ClientsDocAccessFields
+  create: ClientsCreateDocAccess
+  read: ClientsReadDocAccess
+  update: ClientsUpdateDocAccess
+  delete: ClientsDeleteDocAccess
+}
+
+type ClientsDocAccessFields {
+  title: ClientsDocAccessFields_title
+  updatedAt: ClientsDocAccessFields_updatedAt
+  createdAt: ClientsDocAccessFields_createdAt
+}
+
+type ClientsDocAccessFields_title {
+  create: ClientsDocAccessFields_title_Create
+  read: ClientsDocAccessFields_title_Read
+  update: ClientsDocAccessFields_title_Update
+  delete: ClientsDocAccessFields_title_Delete
+}
+
+type ClientsDocAccessFields_title_Create {
+  permission: Boolean!
+}
+
+type ClientsDocAccessFields_title_Read {
+  permission: Boolean!
+}
+
+type ClientsDocAccessFields_title_Update {
+  permission: Boolean!
+}
+
+type ClientsDocAccessFields_title_Delete {
+  permission: Boolean!
+}
+
+type ClientsDocAccessFields_updatedAt {
+  create: ClientsDocAccessFields_updatedAt_Create
+  read: ClientsDocAccessFields_updatedAt_Read
+  update: ClientsDocAccessFields_updatedAt_Update
+  delete: ClientsDocAccessFields_updatedAt_Delete
+}
+
+type ClientsDocAccessFields_updatedAt_Create {
+  permission: Boolean!
+}
+
+type ClientsDocAccessFields_updatedAt_Read {
+  permission: Boolean!
+}
+
+type ClientsDocAccessFields_updatedAt_Update {
+  permission: Boolean!
+}
+
+type ClientsDocAccessFields_updatedAt_Delete {
+  permission: Boolean!
+}
+
+type ClientsDocAccessFields_createdAt {
+  create: ClientsDocAccessFields_createdAt_Create
+  read: ClientsDocAccessFields_createdAt_Read
+  update: ClientsDocAccessFields_createdAt_Update
+  delete: ClientsDocAccessFields_createdAt_Delete
+}
+
+type ClientsDocAccessFields_createdAt_Create {
+  permission: Boolean!
+}
+
+type ClientsDocAccessFields_createdAt_Read {
+  permission: Boolean!
+}
+
+type ClientsDocAccessFields_createdAt_Update {
+  permission: Boolean!
+}
+
+type ClientsDocAccessFields_createdAt_Delete {
+  permission: Boolean!
+}
+
+type ClientsCreateDocAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type ClientsReadDocAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type ClientsUpdateDocAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type ClientsDeleteDocAccess {
   permission: Boolean!
   where: JSONObject
 }
@@ -9161,7 +10147,7 @@ type ArchiveBlock {
   introContent(depth: Int): JSON
   populateBy: ArchiveBlock_populateBy
   relationTo: ArchiveBlock_relationTo
-  categories: [Category!]
+  category: [Category!]
   limit: Float
   showPageRange: Boolean
   selectedDocs: [ArchiveBlock_SelectedDocs_Relationship!]
@@ -9313,8 +10299,9 @@ type Access {
   pages: pagesAccess
   posts: postsAccess
   media: mediaAccess
-  categories: categoriesAccess
+  category: categoryAccess
   keywords: keywordsAccess
+  clients: clientsAccess
   users: usersAccess
   redirects: redirectsAccess
   payload_preferences: payload_preferencesAccess
@@ -9335,7 +10322,6 @@ type PagesFields {
   title: PagesFields_title
   publishedAt: PagesFields_publishedAt
   slug: PagesFields_slug
-  hero: PagesFields_hero
   layout: PagesFields_layout
   meta: PagesFields_meta
   updatedAt: PagesFields_updatedAt
@@ -9412,305 +10398,6 @@ type PagesFields_slug_Delete {
   permission: Boolean!
 }
 
-type PagesFields_hero {
-  create: PagesFields_hero_Create
-  read: PagesFields_hero_Read
-  update: PagesFields_hero_Update
-  delete: PagesFields_hero_Delete
-  fields: PagesFields_hero_Fields
-}
-
-type PagesFields_hero_Create {
-  permission: Boolean!
-}
-
-type PagesFields_hero_Read {
-  permission: Boolean!
-}
-
-type PagesFields_hero_Update {
-  permission: Boolean!
-}
-
-type PagesFields_hero_Delete {
-  permission: Boolean!
-}
-
-type PagesFields_hero_Fields {
-  type: PagesFields_hero_type
-  description: PagesFields_hero_description
-  links: PagesFields_hero_links
-}
-
-type PagesFields_hero_type {
-  create: PagesFields_hero_type_Create
-  read: PagesFields_hero_type_Read
-  update: PagesFields_hero_type_Update
-  delete: PagesFields_hero_type_Delete
-}
-
-type PagesFields_hero_type_Create {
-  permission: Boolean!
-}
-
-type PagesFields_hero_type_Read {
-  permission: Boolean!
-}
-
-type PagesFields_hero_type_Update {
-  permission: Boolean!
-}
-
-type PagesFields_hero_type_Delete {
-  permission: Boolean!
-}
-
-type PagesFields_hero_description {
-  create: PagesFields_hero_description_Create
-  read: PagesFields_hero_description_Read
-  update: PagesFields_hero_description_Update
-  delete: PagesFields_hero_description_Delete
-}
-
-type PagesFields_hero_description_Create {
-  permission: Boolean!
-}
-
-type PagesFields_hero_description_Read {
-  permission: Boolean!
-}
-
-type PagesFields_hero_description_Update {
-  permission: Boolean!
-}
-
-type PagesFields_hero_description_Delete {
-  permission: Boolean!
-}
-
-type PagesFields_hero_links {
-  create: PagesFields_hero_links_Create
-  read: PagesFields_hero_links_Read
-  update: PagesFields_hero_links_Update
-  delete: PagesFields_hero_links_Delete
-  fields: PagesFields_hero_links_Fields
-}
-
-type PagesFields_hero_links_Create {
-  permission: Boolean!
-}
-
-type PagesFields_hero_links_Read {
-  permission: Boolean!
-}
-
-type PagesFields_hero_links_Update {
-  permission: Boolean!
-}
-
-type PagesFields_hero_links_Delete {
-  permission: Boolean!
-}
-
-type PagesFields_hero_links_Fields {
-  link: PagesFields_hero_links_link
-  id: PagesFields_hero_links_id
-}
-
-type PagesFields_hero_links_link {
-  create: PagesFields_hero_links_link_Create
-  read: PagesFields_hero_links_link_Read
-  update: PagesFields_hero_links_link_Update
-  delete: PagesFields_hero_links_link_Delete
-  fields: PagesFields_hero_links_link_Fields
-}
-
-type PagesFields_hero_links_link_Create {
-  permission: Boolean!
-}
-
-type PagesFields_hero_links_link_Read {
-  permission: Boolean!
-}
-
-type PagesFields_hero_links_link_Update {
-  permission: Boolean!
-}
-
-type PagesFields_hero_links_link_Delete {
-  permission: Boolean!
-}
-
-type PagesFields_hero_links_link_Fields {
-  type: PagesFields_hero_links_link_type
-  newTab: PagesFields_hero_links_link_newTab
-  reference: PagesFields_hero_links_link_reference
-  url: PagesFields_hero_links_link_url
-  label: PagesFields_hero_links_link_label
-  appearance: PagesFields_hero_links_link_appearance
-}
-
-type PagesFields_hero_links_link_type {
-  create: PagesFields_hero_links_link_type_Create
-  read: PagesFields_hero_links_link_type_Read
-  update: PagesFields_hero_links_link_type_Update
-  delete: PagesFields_hero_links_link_type_Delete
-}
-
-type PagesFields_hero_links_link_type_Create {
-  permission: Boolean!
-}
-
-type PagesFields_hero_links_link_type_Read {
-  permission: Boolean!
-}
-
-type PagesFields_hero_links_link_type_Update {
-  permission: Boolean!
-}
-
-type PagesFields_hero_links_link_type_Delete {
-  permission: Boolean!
-}
-
-type PagesFields_hero_links_link_newTab {
-  create: PagesFields_hero_links_link_newTab_Create
-  read: PagesFields_hero_links_link_newTab_Read
-  update: PagesFields_hero_links_link_newTab_Update
-  delete: PagesFields_hero_links_link_newTab_Delete
-}
-
-type PagesFields_hero_links_link_newTab_Create {
-  permission: Boolean!
-}
-
-type PagesFields_hero_links_link_newTab_Read {
-  permission: Boolean!
-}
-
-type PagesFields_hero_links_link_newTab_Update {
-  permission: Boolean!
-}
-
-type PagesFields_hero_links_link_newTab_Delete {
-  permission: Boolean!
-}
-
-type PagesFields_hero_links_link_reference {
-  create: PagesFields_hero_links_link_reference_Create
-  read: PagesFields_hero_links_link_reference_Read
-  update: PagesFields_hero_links_link_reference_Update
-  delete: PagesFields_hero_links_link_reference_Delete
-}
-
-type PagesFields_hero_links_link_reference_Create {
-  permission: Boolean!
-}
-
-type PagesFields_hero_links_link_reference_Read {
-  permission: Boolean!
-}
-
-type PagesFields_hero_links_link_reference_Update {
-  permission: Boolean!
-}
-
-type PagesFields_hero_links_link_reference_Delete {
-  permission: Boolean!
-}
-
-type PagesFields_hero_links_link_url {
-  create: PagesFields_hero_links_link_url_Create
-  read: PagesFields_hero_links_link_url_Read
-  update: PagesFields_hero_links_link_url_Update
-  delete: PagesFields_hero_links_link_url_Delete
-}
-
-type PagesFields_hero_links_link_url_Create {
-  permission: Boolean!
-}
-
-type PagesFields_hero_links_link_url_Read {
-  permission: Boolean!
-}
-
-type PagesFields_hero_links_link_url_Update {
-  permission: Boolean!
-}
-
-type PagesFields_hero_links_link_url_Delete {
-  permission: Boolean!
-}
-
-type PagesFields_hero_links_link_label {
-  create: PagesFields_hero_links_link_label_Create
-  read: PagesFields_hero_links_link_label_Read
-  update: PagesFields_hero_links_link_label_Update
-  delete: PagesFields_hero_links_link_label_Delete
-}
-
-type PagesFields_hero_links_link_label_Create {
-  permission: Boolean!
-}
-
-type PagesFields_hero_links_link_label_Read {
-  permission: Boolean!
-}
-
-type PagesFields_hero_links_link_label_Update {
-  permission: Boolean!
-}
-
-type PagesFields_hero_links_link_label_Delete {
-  permission: Boolean!
-}
-
-type PagesFields_hero_links_link_appearance {
-  create: PagesFields_hero_links_link_appearance_Create
-  read: PagesFields_hero_links_link_appearance_Read
-  update: PagesFields_hero_links_link_appearance_Update
-  delete: PagesFields_hero_links_link_appearance_Delete
-}
-
-type PagesFields_hero_links_link_appearance_Create {
-  permission: Boolean!
-}
-
-type PagesFields_hero_links_link_appearance_Read {
-  permission: Boolean!
-}
-
-type PagesFields_hero_links_link_appearance_Update {
-  permission: Boolean!
-}
-
-type PagesFields_hero_links_link_appearance_Delete {
-  permission: Boolean!
-}
-
-type PagesFields_hero_links_id {
-  create: PagesFields_hero_links_id_Create
-  read: PagesFields_hero_links_id_Read
-  update: PagesFields_hero_links_id_Update
-  delete: PagesFields_hero_links_id_Delete
-}
-
-type PagesFields_hero_links_id_Create {
-  permission: Boolean!
-}
-
-type PagesFields_hero_links_id_Read {
-  permission: Boolean!
-}
-
-type PagesFields_hero_links_id_Update {
-  permission: Boolean!
-}
-
-type PagesFields_hero_links_id_Delete {
-  permission: Boolean!
-}
-
 type PagesFields_layout {
   create: PagesFields_layout_Create
   read: PagesFields_layout_Read
@@ -9736,7 +10423,7 @@ type PagesFields_layout_Delete {
 }
 
 type PagesFields_layout_Fields {
-  fixedSideContent: PagesFields_layout_fixedSideContent
+  sideContentPosition: PagesFields_layout_sideContentPosition
   scrollSnap: PagesFields_layout_scrollSnap
   fullPageHeight: PagesFields_layout_fullPageHeight
   sideColumn: PagesFields_layout_sideColumn
@@ -9744,26 +10431,26 @@ type PagesFields_layout_Fields {
   id: PagesFields_layout_id
 }
 
-type PagesFields_layout_fixedSideContent {
-  create: PagesFields_layout_fixedSideContent_Create
-  read: PagesFields_layout_fixedSideContent_Read
-  update: PagesFields_layout_fixedSideContent_Update
-  delete: PagesFields_layout_fixedSideContent_Delete
+type PagesFields_layout_sideContentPosition {
+  create: PagesFields_layout_sideContentPosition_Create
+  read: PagesFields_layout_sideContentPosition_Read
+  update: PagesFields_layout_sideContentPosition_Update
+  delete: PagesFields_layout_sideContentPosition_Delete
 }
 
-type PagesFields_layout_fixedSideContent_Create {
+type PagesFields_layout_sideContentPosition_Create {
   permission: Boolean!
 }
 
-type PagesFields_layout_fixedSideContent_Read {
+type PagesFields_layout_sideContentPosition_Read {
   permission: Boolean!
 }
 
-type PagesFields_layout_fixedSideContent_Update {
+type PagesFields_layout_sideContentPosition_Update {
   permission: Boolean!
 }
 
-type PagesFields_layout_fixedSideContent_Delete {
+type PagesFields_layout_sideContentPosition_Delete {
   permission: Boolean!
 }
 
@@ -9838,31 +10525,631 @@ type PagesFields_layout_sideColumn_Delete {
 }
 
 type PagesFields_layout_sideColumn_Fields {
-  sideStyle: PagesFields_layout_sideColumn_sideStyle
+  style: PagesFields_layout_sideColumn_style
+  hero: PagesFields_layout_sideColumn_hero
+  projectHero: PagesFields_layout_sideColumn_projectHero
   sideContent1: PagesFields_layout_sideColumn_sideContent1
   sideContent2: PagesFields_layout_sideColumn_sideContent2
 }
 
-type PagesFields_layout_sideColumn_sideStyle {
-  create: PagesFields_layout_sideColumn_sideStyle_Create
-  read: PagesFields_layout_sideColumn_sideStyle_Read
-  update: PagesFields_layout_sideColumn_sideStyle_Update
-  delete: PagesFields_layout_sideColumn_sideStyle_Delete
+type PagesFields_layout_sideColumn_style {
+  create: PagesFields_layout_sideColumn_style_Create
+  read: PagesFields_layout_sideColumn_style_Read
+  update: PagesFields_layout_sideColumn_style_Update
+  delete: PagesFields_layout_sideColumn_style_Delete
 }
 
-type PagesFields_layout_sideColumn_sideStyle_Create {
+type PagesFields_layout_sideColumn_style_Create {
   permission: Boolean!
 }
 
-type PagesFields_layout_sideColumn_sideStyle_Read {
+type PagesFields_layout_sideColumn_style_Read {
   permission: Boolean!
 }
 
-type PagesFields_layout_sideColumn_sideStyle_Update {
+type PagesFields_layout_sideColumn_style_Update {
   permission: Boolean!
 }
 
-type PagesFields_layout_sideColumn_sideStyle_Delete {
+type PagesFields_layout_sideColumn_style_Delete {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_hero {
+  create: PagesFields_layout_sideColumn_hero_Create
+  read: PagesFields_layout_sideColumn_hero_Read
+  update: PagesFields_layout_sideColumn_hero_Update
+  delete: PagesFields_layout_sideColumn_hero_Delete
+  fields: PagesFields_layout_sideColumn_hero_Fields
+}
+
+type PagesFields_layout_sideColumn_hero_Create {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_hero_Read {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_hero_Update {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_hero_Delete {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_hero_Fields {
+  media: PagesFields_layout_sideColumn_hero_media
+  description: PagesFields_layout_sideColumn_hero_description
+  links: PagesFields_layout_sideColumn_hero_links
+}
+
+type PagesFields_layout_sideColumn_hero_media {
+  create: PagesFields_layout_sideColumn_hero_media_Create
+  read: PagesFields_layout_sideColumn_hero_media_Read
+  update: PagesFields_layout_sideColumn_hero_media_Update
+  delete: PagesFields_layout_sideColumn_hero_media_Delete
+}
+
+type PagesFields_layout_sideColumn_hero_media_Create {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_hero_media_Read {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_hero_media_Update {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_hero_media_Delete {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_hero_description {
+  create: PagesFields_layout_sideColumn_hero_description_Create
+  read: PagesFields_layout_sideColumn_hero_description_Read
+  update: PagesFields_layout_sideColumn_hero_description_Update
+  delete: PagesFields_layout_sideColumn_hero_description_Delete
+}
+
+type PagesFields_layout_sideColumn_hero_description_Create {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_hero_description_Read {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_hero_description_Update {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_hero_description_Delete {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_hero_links {
+  create: PagesFields_layout_sideColumn_hero_links_Create
+  read: PagesFields_layout_sideColumn_hero_links_Read
+  update: PagesFields_layout_sideColumn_hero_links_Update
+  delete: PagesFields_layout_sideColumn_hero_links_Delete
+  fields: PagesFields_layout_sideColumn_hero_links_Fields
+}
+
+type PagesFields_layout_sideColumn_hero_links_Create {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_hero_links_Read {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_hero_links_Update {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_hero_links_Delete {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_hero_links_Fields {
+  link: PagesFields_layout_sideColumn_hero_links_link
+  id: PagesFields_layout_sideColumn_hero_links_id
+}
+
+type PagesFields_layout_sideColumn_hero_links_link {
+  create: PagesFields_layout_sideColumn_hero_links_link_Create
+  read: PagesFields_layout_sideColumn_hero_links_link_Read
+  update: PagesFields_layout_sideColumn_hero_links_link_Update
+  delete: PagesFields_layout_sideColumn_hero_links_link_Delete
+  fields: PagesFields_layout_sideColumn_hero_links_link_Fields
+}
+
+type PagesFields_layout_sideColumn_hero_links_link_Create {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_hero_links_link_Read {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_hero_links_link_Update {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_hero_links_link_Delete {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_hero_links_link_Fields {
+  type: PagesFields_layout_sideColumn_hero_links_link_type
+  newTab: PagesFields_layout_sideColumn_hero_links_link_newTab
+  reference: PagesFields_layout_sideColumn_hero_links_link_reference
+  url: PagesFields_layout_sideColumn_hero_links_link_url
+  label: PagesFields_layout_sideColumn_hero_links_link_label
+  appearance: PagesFields_layout_sideColumn_hero_links_link_appearance
+}
+
+type PagesFields_layout_sideColumn_hero_links_link_type {
+  create: PagesFields_layout_sideColumn_hero_links_link_type_Create
+  read: PagesFields_layout_sideColumn_hero_links_link_type_Read
+  update: PagesFields_layout_sideColumn_hero_links_link_type_Update
+  delete: PagesFields_layout_sideColumn_hero_links_link_type_Delete
+}
+
+type PagesFields_layout_sideColumn_hero_links_link_type_Create {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_hero_links_link_type_Read {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_hero_links_link_type_Update {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_hero_links_link_type_Delete {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_hero_links_link_newTab {
+  create: PagesFields_layout_sideColumn_hero_links_link_newTab_Create
+  read: PagesFields_layout_sideColumn_hero_links_link_newTab_Read
+  update: PagesFields_layout_sideColumn_hero_links_link_newTab_Update
+  delete: PagesFields_layout_sideColumn_hero_links_link_newTab_Delete
+}
+
+type PagesFields_layout_sideColumn_hero_links_link_newTab_Create {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_hero_links_link_newTab_Read {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_hero_links_link_newTab_Update {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_hero_links_link_newTab_Delete {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_hero_links_link_reference {
+  create: PagesFields_layout_sideColumn_hero_links_link_reference_Create
+  read: PagesFields_layout_sideColumn_hero_links_link_reference_Read
+  update: PagesFields_layout_sideColumn_hero_links_link_reference_Update
+  delete: PagesFields_layout_sideColumn_hero_links_link_reference_Delete
+}
+
+type PagesFields_layout_sideColumn_hero_links_link_reference_Create {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_hero_links_link_reference_Read {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_hero_links_link_reference_Update {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_hero_links_link_reference_Delete {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_hero_links_link_url {
+  create: PagesFields_layout_sideColumn_hero_links_link_url_Create
+  read: PagesFields_layout_sideColumn_hero_links_link_url_Read
+  update: PagesFields_layout_sideColumn_hero_links_link_url_Update
+  delete: PagesFields_layout_sideColumn_hero_links_link_url_Delete
+}
+
+type PagesFields_layout_sideColumn_hero_links_link_url_Create {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_hero_links_link_url_Read {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_hero_links_link_url_Update {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_hero_links_link_url_Delete {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_hero_links_link_label {
+  create: PagesFields_layout_sideColumn_hero_links_link_label_Create
+  read: PagesFields_layout_sideColumn_hero_links_link_label_Read
+  update: PagesFields_layout_sideColumn_hero_links_link_label_Update
+  delete: PagesFields_layout_sideColumn_hero_links_link_label_Delete
+}
+
+type PagesFields_layout_sideColumn_hero_links_link_label_Create {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_hero_links_link_label_Read {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_hero_links_link_label_Update {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_hero_links_link_label_Delete {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_hero_links_link_appearance {
+  create: PagesFields_layout_sideColumn_hero_links_link_appearance_Create
+  read: PagesFields_layout_sideColumn_hero_links_link_appearance_Read
+  update: PagesFields_layout_sideColumn_hero_links_link_appearance_Update
+  delete: PagesFields_layout_sideColumn_hero_links_link_appearance_Delete
+}
+
+type PagesFields_layout_sideColumn_hero_links_link_appearance_Create {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_hero_links_link_appearance_Read {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_hero_links_link_appearance_Update {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_hero_links_link_appearance_Delete {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_hero_links_id {
+  create: PagesFields_layout_sideColumn_hero_links_id_Create
+  read: PagesFields_layout_sideColumn_hero_links_id_Read
+  update: PagesFields_layout_sideColumn_hero_links_id_Update
+  delete: PagesFields_layout_sideColumn_hero_links_id_Delete
+}
+
+type PagesFields_layout_sideColumn_hero_links_id_Create {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_hero_links_id_Read {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_hero_links_id_Update {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_hero_links_id_Delete {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_projectHero {
+  create: PagesFields_layout_sideColumn_projectHero_Create
+  read: PagesFields_layout_sideColumn_projectHero_Read
+  update: PagesFields_layout_sideColumn_projectHero_Update
+  delete: PagesFields_layout_sideColumn_projectHero_Delete
+  fields: PagesFields_layout_sideColumn_projectHero_Fields
+}
+
+type PagesFields_layout_sideColumn_projectHero_Create {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_projectHero_Read {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_projectHero_Update {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_projectHero_Delete {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_projectHero_Fields {
+  year: PagesFields_layout_sideColumn_projectHero_year
+  client: PagesFields_layout_sideColumn_projectHero_client
+  links: PagesFields_layout_sideColumn_projectHero_links
+}
+
+type PagesFields_layout_sideColumn_projectHero_year {
+  create: PagesFields_layout_sideColumn_projectHero_year_Create
+  read: PagesFields_layout_sideColumn_projectHero_year_Read
+  update: PagesFields_layout_sideColumn_projectHero_year_Update
+  delete: PagesFields_layout_sideColumn_projectHero_year_Delete
+}
+
+type PagesFields_layout_sideColumn_projectHero_year_Create {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_projectHero_year_Read {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_projectHero_year_Update {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_projectHero_year_Delete {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_projectHero_client {
+  create: PagesFields_layout_sideColumn_projectHero_client_Create
+  read: PagesFields_layout_sideColumn_projectHero_client_Read
+  update: PagesFields_layout_sideColumn_projectHero_client_Update
+  delete: PagesFields_layout_sideColumn_projectHero_client_Delete
+}
+
+type PagesFields_layout_sideColumn_projectHero_client_Create {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_projectHero_client_Read {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_projectHero_client_Update {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_projectHero_client_Delete {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_projectHero_links {
+  create: PagesFields_layout_sideColumn_projectHero_links_Create
+  read: PagesFields_layout_sideColumn_projectHero_links_Read
+  update: PagesFields_layout_sideColumn_projectHero_links_Update
+  delete: PagesFields_layout_sideColumn_projectHero_links_Delete
+  fields: PagesFields_layout_sideColumn_projectHero_links_Fields
+}
+
+type PagesFields_layout_sideColumn_projectHero_links_Create {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_projectHero_links_Read {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_projectHero_links_Update {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_projectHero_links_Delete {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_projectHero_links_Fields {
+  link: PagesFields_layout_sideColumn_projectHero_links_link
+  id: PagesFields_layout_sideColumn_projectHero_links_id
+}
+
+type PagesFields_layout_sideColumn_projectHero_links_link {
+  create: PagesFields_layout_sideColumn_projectHero_links_link_Create
+  read: PagesFields_layout_sideColumn_projectHero_links_link_Read
+  update: PagesFields_layout_sideColumn_projectHero_links_link_Update
+  delete: PagesFields_layout_sideColumn_projectHero_links_link_Delete
+  fields: PagesFields_layout_sideColumn_projectHero_links_link_Fields
+}
+
+type PagesFields_layout_sideColumn_projectHero_links_link_Create {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_projectHero_links_link_Read {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_projectHero_links_link_Update {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_projectHero_links_link_Delete {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_projectHero_links_link_Fields {
+  type: PagesFields_layout_sideColumn_projectHero_links_link_type
+  newTab: PagesFields_layout_sideColumn_projectHero_links_link_newTab
+  reference: PagesFields_layout_sideColumn_projectHero_links_link_reference
+  url: PagesFields_layout_sideColumn_projectHero_links_link_url
+  label: PagesFields_layout_sideColumn_projectHero_links_link_label
+  appearance: PagesFields_layout_sideColumn_projectHero_links_link_appearance
+}
+
+type PagesFields_layout_sideColumn_projectHero_links_link_type {
+  create: PagesFields_layout_sideColumn_projectHero_links_link_type_Create
+  read: PagesFields_layout_sideColumn_projectHero_links_link_type_Read
+  update: PagesFields_layout_sideColumn_projectHero_links_link_type_Update
+  delete: PagesFields_layout_sideColumn_projectHero_links_link_type_Delete
+}
+
+type PagesFields_layout_sideColumn_projectHero_links_link_type_Create {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_projectHero_links_link_type_Read {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_projectHero_links_link_type_Update {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_projectHero_links_link_type_Delete {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_projectHero_links_link_newTab {
+  create: PagesFields_layout_sideColumn_projectHero_links_link_newTab_Create
+  read: PagesFields_layout_sideColumn_projectHero_links_link_newTab_Read
+  update: PagesFields_layout_sideColumn_projectHero_links_link_newTab_Update
+  delete: PagesFields_layout_sideColumn_projectHero_links_link_newTab_Delete
+}
+
+type PagesFields_layout_sideColumn_projectHero_links_link_newTab_Create {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_projectHero_links_link_newTab_Read {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_projectHero_links_link_newTab_Update {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_projectHero_links_link_newTab_Delete {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_projectHero_links_link_reference {
+  create: PagesFields_layout_sideColumn_projectHero_links_link_reference_Create
+  read: PagesFields_layout_sideColumn_projectHero_links_link_reference_Read
+  update: PagesFields_layout_sideColumn_projectHero_links_link_reference_Update
+  delete: PagesFields_layout_sideColumn_projectHero_links_link_reference_Delete
+}
+
+type PagesFields_layout_sideColumn_projectHero_links_link_reference_Create {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_projectHero_links_link_reference_Read {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_projectHero_links_link_reference_Update {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_projectHero_links_link_reference_Delete {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_projectHero_links_link_url {
+  create: PagesFields_layout_sideColumn_projectHero_links_link_url_Create
+  read: PagesFields_layout_sideColumn_projectHero_links_link_url_Read
+  update: PagesFields_layout_sideColumn_projectHero_links_link_url_Update
+  delete: PagesFields_layout_sideColumn_projectHero_links_link_url_Delete
+}
+
+type PagesFields_layout_sideColumn_projectHero_links_link_url_Create {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_projectHero_links_link_url_Read {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_projectHero_links_link_url_Update {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_projectHero_links_link_url_Delete {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_projectHero_links_link_label {
+  create: PagesFields_layout_sideColumn_projectHero_links_link_label_Create
+  read: PagesFields_layout_sideColumn_projectHero_links_link_label_Read
+  update: PagesFields_layout_sideColumn_projectHero_links_link_label_Update
+  delete: PagesFields_layout_sideColumn_projectHero_links_link_label_Delete
+}
+
+type PagesFields_layout_sideColumn_projectHero_links_link_label_Create {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_projectHero_links_link_label_Read {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_projectHero_links_link_label_Update {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_projectHero_links_link_label_Delete {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_projectHero_links_link_appearance {
+  create: PagesFields_layout_sideColumn_projectHero_links_link_appearance_Create
+  read: PagesFields_layout_sideColumn_projectHero_links_link_appearance_Read
+  update: PagesFields_layout_sideColumn_projectHero_links_link_appearance_Update
+  delete: PagesFields_layout_sideColumn_projectHero_links_link_appearance_Delete
+}
+
+type PagesFields_layout_sideColumn_projectHero_links_link_appearance_Create {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_projectHero_links_link_appearance_Read {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_projectHero_links_link_appearance_Update {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_projectHero_links_link_appearance_Delete {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_projectHero_links_id {
+  create: PagesFields_layout_sideColumn_projectHero_links_id_Create
+  read: PagesFields_layout_sideColumn_projectHero_links_id_Read
+  update: PagesFields_layout_sideColumn_projectHero_links_id_Update
+  delete: PagesFields_layout_sideColumn_projectHero_links_id_Delete
+}
+
+type PagesFields_layout_sideColumn_projectHero_links_id_Create {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_projectHero_links_id_Read {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_projectHero_links_id_Update {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_projectHero_links_id_Delete {
   permission: Boolean!
 }
 
@@ -9937,461 +11224,125 @@ type PagesFields_layout_mainColumn_Delete {
 }
 
 type PagesFields_layout_mainColumn_Fields {
-  layoutStyle: PagesFields_layout_mainColumn_layoutStyle
-  singleLayout: PagesFields_layout_mainColumn_singleLayout
-  twoRows: PagesFields_layout_mainColumn_twoRows
-  twoColumns: PagesFields_layout_mainColumn_twoColumns
-  threeColumns: PagesFields_layout_mainColumn_threeColumns
-  threeSectionGrid: PagesFields_layout_mainColumn_threeSectionGrid
+  style: PagesFields_layout_mainColumn_style
+  row1column1: PagesFields_layout_mainColumn_row1column1
+  row1column2: PagesFields_layout_mainColumn_row1column2
+  row2column1: PagesFields_layout_mainColumn_row2column1
+  row2column2: PagesFields_layout_mainColumn_row2column2
 }
 
-type PagesFields_layout_mainColumn_layoutStyle {
-  create: PagesFields_layout_mainColumn_layoutStyle_Create
-  read: PagesFields_layout_mainColumn_layoutStyle_Read
-  update: PagesFields_layout_mainColumn_layoutStyle_Update
-  delete: PagesFields_layout_mainColumn_layoutStyle_Delete
+type PagesFields_layout_mainColumn_style {
+  create: PagesFields_layout_mainColumn_style_Create
+  read: PagesFields_layout_mainColumn_style_Read
+  update: PagesFields_layout_mainColumn_style_Update
+  delete: PagesFields_layout_mainColumn_style_Delete
 }
 
-type PagesFields_layout_mainColumn_layoutStyle_Create {
+type PagesFields_layout_mainColumn_style_Create {
   permission: Boolean!
 }
 
-type PagesFields_layout_mainColumn_layoutStyle_Read {
+type PagesFields_layout_mainColumn_style_Read {
   permission: Boolean!
 }
 
-type PagesFields_layout_mainColumn_layoutStyle_Update {
+type PagesFields_layout_mainColumn_style_Update {
   permission: Boolean!
 }
 
-type PagesFields_layout_mainColumn_layoutStyle_Delete {
+type PagesFields_layout_mainColumn_style_Delete {
   permission: Boolean!
 }
 
-type PagesFields_layout_mainColumn_singleLayout {
-  create: PagesFields_layout_mainColumn_singleLayout_Create
-  read: PagesFields_layout_mainColumn_singleLayout_Read
-  update: PagesFields_layout_mainColumn_singleLayout_Update
-  delete: PagesFields_layout_mainColumn_singleLayout_Delete
-  fields: PagesFields_layout_mainColumn_singleLayout_Fields
+type PagesFields_layout_mainColumn_row1column1 {
+  create: PagesFields_layout_mainColumn_row1column1_Create
+  read: PagesFields_layout_mainColumn_row1column1_Read
+  update: PagesFields_layout_mainColumn_row1column1_Update
+  delete: PagesFields_layout_mainColumn_row1column1_Delete
 }
 
-type PagesFields_layout_mainColumn_singleLayout_Create {
+type PagesFields_layout_mainColumn_row1column1_Create {
   permission: Boolean!
 }
 
-type PagesFields_layout_mainColumn_singleLayout_Read {
+type PagesFields_layout_mainColumn_row1column1_Read {
   permission: Boolean!
 }
 
-type PagesFields_layout_mainColumn_singleLayout_Update {
+type PagesFields_layout_mainColumn_row1column1_Update {
   permission: Boolean!
 }
 
-type PagesFields_layout_mainColumn_singleLayout_Delete {
+type PagesFields_layout_mainColumn_row1column1_Delete {
   permission: Boolean!
 }
 
-type PagesFields_layout_mainColumn_singleLayout_Fields {
-  singleLayout1: PagesFields_layout_mainColumn_singleLayout_singleLayout1
+type PagesFields_layout_mainColumn_row1column2 {
+  create: PagesFields_layout_mainColumn_row1column2_Create
+  read: PagesFields_layout_mainColumn_row1column2_Read
+  update: PagesFields_layout_mainColumn_row1column2_Update
+  delete: PagesFields_layout_mainColumn_row1column2_Delete
 }
 
-type PagesFields_layout_mainColumn_singleLayout_singleLayout1 {
-  create: PagesFields_layout_mainColumn_singleLayout_singleLayout1_Create
-  read: PagesFields_layout_mainColumn_singleLayout_singleLayout1_Read
-  update: PagesFields_layout_mainColumn_singleLayout_singleLayout1_Update
-  delete: PagesFields_layout_mainColumn_singleLayout_singleLayout1_Delete
-}
-
-type PagesFields_layout_mainColumn_singleLayout_singleLayout1_Create {
-  permission: Boolean!
-}
-
-type PagesFields_layout_mainColumn_singleLayout_singleLayout1_Read {
-  permission: Boolean!
-}
-
-type PagesFields_layout_mainColumn_singleLayout_singleLayout1_Update {
-  permission: Boolean!
-}
-
-type PagesFields_layout_mainColumn_singleLayout_singleLayout1_Delete {
-  permission: Boolean!
-}
-
-type PagesFields_layout_mainColumn_twoRows {
-  create: PagesFields_layout_mainColumn_twoRows_Create
-  read: PagesFields_layout_mainColumn_twoRows_Read
-  update: PagesFields_layout_mainColumn_twoRows_Update
-  delete: PagesFields_layout_mainColumn_twoRows_Delete
-  fields: PagesFields_layout_mainColumn_twoRows_Fields
-}
-
-type PagesFields_layout_mainColumn_twoRows_Create {
-  permission: Boolean!
-}
-
-type PagesFields_layout_mainColumn_twoRows_Read {
-  permission: Boolean!
-}
-
-type PagesFields_layout_mainColumn_twoRows_Update {
-  permission: Boolean!
-}
-
-type PagesFields_layout_mainColumn_twoRows_Delete {
-  permission: Boolean!
-}
-
-type PagesFields_layout_mainColumn_twoRows_Fields {
-  row1: PagesFields_layout_mainColumn_twoRows_row1
-  row2: PagesFields_layout_mainColumn_twoRows_row2
-}
-
-type PagesFields_layout_mainColumn_twoRows_row1 {
-  create: PagesFields_layout_mainColumn_twoRows_row1_Create
-  read: PagesFields_layout_mainColumn_twoRows_row1_Read
-  update: PagesFields_layout_mainColumn_twoRows_row1_Update
-  delete: PagesFields_layout_mainColumn_twoRows_row1_Delete
-}
-
-type PagesFields_layout_mainColumn_twoRows_row1_Create {
-  permission: Boolean!
-}
-
-type PagesFields_layout_mainColumn_twoRows_row1_Read {
-  permission: Boolean!
-}
-
-type PagesFields_layout_mainColumn_twoRows_row1_Update {
-  permission: Boolean!
-}
-
-type PagesFields_layout_mainColumn_twoRows_row1_Delete {
-  permission: Boolean!
-}
-
-type PagesFields_layout_mainColumn_twoRows_row2 {
-  create: PagesFields_layout_mainColumn_twoRows_row2_Create
-  read: PagesFields_layout_mainColumn_twoRows_row2_Read
-  update: PagesFields_layout_mainColumn_twoRows_row2_Update
-  delete: PagesFields_layout_mainColumn_twoRows_row2_Delete
-}
-
-type PagesFields_layout_mainColumn_twoRows_row2_Create {
-  permission: Boolean!
-}
-
-type PagesFields_layout_mainColumn_twoRows_row2_Read {
-  permission: Boolean!
-}
-
-type PagesFields_layout_mainColumn_twoRows_row2_Update {
-  permission: Boolean!
-}
-
-type PagesFields_layout_mainColumn_twoRows_row2_Delete {
-  permission: Boolean!
-}
-
-type PagesFields_layout_mainColumn_twoColumns {
-  create: PagesFields_layout_mainColumn_twoColumns_Create
-  read: PagesFields_layout_mainColumn_twoColumns_Read
-  update: PagesFields_layout_mainColumn_twoColumns_Update
-  delete: PagesFields_layout_mainColumn_twoColumns_Delete
-  fields: PagesFields_layout_mainColumn_twoColumns_Fields
-}
-
-type PagesFields_layout_mainColumn_twoColumns_Create {
-  permission: Boolean!
-}
-
-type PagesFields_layout_mainColumn_twoColumns_Read {
-  permission: Boolean!
-}
-
-type PagesFields_layout_mainColumn_twoColumns_Update {
-  permission: Boolean!
-}
-
-type PagesFields_layout_mainColumn_twoColumns_Delete {
-  permission: Boolean!
-}
-
-type PagesFields_layout_mainColumn_twoColumns_Fields {
-  col1: PagesFields_layout_mainColumn_twoColumns_col1
-  col2: PagesFields_layout_mainColumn_twoColumns_col2
-}
-
-type PagesFields_layout_mainColumn_twoColumns_col1 {
-  create: PagesFields_layout_mainColumn_twoColumns_col1_Create
-  read: PagesFields_layout_mainColumn_twoColumns_col1_Read
-  update: PagesFields_layout_mainColumn_twoColumns_col1_Update
-  delete: PagesFields_layout_mainColumn_twoColumns_col1_Delete
-}
-
-type PagesFields_layout_mainColumn_twoColumns_col1_Create {
-  permission: Boolean!
-}
-
-type PagesFields_layout_mainColumn_twoColumns_col1_Read {
-  permission: Boolean!
-}
-
-type PagesFields_layout_mainColumn_twoColumns_col1_Update {
-  permission: Boolean!
-}
-
-type PagesFields_layout_mainColumn_twoColumns_col1_Delete {
-  permission: Boolean!
-}
-
-type PagesFields_layout_mainColumn_twoColumns_col2 {
-  create: PagesFields_layout_mainColumn_twoColumns_col2_Create
-  read: PagesFields_layout_mainColumn_twoColumns_col2_Read
-  update: PagesFields_layout_mainColumn_twoColumns_col2_Update
-  delete: PagesFields_layout_mainColumn_twoColumns_col2_Delete
-}
-
-type PagesFields_layout_mainColumn_twoColumns_col2_Create {
-  permission: Boolean!
-}
-
-type PagesFields_layout_mainColumn_twoColumns_col2_Read {
-  permission: Boolean!
-}
-
-type PagesFields_layout_mainColumn_twoColumns_col2_Update {
-  permission: Boolean!
-}
-
-type PagesFields_layout_mainColumn_twoColumns_col2_Delete {
-  permission: Boolean!
-}
-
-type PagesFields_layout_mainColumn_threeColumns {
-  create: PagesFields_layout_mainColumn_threeColumns_Create
-  read: PagesFields_layout_mainColumn_threeColumns_Read
-  update: PagesFields_layout_mainColumn_threeColumns_Update
-  delete: PagesFields_layout_mainColumn_threeColumns_Delete
-  fields: PagesFields_layout_mainColumn_threeColumns_Fields
-}
-
-type PagesFields_layout_mainColumn_threeColumns_Create {
-  permission: Boolean!
-}
-
-type PagesFields_layout_mainColumn_threeColumns_Read {
-  permission: Boolean!
-}
-
-type PagesFields_layout_mainColumn_threeColumns_Update {
-  permission: Boolean!
-}
-
-type PagesFields_layout_mainColumn_threeColumns_Delete {
-  permission: Boolean!
-}
-
-type PagesFields_layout_mainColumn_threeColumns_Fields {
-  col1: PagesFields_layout_mainColumn_threeColumns_col1
-  col2: PagesFields_layout_mainColumn_threeColumns_col2
-  col3: PagesFields_layout_mainColumn_threeColumns_col3
-}
-
-type PagesFields_layout_mainColumn_threeColumns_col1 {
-  create: PagesFields_layout_mainColumn_threeColumns_col1_Create
-  read: PagesFields_layout_mainColumn_threeColumns_col1_Read
-  update: PagesFields_layout_mainColumn_threeColumns_col1_Update
-  delete: PagesFields_layout_mainColumn_threeColumns_col1_Delete
-}
-
-type PagesFields_layout_mainColumn_threeColumns_col1_Create {
-  permission: Boolean!
-}
-
-type PagesFields_layout_mainColumn_threeColumns_col1_Read {
-  permission: Boolean!
-}
-
-type PagesFields_layout_mainColumn_threeColumns_col1_Update {
-  permission: Boolean!
-}
-
-type PagesFields_layout_mainColumn_threeColumns_col1_Delete {
-  permission: Boolean!
-}
-
-type PagesFields_layout_mainColumn_threeColumns_col2 {
-  create: PagesFields_layout_mainColumn_threeColumns_col2_Create
-  read: PagesFields_layout_mainColumn_threeColumns_col2_Read
-  update: PagesFields_layout_mainColumn_threeColumns_col2_Update
-  delete: PagesFields_layout_mainColumn_threeColumns_col2_Delete
-}
-
-type PagesFields_layout_mainColumn_threeColumns_col2_Create {
-  permission: Boolean!
-}
-
-type PagesFields_layout_mainColumn_threeColumns_col2_Read {
-  permission: Boolean!
-}
-
-type PagesFields_layout_mainColumn_threeColumns_col2_Update {
-  permission: Boolean!
-}
-
-type PagesFields_layout_mainColumn_threeColumns_col2_Delete {
-  permission: Boolean!
-}
-
-type PagesFields_layout_mainColumn_threeColumns_col3 {
-  create: PagesFields_layout_mainColumn_threeColumns_col3_Create
-  read: PagesFields_layout_mainColumn_threeColumns_col3_Read
-  update: PagesFields_layout_mainColumn_threeColumns_col3_Update
-  delete: PagesFields_layout_mainColumn_threeColumns_col3_Delete
-}
-
-type PagesFields_layout_mainColumn_threeColumns_col3_Create {
-  permission: Boolean!
-}
-
-type PagesFields_layout_mainColumn_threeColumns_col3_Read {
-  permission: Boolean!
-}
-
-type PagesFields_layout_mainColumn_threeColumns_col3_Update {
-  permission: Boolean!
-}
-
-type PagesFields_layout_mainColumn_threeColumns_col3_Delete {
-  permission: Boolean!
-}
-
-type PagesFields_layout_mainColumn_threeSectionGrid {
-  create: PagesFields_layout_mainColumn_threeSectionGrid_Create
-  read: PagesFields_layout_mainColumn_threeSectionGrid_Read
-  update: PagesFields_layout_mainColumn_threeSectionGrid_Update
-  delete: PagesFields_layout_mainColumn_threeSectionGrid_Delete
-  fields: PagesFields_layout_mainColumn_threeSectionGrid_Fields
-}
-
-type PagesFields_layout_mainColumn_threeSectionGrid_Create {
-  permission: Boolean!
-}
-
-type PagesFields_layout_mainColumn_threeSectionGrid_Read {
-  permission: Boolean!
-}
-
-type PagesFields_layout_mainColumn_threeSectionGrid_Update {
-  permission: Boolean!
-}
-
-type PagesFields_layout_mainColumn_threeSectionGrid_Delete {
-  permission: Boolean!
-}
-
-type PagesFields_layout_mainColumn_threeSectionGrid_Fields {
-  left: PagesFields_layout_mainColumn_threeSectionGrid_left
-  right: PagesFields_layout_mainColumn_threeSectionGrid_right
-}
-
-type PagesFields_layout_mainColumn_threeSectionGrid_left {
-  create: PagesFields_layout_mainColumn_threeSectionGrid_left_Create
-  read: PagesFields_layout_mainColumn_threeSectionGrid_left_Read
-  update: PagesFields_layout_mainColumn_threeSectionGrid_left_Update
-  delete: PagesFields_layout_mainColumn_threeSectionGrid_left_Delete
-}
-
-type PagesFields_layout_mainColumn_threeSectionGrid_left_Create {
-  permission: Boolean!
-}
-
-type PagesFields_layout_mainColumn_threeSectionGrid_left_Read {
+type PagesFields_layout_mainColumn_row1column2_Create {
   permission: Boolean!
 }
 
-type PagesFields_layout_mainColumn_threeSectionGrid_left_Update {
+type PagesFields_layout_mainColumn_row1column2_Read {
   permission: Boolean!
 }
 
-type PagesFields_layout_mainColumn_threeSectionGrid_left_Delete {
+type PagesFields_layout_mainColumn_row1column2_Update {
   permission: Boolean!
 }
 
-type PagesFields_layout_mainColumn_threeSectionGrid_right {
-  create: PagesFields_layout_mainColumn_threeSectionGrid_right_Create
-  read: PagesFields_layout_mainColumn_threeSectionGrid_right_Read
-  update: PagesFields_layout_mainColumn_threeSectionGrid_right_Update
-  delete: PagesFields_layout_mainColumn_threeSectionGrid_right_Delete
-  fields: PagesFields_layout_mainColumn_threeSectionGrid_right_Fields
-}
-
-type PagesFields_layout_mainColumn_threeSectionGrid_right_Create {
-  permission: Boolean!
-}
-
-type PagesFields_layout_mainColumn_threeSectionGrid_right_Read {
-  permission: Boolean!
-}
-
-type PagesFields_layout_mainColumn_threeSectionGrid_right_Update {
-  permission: Boolean!
-}
-
-type PagesFields_layout_mainColumn_threeSectionGrid_right_Delete {
+type PagesFields_layout_mainColumn_row1column2_Delete {
   permission: Boolean!
-}
-
-type PagesFields_layout_mainColumn_threeSectionGrid_right_Fields {
-  rightTop: PagesFields_layout_mainColumn_threeSectionGrid_right_rightTop
-  rightBottom: PagesFields_layout_mainColumn_threeSectionGrid_right_rightBottom
 }
 
-type PagesFields_layout_mainColumn_threeSectionGrid_right_rightTop {
-  create: PagesFields_layout_mainColumn_threeSectionGrid_right_rightTop_Create
-  read: PagesFields_layout_mainColumn_threeSectionGrid_right_rightTop_Read
-  update: PagesFields_layout_mainColumn_threeSectionGrid_right_rightTop_Update
-  delete: PagesFields_layout_mainColumn_threeSectionGrid_right_rightTop_Delete
+type PagesFields_layout_mainColumn_row2column1 {
+  create: PagesFields_layout_mainColumn_row2column1_Create
+  read: PagesFields_layout_mainColumn_row2column1_Read
+  update: PagesFields_layout_mainColumn_row2column1_Update
+  delete: PagesFields_layout_mainColumn_row2column1_Delete
 }
 
-type PagesFields_layout_mainColumn_threeSectionGrid_right_rightTop_Create {
+type PagesFields_layout_mainColumn_row2column1_Create {
   permission: Boolean!
 }
 
-type PagesFields_layout_mainColumn_threeSectionGrid_right_rightTop_Read {
+type PagesFields_layout_mainColumn_row2column1_Read {
   permission: Boolean!
 }
 
-type PagesFields_layout_mainColumn_threeSectionGrid_right_rightTop_Update {
+type PagesFields_layout_mainColumn_row2column1_Update {
   permission: Boolean!
 }
 
-type PagesFields_layout_mainColumn_threeSectionGrid_right_rightTop_Delete {
+type PagesFields_layout_mainColumn_row2column1_Delete {
   permission: Boolean!
 }
 
-type PagesFields_layout_mainColumn_threeSectionGrid_right_rightBottom {
-  create: PagesFields_layout_mainColumn_threeSectionGrid_right_rightBottom_Create
-  read: PagesFields_layout_mainColumn_threeSectionGrid_right_rightBottom_Read
-  update: PagesFields_layout_mainColumn_threeSectionGrid_right_rightBottom_Update
-  delete: PagesFields_layout_mainColumn_threeSectionGrid_right_rightBottom_Delete
+type PagesFields_layout_mainColumn_row2column2 {
+  create: PagesFields_layout_mainColumn_row2column2_Create
+  read: PagesFields_layout_mainColumn_row2column2_Read
+  update: PagesFields_layout_mainColumn_row2column2_Update
+  delete: PagesFields_layout_mainColumn_row2column2_Delete
 }
 
-type PagesFields_layout_mainColumn_threeSectionGrid_right_rightBottom_Create {
+type PagesFields_layout_mainColumn_row2column2_Create {
   permission: Boolean!
 }
 
-type PagesFields_layout_mainColumn_threeSectionGrid_right_rightBottom_Read {
+type PagesFields_layout_mainColumn_row2column2_Read {
   permission: Boolean!
 }
 
-type PagesFields_layout_mainColumn_threeSectionGrid_right_rightBottom_Update {
+type PagesFields_layout_mainColumn_row2column2_Update {
   permission: Boolean!
 }
 
-type PagesFields_layout_mainColumn_threeSectionGrid_right_rightBottom_Delete {
+type PagesFields_layout_mainColumn_row2column2_Delete {
   permission: Boolean!
 }
 
@@ -10443,34 +11394,9 @@ type PagesFields_meta_Delete {
 }
 
 type PagesFields_meta_Fields {
-  overview: PagesFields_meta_overview
   title: PagesFields_meta_title
   description: PagesFields_meta_description
   image: PagesFields_meta_image
-  preview: PagesFields_meta_preview
-}
-
-type PagesFields_meta_overview {
-  create: PagesFields_meta_overview_Create
-  read: PagesFields_meta_overview_Read
-  update: PagesFields_meta_overview_Update
-  delete: PagesFields_meta_overview_Delete
-}
-
-type PagesFields_meta_overview_Create {
-  permission: Boolean!
-}
-
-type PagesFields_meta_overview_Read {
-  permission: Boolean!
-}
-
-type PagesFields_meta_overview_Update {
-  permission: Boolean!
-}
-
-type PagesFields_meta_overview_Delete {
-  permission: Boolean!
 }
 
 type PagesFields_meta_title {
@@ -10539,29 +11465,6 @@ type PagesFields_meta_image_Update {
 }
 
 type PagesFields_meta_image_Delete {
-  permission: Boolean!
-}
-
-type PagesFields_meta_preview {
-  create: PagesFields_meta_preview_Create
-  read: PagesFields_meta_preview_Read
-  update: PagesFields_meta_preview_Update
-  delete: PagesFields_meta_preview_Delete
-}
-
-type PagesFields_meta_preview_Create {
-  permission: Boolean!
-}
-
-type PagesFields_meta_preview_Read {
-  permission: Boolean!
-}
-
-type PagesFields_meta_preview_Update {
-  permission: Boolean!
-}
-
-type PagesFields_meta_preview_Delete {
   permission: Boolean!
 }
 
@@ -10670,15 +11573,16 @@ type postsAccess {
 
 type PostsFields {
   title: PostsFields_title
-  categories: PostsFields_categories
+  description: PostsFields_description
+  category: PostsFields_category
   keywords: PostsFields_keywords
+  slug: PostsFields_slug
   publishedAt: PostsFields_publishedAt
   authors: PostsFields_authors
   populatedAuthors: PostsFields_populatedAuthors
-  hero: PostsFields_hero
+  card: PostsFields_card
   layout: PostsFields_layout
   relatedPosts: PostsFields_relatedPosts
-  slug: PostsFields_slug
   meta: PostsFields_meta
   updatedAt: PostsFields_updatedAt
   createdAt: PostsFields_createdAt
@@ -10708,26 +11612,49 @@ type PostsFields_title_Delete {
   permission: Boolean!
 }
 
-type PostsFields_categories {
-  create: PostsFields_categories_Create
-  read: PostsFields_categories_Read
-  update: PostsFields_categories_Update
-  delete: PostsFields_categories_Delete
+type PostsFields_description {
+  create: PostsFields_description_Create
+  read: PostsFields_description_Read
+  update: PostsFields_description_Update
+  delete: PostsFields_description_Delete
 }
 
-type PostsFields_categories_Create {
+type PostsFields_description_Create {
   permission: Boolean!
 }
 
-type PostsFields_categories_Read {
+type PostsFields_description_Read {
   permission: Boolean!
 }
 
-type PostsFields_categories_Update {
+type PostsFields_description_Update {
   permission: Boolean!
 }
 
-type PostsFields_categories_Delete {
+type PostsFields_description_Delete {
+  permission: Boolean!
+}
+
+type PostsFields_category {
+  create: PostsFields_category_Create
+  read: PostsFields_category_Read
+  update: PostsFields_category_Update
+  delete: PostsFields_category_Delete
+}
+
+type PostsFields_category_Create {
+  permission: Boolean!
+}
+
+type PostsFields_category_Read {
+  permission: Boolean!
+}
+
+type PostsFields_category_Update {
+  permission: Boolean!
+}
+
+type PostsFields_category_Delete {
   permission: Boolean!
 }
 
@@ -10751,6 +11678,29 @@ type PostsFields_keywords_Update {
 }
 
 type PostsFields_keywords_Delete {
+  permission: Boolean!
+}
+
+type PostsFields_slug {
+  create: PostsFields_slug_Create
+  read: PostsFields_slug_Read
+  update: PostsFields_slug_Update
+  delete: PostsFields_slug_Delete
+}
+
+type PostsFields_slug_Create {
+  permission: Boolean!
+}
+
+type PostsFields_slug_Read {
+  permission: Boolean!
+}
+
+type PostsFields_slug_Update {
+  permission: Boolean!
+}
+
+type PostsFields_slug_Delete {
   permission: Boolean!
 }
 
@@ -10875,302 +11825,126 @@ type PostsFields_populatedAuthors_name_Delete {
   permission: Boolean!
 }
 
-type PostsFields_hero {
-  create: PostsFields_hero_Create
-  read: PostsFields_hero_Read
-  update: PostsFields_hero_Update
-  delete: PostsFields_hero_Delete
-  fields: PostsFields_hero_Fields
+type PostsFields_card {
+  create: PostsFields_card_Create
+  read: PostsFields_card_Read
+  update: PostsFields_card_Update
+  delete: PostsFields_card_Delete
+  fields: PostsFields_card_Fields
 }
 
-type PostsFields_hero_Create {
+type PostsFields_card_Create {
   permission: Boolean!
 }
 
-type PostsFields_hero_Read {
+type PostsFields_card_Read {
   permission: Boolean!
 }
 
-type PostsFields_hero_Update {
+type PostsFields_card_Update {
   permission: Boolean!
 }
 
-type PostsFields_hero_Delete {
+type PostsFields_card_Delete {
   permission: Boolean!
 }
 
-type PostsFields_hero_Fields {
-  type: PostsFields_hero_type
-  description: PostsFields_hero_description
-  links: PostsFields_hero_links
+type PostsFields_card_Fields {
+  media: PostsFields_card_media
+  backgroundColour: PostsFields_card_backgroundColour
+  overlayImage: PostsFields_card_overlayImage
+  showDate: PostsFields_card_showDate
 }
 
-type PostsFields_hero_type {
-  create: PostsFields_hero_type_Create
-  read: PostsFields_hero_type_Read
-  update: PostsFields_hero_type_Update
-  delete: PostsFields_hero_type_Delete
+type PostsFields_card_media {
+  create: PostsFields_card_media_Create
+  read: PostsFields_card_media_Read
+  update: PostsFields_card_media_Update
+  delete: PostsFields_card_media_Delete
 }
 
-type PostsFields_hero_type_Create {
+type PostsFields_card_media_Create {
   permission: Boolean!
 }
 
-type PostsFields_hero_type_Read {
+type PostsFields_card_media_Read {
   permission: Boolean!
 }
 
-type PostsFields_hero_type_Update {
+type PostsFields_card_media_Update {
   permission: Boolean!
 }
 
-type PostsFields_hero_type_Delete {
+type PostsFields_card_media_Delete {
   permission: Boolean!
 }
 
-type PostsFields_hero_description {
-  create: PostsFields_hero_description_Create
-  read: PostsFields_hero_description_Read
-  update: PostsFields_hero_description_Update
-  delete: PostsFields_hero_description_Delete
+type PostsFields_card_backgroundColour {
+  create: PostsFields_card_backgroundColour_Create
+  read: PostsFields_card_backgroundColour_Read
+  update: PostsFields_card_backgroundColour_Update
+  delete: PostsFields_card_backgroundColour_Delete
 }
 
-type PostsFields_hero_description_Create {
+type PostsFields_card_backgroundColour_Create {
   permission: Boolean!
 }
 
-type PostsFields_hero_description_Read {
+type PostsFields_card_backgroundColour_Read {
   permission: Boolean!
 }
 
-type PostsFields_hero_description_Update {
+type PostsFields_card_backgroundColour_Update {
   permission: Boolean!
 }
 
-type PostsFields_hero_description_Delete {
+type PostsFields_card_backgroundColour_Delete {
   permission: Boolean!
 }
 
-type PostsFields_hero_links {
-  create: PostsFields_hero_links_Create
-  read: PostsFields_hero_links_Read
-  update: PostsFields_hero_links_Update
-  delete: PostsFields_hero_links_Delete
-  fields: PostsFields_hero_links_Fields
+type PostsFields_card_overlayImage {
+  create: PostsFields_card_overlayImage_Create
+  read: PostsFields_card_overlayImage_Read
+  update: PostsFields_card_overlayImage_Update
+  delete: PostsFields_card_overlayImage_Delete
 }
 
-type PostsFields_hero_links_Create {
+type PostsFields_card_overlayImage_Create {
   permission: Boolean!
 }
 
-type PostsFields_hero_links_Read {
+type PostsFields_card_overlayImage_Read {
   permission: Boolean!
 }
 
-type PostsFields_hero_links_Update {
+type PostsFields_card_overlayImage_Update {
   permission: Boolean!
 }
 
-type PostsFields_hero_links_Delete {
+type PostsFields_card_overlayImage_Delete {
   permission: Boolean!
 }
 
-type PostsFields_hero_links_Fields {
-  link: PostsFields_hero_links_link
-  id: PostsFields_hero_links_id
+type PostsFields_card_showDate {
+  create: PostsFields_card_showDate_Create
+  read: PostsFields_card_showDate_Read
+  update: PostsFields_card_showDate_Update
+  delete: PostsFields_card_showDate_Delete
 }
 
-type PostsFields_hero_links_link {
-  create: PostsFields_hero_links_link_Create
-  read: PostsFields_hero_links_link_Read
-  update: PostsFields_hero_links_link_Update
-  delete: PostsFields_hero_links_link_Delete
-  fields: PostsFields_hero_links_link_Fields
-}
-
-type PostsFields_hero_links_link_Create {
+type PostsFields_card_showDate_Create {
   permission: Boolean!
 }
 
-type PostsFields_hero_links_link_Read {
+type PostsFields_card_showDate_Read {
   permission: Boolean!
 }
 
-type PostsFields_hero_links_link_Update {
+type PostsFields_card_showDate_Update {
   permission: Boolean!
 }
 
-type PostsFields_hero_links_link_Delete {
-  permission: Boolean!
-}
-
-type PostsFields_hero_links_link_Fields {
-  type: PostsFields_hero_links_link_type
-  newTab: PostsFields_hero_links_link_newTab
-  reference: PostsFields_hero_links_link_reference
-  url: PostsFields_hero_links_link_url
-  label: PostsFields_hero_links_link_label
-  appearance: PostsFields_hero_links_link_appearance
-}
-
-type PostsFields_hero_links_link_type {
-  create: PostsFields_hero_links_link_type_Create
-  read: PostsFields_hero_links_link_type_Read
-  update: PostsFields_hero_links_link_type_Update
-  delete: PostsFields_hero_links_link_type_Delete
-}
-
-type PostsFields_hero_links_link_type_Create {
-  permission: Boolean!
-}
-
-type PostsFields_hero_links_link_type_Read {
-  permission: Boolean!
-}
-
-type PostsFields_hero_links_link_type_Update {
-  permission: Boolean!
-}
-
-type PostsFields_hero_links_link_type_Delete {
-  permission: Boolean!
-}
-
-type PostsFields_hero_links_link_newTab {
-  create: PostsFields_hero_links_link_newTab_Create
-  read: PostsFields_hero_links_link_newTab_Read
-  update: PostsFields_hero_links_link_newTab_Update
-  delete: PostsFields_hero_links_link_newTab_Delete
-}
-
-type PostsFields_hero_links_link_newTab_Create {
-  permission: Boolean!
-}
-
-type PostsFields_hero_links_link_newTab_Read {
-  permission: Boolean!
-}
-
-type PostsFields_hero_links_link_newTab_Update {
-  permission: Boolean!
-}
-
-type PostsFields_hero_links_link_newTab_Delete {
-  permission: Boolean!
-}
-
-type PostsFields_hero_links_link_reference {
-  create: PostsFields_hero_links_link_reference_Create
-  read: PostsFields_hero_links_link_reference_Read
-  update: PostsFields_hero_links_link_reference_Update
-  delete: PostsFields_hero_links_link_reference_Delete
-}
-
-type PostsFields_hero_links_link_reference_Create {
-  permission: Boolean!
-}
-
-type PostsFields_hero_links_link_reference_Read {
-  permission: Boolean!
-}
-
-type PostsFields_hero_links_link_reference_Update {
-  permission: Boolean!
-}
-
-type PostsFields_hero_links_link_reference_Delete {
-  permission: Boolean!
-}
-
-type PostsFields_hero_links_link_url {
-  create: PostsFields_hero_links_link_url_Create
-  read: PostsFields_hero_links_link_url_Read
-  update: PostsFields_hero_links_link_url_Update
-  delete: PostsFields_hero_links_link_url_Delete
-}
-
-type PostsFields_hero_links_link_url_Create {
-  permission: Boolean!
-}
-
-type PostsFields_hero_links_link_url_Read {
-  permission: Boolean!
-}
-
-type PostsFields_hero_links_link_url_Update {
-  permission: Boolean!
-}
-
-type PostsFields_hero_links_link_url_Delete {
-  permission: Boolean!
-}
-
-type PostsFields_hero_links_link_label {
-  create: PostsFields_hero_links_link_label_Create
-  read: PostsFields_hero_links_link_label_Read
-  update: PostsFields_hero_links_link_label_Update
-  delete: PostsFields_hero_links_link_label_Delete
-}
-
-type PostsFields_hero_links_link_label_Create {
-  permission: Boolean!
-}
-
-type PostsFields_hero_links_link_label_Read {
-  permission: Boolean!
-}
-
-type PostsFields_hero_links_link_label_Update {
-  permission: Boolean!
-}
-
-type PostsFields_hero_links_link_label_Delete {
-  permission: Boolean!
-}
-
-type PostsFields_hero_links_link_appearance {
-  create: PostsFields_hero_links_link_appearance_Create
-  read: PostsFields_hero_links_link_appearance_Read
-  update: PostsFields_hero_links_link_appearance_Update
-  delete: PostsFields_hero_links_link_appearance_Delete
-}
-
-type PostsFields_hero_links_link_appearance_Create {
-  permission: Boolean!
-}
-
-type PostsFields_hero_links_link_appearance_Read {
-  permission: Boolean!
-}
-
-type PostsFields_hero_links_link_appearance_Update {
-  permission: Boolean!
-}
-
-type PostsFields_hero_links_link_appearance_Delete {
-  permission: Boolean!
-}
-
-type PostsFields_hero_links_id {
-  create: PostsFields_hero_links_id_Create
-  read: PostsFields_hero_links_id_Read
-  update: PostsFields_hero_links_id_Update
-  delete: PostsFields_hero_links_id_Delete
-}
-
-type PostsFields_hero_links_id_Create {
-  permission: Boolean!
-}
-
-type PostsFields_hero_links_id_Read {
-  permission: Boolean!
-}
-
-type PostsFields_hero_links_id_Update {
-  permission: Boolean!
-}
-
-type PostsFields_hero_links_id_Delete {
+type PostsFields_card_showDate_Delete {
   permission: Boolean!
 }
 
@@ -11199,7 +11973,7 @@ type PostsFields_layout_Delete {
 }
 
 type PostsFields_layout_Fields {
-  fixedSideContent: PostsFields_layout_fixedSideContent
+  sideContentPosition: PostsFields_layout_sideContentPosition
   scrollSnap: PostsFields_layout_scrollSnap
   fullPageHeight: PostsFields_layout_fullPageHeight
   sideColumn: PostsFields_layout_sideColumn
@@ -11207,26 +11981,26 @@ type PostsFields_layout_Fields {
   id: PostsFields_layout_id
 }
 
-type PostsFields_layout_fixedSideContent {
-  create: PostsFields_layout_fixedSideContent_Create
-  read: PostsFields_layout_fixedSideContent_Read
-  update: PostsFields_layout_fixedSideContent_Update
-  delete: PostsFields_layout_fixedSideContent_Delete
+type PostsFields_layout_sideContentPosition {
+  create: PostsFields_layout_sideContentPosition_Create
+  read: PostsFields_layout_sideContentPosition_Read
+  update: PostsFields_layout_sideContentPosition_Update
+  delete: PostsFields_layout_sideContentPosition_Delete
 }
 
-type PostsFields_layout_fixedSideContent_Create {
+type PostsFields_layout_sideContentPosition_Create {
   permission: Boolean!
 }
 
-type PostsFields_layout_fixedSideContent_Read {
+type PostsFields_layout_sideContentPosition_Read {
   permission: Boolean!
 }
 
-type PostsFields_layout_fixedSideContent_Update {
+type PostsFields_layout_sideContentPosition_Update {
   permission: Boolean!
 }
 
-type PostsFields_layout_fixedSideContent_Delete {
+type PostsFields_layout_sideContentPosition_Delete {
   permission: Boolean!
 }
 
@@ -11301,31 +12075,631 @@ type PostsFields_layout_sideColumn_Delete {
 }
 
 type PostsFields_layout_sideColumn_Fields {
-  sideStyle: PostsFields_layout_sideColumn_sideStyle
+  style: PostsFields_layout_sideColumn_style
+  hero: PostsFields_layout_sideColumn_hero
+  projectHero: PostsFields_layout_sideColumn_projectHero
   sideContent1: PostsFields_layout_sideColumn_sideContent1
   sideContent2: PostsFields_layout_sideColumn_sideContent2
 }
 
-type PostsFields_layout_sideColumn_sideStyle {
-  create: PostsFields_layout_sideColumn_sideStyle_Create
-  read: PostsFields_layout_sideColumn_sideStyle_Read
-  update: PostsFields_layout_sideColumn_sideStyle_Update
-  delete: PostsFields_layout_sideColumn_sideStyle_Delete
+type PostsFields_layout_sideColumn_style {
+  create: PostsFields_layout_sideColumn_style_Create
+  read: PostsFields_layout_sideColumn_style_Read
+  update: PostsFields_layout_sideColumn_style_Update
+  delete: PostsFields_layout_sideColumn_style_Delete
 }
 
-type PostsFields_layout_sideColumn_sideStyle_Create {
+type PostsFields_layout_sideColumn_style_Create {
   permission: Boolean!
 }
 
-type PostsFields_layout_sideColumn_sideStyle_Read {
+type PostsFields_layout_sideColumn_style_Read {
   permission: Boolean!
 }
 
-type PostsFields_layout_sideColumn_sideStyle_Update {
+type PostsFields_layout_sideColumn_style_Update {
   permission: Boolean!
 }
 
-type PostsFields_layout_sideColumn_sideStyle_Delete {
+type PostsFields_layout_sideColumn_style_Delete {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_hero {
+  create: PostsFields_layout_sideColumn_hero_Create
+  read: PostsFields_layout_sideColumn_hero_Read
+  update: PostsFields_layout_sideColumn_hero_Update
+  delete: PostsFields_layout_sideColumn_hero_Delete
+  fields: PostsFields_layout_sideColumn_hero_Fields
+}
+
+type PostsFields_layout_sideColumn_hero_Create {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_hero_Read {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_hero_Update {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_hero_Delete {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_hero_Fields {
+  media: PostsFields_layout_sideColumn_hero_media
+  description: PostsFields_layout_sideColumn_hero_description
+  links: PostsFields_layout_sideColumn_hero_links
+}
+
+type PostsFields_layout_sideColumn_hero_media {
+  create: PostsFields_layout_sideColumn_hero_media_Create
+  read: PostsFields_layout_sideColumn_hero_media_Read
+  update: PostsFields_layout_sideColumn_hero_media_Update
+  delete: PostsFields_layout_sideColumn_hero_media_Delete
+}
+
+type PostsFields_layout_sideColumn_hero_media_Create {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_hero_media_Read {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_hero_media_Update {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_hero_media_Delete {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_hero_description {
+  create: PostsFields_layout_sideColumn_hero_description_Create
+  read: PostsFields_layout_sideColumn_hero_description_Read
+  update: PostsFields_layout_sideColumn_hero_description_Update
+  delete: PostsFields_layout_sideColumn_hero_description_Delete
+}
+
+type PostsFields_layout_sideColumn_hero_description_Create {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_hero_description_Read {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_hero_description_Update {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_hero_description_Delete {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_hero_links {
+  create: PostsFields_layout_sideColumn_hero_links_Create
+  read: PostsFields_layout_sideColumn_hero_links_Read
+  update: PostsFields_layout_sideColumn_hero_links_Update
+  delete: PostsFields_layout_sideColumn_hero_links_Delete
+  fields: PostsFields_layout_sideColumn_hero_links_Fields
+}
+
+type PostsFields_layout_sideColumn_hero_links_Create {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_hero_links_Read {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_hero_links_Update {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_hero_links_Delete {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_hero_links_Fields {
+  link: PostsFields_layout_sideColumn_hero_links_link
+  id: PostsFields_layout_sideColumn_hero_links_id
+}
+
+type PostsFields_layout_sideColumn_hero_links_link {
+  create: PostsFields_layout_sideColumn_hero_links_link_Create
+  read: PostsFields_layout_sideColumn_hero_links_link_Read
+  update: PostsFields_layout_sideColumn_hero_links_link_Update
+  delete: PostsFields_layout_sideColumn_hero_links_link_Delete
+  fields: PostsFields_layout_sideColumn_hero_links_link_Fields
+}
+
+type PostsFields_layout_sideColumn_hero_links_link_Create {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_hero_links_link_Read {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_hero_links_link_Update {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_hero_links_link_Delete {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_hero_links_link_Fields {
+  type: PostsFields_layout_sideColumn_hero_links_link_type
+  newTab: PostsFields_layout_sideColumn_hero_links_link_newTab
+  reference: PostsFields_layout_sideColumn_hero_links_link_reference
+  url: PostsFields_layout_sideColumn_hero_links_link_url
+  label: PostsFields_layout_sideColumn_hero_links_link_label
+  appearance: PostsFields_layout_sideColumn_hero_links_link_appearance
+}
+
+type PostsFields_layout_sideColumn_hero_links_link_type {
+  create: PostsFields_layout_sideColumn_hero_links_link_type_Create
+  read: PostsFields_layout_sideColumn_hero_links_link_type_Read
+  update: PostsFields_layout_sideColumn_hero_links_link_type_Update
+  delete: PostsFields_layout_sideColumn_hero_links_link_type_Delete
+}
+
+type PostsFields_layout_sideColumn_hero_links_link_type_Create {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_hero_links_link_type_Read {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_hero_links_link_type_Update {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_hero_links_link_type_Delete {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_hero_links_link_newTab {
+  create: PostsFields_layout_sideColumn_hero_links_link_newTab_Create
+  read: PostsFields_layout_sideColumn_hero_links_link_newTab_Read
+  update: PostsFields_layout_sideColumn_hero_links_link_newTab_Update
+  delete: PostsFields_layout_sideColumn_hero_links_link_newTab_Delete
+}
+
+type PostsFields_layout_sideColumn_hero_links_link_newTab_Create {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_hero_links_link_newTab_Read {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_hero_links_link_newTab_Update {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_hero_links_link_newTab_Delete {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_hero_links_link_reference {
+  create: PostsFields_layout_sideColumn_hero_links_link_reference_Create
+  read: PostsFields_layout_sideColumn_hero_links_link_reference_Read
+  update: PostsFields_layout_sideColumn_hero_links_link_reference_Update
+  delete: PostsFields_layout_sideColumn_hero_links_link_reference_Delete
+}
+
+type PostsFields_layout_sideColumn_hero_links_link_reference_Create {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_hero_links_link_reference_Read {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_hero_links_link_reference_Update {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_hero_links_link_reference_Delete {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_hero_links_link_url {
+  create: PostsFields_layout_sideColumn_hero_links_link_url_Create
+  read: PostsFields_layout_sideColumn_hero_links_link_url_Read
+  update: PostsFields_layout_sideColumn_hero_links_link_url_Update
+  delete: PostsFields_layout_sideColumn_hero_links_link_url_Delete
+}
+
+type PostsFields_layout_sideColumn_hero_links_link_url_Create {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_hero_links_link_url_Read {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_hero_links_link_url_Update {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_hero_links_link_url_Delete {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_hero_links_link_label {
+  create: PostsFields_layout_sideColumn_hero_links_link_label_Create
+  read: PostsFields_layout_sideColumn_hero_links_link_label_Read
+  update: PostsFields_layout_sideColumn_hero_links_link_label_Update
+  delete: PostsFields_layout_sideColumn_hero_links_link_label_Delete
+}
+
+type PostsFields_layout_sideColumn_hero_links_link_label_Create {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_hero_links_link_label_Read {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_hero_links_link_label_Update {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_hero_links_link_label_Delete {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_hero_links_link_appearance {
+  create: PostsFields_layout_sideColumn_hero_links_link_appearance_Create
+  read: PostsFields_layout_sideColumn_hero_links_link_appearance_Read
+  update: PostsFields_layout_sideColumn_hero_links_link_appearance_Update
+  delete: PostsFields_layout_sideColumn_hero_links_link_appearance_Delete
+}
+
+type PostsFields_layout_sideColumn_hero_links_link_appearance_Create {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_hero_links_link_appearance_Read {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_hero_links_link_appearance_Update {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_hero_links_link_appearance_Delete {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_hero_links_id {
+  create: PostsFields_layout_sideColumn_hero_links_id_Create
+  read: PostsFields_layout_sideColumn_hero_links_id_Read
+  update: PostsFields_layout_sideColumn_hero_links_id_Update
+  delete: PostsFields_layout_sideColumn_hero_links_id_Delete
+}
+
+type PostsFields_layout_sideColumn_hero_links_id_Create {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_hero_links_id_Read {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_hero_links_id_Update {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_hero_links_id_Delete {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_projectHero {
+  create: PostsFields_layout_sideColumn_projectHero_Create
+  read: PostsFields_layout_sideColumn_projectHero_Read
+  update: PostsFields_layout_sideColumn_projectHero_Update
+  delete: PostsFields_layout_sideColumn_projectHero_Delete
+  fields: PostsFields_layout_sideColumn_projectHero_Fields
+}
+
+type PostsFields_layout_sideColumn_projectHero_Create {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_projectHero_Read {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_projectHero_Update {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_projectHero_Delete {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_projectHero_Fields {
+  year: PostsFields_layout_sideColumn_projectHero_year
+  client: PostsFields_layout_sideColumn_projectHero_client
+  links: PostsFields_layout_sideColumn_projectHero_links
+}
+
+type PostsFields_layout_sideColumn_projectHero_year {
+  create: PostsFields_layout_sideColumn_projectHero_year_Create
+  read: PostsFields_layout_sideColumn_projectHero_year_Read
+  update: PostsFields_layout_sideColumn_projectHero_year_Update
+  delete: PostsFields_layout_sideColumn_projectHero_year_Delete
+}
+
+type PostsFields_layout_sideColumn_projectHero_year_Create {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_projectHero_year_Read {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_projectHero_year_Update {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_projectHero_year_Delete {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_projectHero_client {
+  create: PostsFields_layout_sideColumn_projectHero_client_Create
+  read: PostsFields_layout_sideColumn_projectHero_client_Read
+  update: PostsFields_layout_sideColumn_projectHero_client_Update
+  delete: PostsFields_layout_sideColumn_projectHero_client_Delete
+}
+
+type PostsFields_layout_sideColumn_projectHero_client_Create {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_projectHero_client_Read {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_projectHero_client_Update {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_projectHero_client_Delete {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_projectHero_links {
+  create: PostsFields_layout_sideColumn_projectHero_links_Create
+  read: PostsFields_layout_sideColumn_projectHero_links_Read
+  update: PostsFields_layout_sideColumn_projectHero_links_Update
+  delete: PostsFields_layout_sideColumn_projectHero_links_Delete
+  fields: PostsFields_layout_sideColumn_projectHero_links_Fields
+}
+
+type PostsFields_layout_sideColumn_projectHero_links_Create {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_projectHero_links_Read {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_projectHero_links_Update {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_projectHero_links_Delete {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_projectHero_links_Fields {
+  link: PostsFields_layout_sideColumn_projectHero_links_link
+  id: PostsFields_layout_sideColumn_projectHero_links_id
+}
+
+type PostsFields_layout_sideColumn_projectHero_links_link {
+  create: PostsFields_layout_sideColumn_projectHero_links_link_Create
+  read: PostsFields_layout_sideColumn_projectHero_links_link_Read
+  update: PostsFields_layout_sideColumn_projectHero_links_link_Update
+  delete: PostsFields_layout_sideColumn_projectHero_links_link_Delete
+  fields: PostsFields_layout_sideColumn_projectHero_links_link_Fields
+}
+
+type PostsFields_layout_sideColumn_projectHero_links_link_Create {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_projectHero_links_link_Read {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_projectHero_links_link_Update {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_projectHero_links_link_Delete {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_projectHero_links_link_Fields {
+  type: PostsFields_layout_sideColumn_projectHero_links_link_type
+  newTab: PostsFields_layout_sideColumn_projectHero_links_link_newTab
+  reference: PostsFields_layout_sideColumn_projectHero_links_link_reference
+  url: PostsFields_layout_sideColumn_projectHero_links_link_url
+  label: PostsFields_layout_sideColumn_projectHero_links_link_label
+  appearance: PostsFields_layout_sideColumn_projectHero_links_link_appearance
+}
+
+type PostsFields_layout_sideColumn_projectHero_links_link_type {
+  create: PostsFields_layout_sideColumn_projectHero_links_link_type_Create
+  read: PostsFields_layout_sideColumn_projectHero_links_link_type_Read
+  update: PostsFields_layout_sideColumn_projectHero_links_link_type_Update
+  delete: PostsFields_layout_sideColumn_projectHero_links_link_type_Delete
+}
+
+type PostsFields_layout_sideColumn_projectHero_links_link_type_Create {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_projectHero_links_link_type_Read {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_projectHero_links_link_type_Update {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_projectHero_links_link_type_Delete {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_projectHero_links_link_newTab {
+  create: PostsFields_layout_sideColumn_projectHero_links_link_newTab_Create
+  read: PostsFields_layout_sideColumn_projectHero_links_link_newTab_Read
+  update: PostsFields_layout_sideColumn_projectHero_links_link_newTab_Update
+  delete: PostsFields_layout_sideColumn_projectHero_links_link_newTab_Delete
+}
+
+type PostsFields_layout_sideColumn_projectHero_links_link_newTab_Create {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_projectHero_links_link_newTab_Read {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_projectHero_links_link_newTab_Update {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_projectHero_links_link_newTab_Delete {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_projectHero_links_link_reference {
+  create: PostsFields_layout_sideColumn_projectHero_links_link_reference_Create
+  read: PostsFields_layout_sideColumn_projectHero_links_link_reference_Read
+  update: PostsFields_layout_sideColumn_projectHero_links_link_reference_Update
+  delete: PostsFields_layout_sideColumn_projectHero_links_link_reference_Delete
+}
+
+type PostsFields_layout_sideColumn_projectHero_links_link_reference_Create {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_projectHero_links_link_reference_Read {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_projectHero_links_link_reference_Update {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_projectHero_links_link_reference_Delete {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_projectHero_links_link_url {
+  create: PostsFields_layout_sideColumn_projectHero_links_link_url_Create
+  read: PostsFields_layout_sideColumn_projectHero_links_link_url_Read
+  update: PostsFields_layout_sideColumn_projectHero_links_link_url_Update
+  delete: PostsFields_layout_sideColumn_projectHero_links_link_url_Delete
+}
+
+type PostsFields_layout_sideColumn_projectHero_links_link_url_Create {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_projectHero_links_link_url_Read {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_projectHero_links_link_url_Update {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_projectHero_links_link_url_Delete {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_projectHero_links_link_label {
+  create: PostsFields_layout_sideColumn_projectHero_links_link_label_Create
+  read: PostsFields_layout_sideColumn_projectHero_links_link_label_Read
+  update: PostsFields_layout_sideColumn_projectHero_links_link_label_Update
+  delete: PostsFields_layout_sideColumn_projectHero_links_link_label_Delete
+}
+
+type PostsFields_layout_sideColumn_projectHero_links_link_label_Create {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_projectHero_links_link_label_Read {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_projectHero_links_link_label_Update {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_projectHero_links_link_label_Delete {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_projectHero_links_link_appearance {
+  create: PostsFields_layout_sideColumn_projectHero_links_link_appearance_Create
+  read: PostsFields_layout_sideColumn_projectHero_links_link_appearance_Read
+  update: PostsFields_layout_sideColumn_projectHero_links_link_appearance_Update
+  delete: PostsFields_layout_sideColumn_projectHero_links_link_appearance_Delete
+}
+
+type PostsFields_layout_sideColumn_projectHero_links_link_appearance_Create {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_projectHero_links_link_appearance_Read {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_projectHero_links_link_appearance_Update {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_projectHero_links_link_appearance_Delete {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_projectHero_links_id {
+  create: PostsFields_layout_sideColumn_projectHero_links_id_Create
+  read: PostsFields_layout_sideColumn_projectHero_links_id_Read
+  update: PostsFields_layout_sideColumn_projectHero_links_id_Update
+  delete: PostsFields_layout_sideColumn_projectHero_links_id_Delete
+}
+
+type PostsFields_layout_sideColumn_projectHero_links_id_Create {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_projectHero_links_id_Read {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_projectHero_links_id_Update {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_projectHero_links_id_Delete {
   permission: Boolean!
 }
 
@@ -11400,461 +12774,125 @@ type PostsFields_layout_mainColumn_Delete {
 }
 
 type PostsFields_layout_mainColumn_Fields {
-  layoutStyle: PostsFields_layout_mainColumn_layoutStyle
-  singleLayout: PostsFields_layout_mainColumn_singleLayout
-  twoRows: PostsFields_layout_mainColumn_twoRows
-  twoColumns: PostsFields_layout_mainColumn_twoColumns
-  threeColumns: PostsFields_layout_mainColumn_threeColumns
-  threeSectionGrid: PostsFields_layout_mainColumn_threeSectionGrid
+  style: PostsFields_layout_mainColumn_style
+  row1column1: PostsFields_layout_mainColumn_row1column1
+  row1column2: PostsFields_layout_mainColumn_row1column2
+  row2column1: PostsFields_layout_mainColumn_row2column1
+  row2column2: PostsFields_layout_mainColumn_row2column2
 }
 
-type PostsFields_layout_mainColumn_layoutStyle {
-  create: PostsFields_layout_mainColumn_layoutStyle_Create
-  read: PostsFields_layout_mainColumn_layoutStyle_Read
-  update: PostsFields_layout_mainColumn_layoutStyle_Update
-  delete: PostsFields_layout_mainColumn_layoutStyle_Delete
+type PostsFields_layout_mainColumn_style {
+  create: PostsFields_layout_mainColumn_style_Create
+  read: PostsFields_layout_mainColumn_style_Read
+  update: PostsFields_layout_mainColumn_style_Update
+  delete: PostsFields_layout_mainColumn_style_Delete
 }
 
-type PostsFields_layout_mainColumn_layoutStyle_Create {
+type PostsFields_layout_mainColumn_style_Create {
   permission: Boolean!
 }
 
-type PostsFields_layout_mainColumn_layoutStyle_Read {
+type PostsFields_layout_mainColumn_style_Read {
   permission: Boolean!
 }
 
-type PostsFields_layout_mainColumn_layoutStyle_Update {
+type PostsFields_layout_mainColumn_style_Update {
   permission: Boolean!
 }
 
-type PostsFields_layout_mainColumn_layoutStyle_Delete {
+type PostsFields_layout_mainColumn_style_Delete {
   permission: Boolean!
 }
 
-type PostsFields_layout_mainColumn_singleLayout {
-  create: PostsFields_layout_mainColumn_singleLayout_Create
-  read: PostsFields_layout_mainColumn_singleLayout_Read
-  update: PostsFields_layout_mainColumn_singleLayout_Update
-  delete: PostsFields_layout_mainColumn_singleLayout_Delete
-  fields: PostsFields_layout_mainColumn_singleLayout_Fields
+type PostsFields_layout_mainColumn_row1column1 {
+  create: PostsFields_layout_mainColumn_row1column1_Create
+  read: PostsFields_layout_mainColumn_row1column1_Read
+  update: PostsFields_layout_mainColumn_row1column1_Update
+  delete: PostsFields_layout_mainColumn_row1column1_Delete
 }
 
-type PostsFields_layout_mainColumn_singleLayout_Create {
+type PostsFields_layout_mainColumn_row1column1_Create {
   permission: Boolean!
 }
 
-type PostsFields_layout_mainColumn_singleLayout_Read {
+type PostsFields_layout_mainColumn_row1column1_Read {
   permission: Boolean!
 }
 
-type PostsFields_layout_mainColumn_singleLayout_Update {
+type PostsFields_layout_mainColumn_row1column1_Update {
   permission: Boolean!
 }
 
-type PostsFields_layout_mainColumn_singleLayout_Delete {
+type PostsFields_layout_mainColumn_row1column1_Delete {
   permission: Boolean!
 }
 
-type PostsFields_layout_mainColumn_singleLayout_Fields {
-  singleLayout1: PostsFields_layout_mainColumn_singleLayout_singleLayout1
+type PostsFields_layout_mainColumn_row1column2 {
+  create: PostsFields_layout_mainColumn_row1column2_Create
+  read: PostsFields_layout_mainColumn_row1column2_Read
+  update: PostsFields_layout_mainColumn_row1column2_Update
+  delete: PostsFields_layout_mainColumn_row1column2_Delete
 }
 
-type PostsFields_layout_mainColumn_singleLayout_singleLayout1 {
-  create: PostsFields_layout_mainColumn_singleLayout_singleLayout1_Create
-  read: PostsFields_layout_mainColumn_singleLayout_singleLayout1_Read
-  update: PostsFields_layout_mainColumn_singleLayout_singleLayout1_Update
-  delete: PostsFields_layout_mainColumn_singleLayout_singleLayout1_Delete
-}
-
-type PostsFields_layout_mainColumn_singleLayout_singleLayout1_Create {
-  permission: Boolean!
-}
-
-type PostsFields_layout_mainColumn_singleLayout_singleLayout1_Read {
-  permission: Boolean!
-}
-
-type PostsFields_layout_mainColumn_singleLayout_singleLayout1_Update {
-  permission: Boolean!
-}
-
-type PostsFields_layout_mainColumn_singleLayout_singleLayout1_Delete {
-  permission: Boolean!
-}
-
-type PostsFields_layout_mainColumn_twoRows {
-  create: PostsFields_layout_mainColumn_twoRows_Create
-  read: PostsFields_layout_mainColumn_twoRows_Read
-  update: PostsFields_layout_mainColumn_twoRows_Update
-  delete: PostsFields_layout_mainColumn_twoRows_Delete
-  fields: PostsFields_layout_mainColumn_twoRows_Fields
-}
-
-type PostsFields_layout_mainColumn_twoRows_Create {
-  permission: Boolean!
-}
-
-type PostsFields_layout_mainColumn_twoRows_Read {
-  permission: Boolean!
-}
-
-type PostsFields_layout_mainColumn_twoRows_Update {
-  permission: Boolean!
-}
-
-type PostsFields_layout_mainColumn_twoRows_Delete {
-  permission: Boolean!
-}
-
-type PostsFields_layout_mainColumn_twoRows_Fields {
-  row1: PostsFields_layout_mainColumn_twoRows_row1
-  row2: PostsFields_layout_mainColumn_twoRows_row2
-}
-
-type PostsFields_layout_mainColumn_twoRows_row1 {
-  create: PostsFields_layout_mainColumn_twoRows_row1_Create
-  read: PostsFields_layout_mainColumn_twoRows_row1_Read
-  update: PostsFields_layout_mainColumn_twoRows_row1_Update
-  delete: PostsFields_layout_mainColumn_twoRows_row1_Delete
-}
-
-type PostsFields_layout_mainColumn_twoRows_row1_Create {
-  permission: Boolean!
-}
-
-type PostsFields_layout_mainColumn_twoRows_row1_Read {
-  permission: Boolean!
-}
-
-type PostsFields_layout_mainColumn_twoRows_row1_Update {
-  permission: Boolean!
-}
-
-type PostsFields_layout_mainColumn_twoRows_row1_Delete {
-  permission: Boolean!
-}
-
-type PostsFields_layout_mainColumn_twoRows_row2 {
-  create: PostsFields_layout_mainColumn_twoRows_row2_Create
-  read: PostsFields_layout_mainColumn_twoRows_row2_Read
-  update: PostsFields_layout_mainColumn_twoRows_row2_Update
-  delete: PostsFields_layout_mainColumn_twoRows_row2_Delete
-}
-
-type PostsFields_layout_mainColumn_twoRows_row2_Create {
-  permission: Boolean!
-}
-
-type PostsFields_layout_mainColumn_twoRows_row2_Read {
-  permission: Boolean!
-}
-
-type PostsFields_layout_mainColumn_twoRows_row2_Update {
-  permission: Boolean!
-}
-
-type PostsFields_layout_mainColumn_twoRows_row2_Delete {
-  permission: Boolean!
-}
-
-type PostsFields_layout_mainColumn_twoColumns {
-  create: PostsFields_layout_mainColumn_twoColumns_Create
-  read: PostsFields_layout_mainColumn_twoColumns_Read
-  update: PostsFields_layout_mainColumn_twoColumns_Update
-  delete: PostsFields_layout_mainColumn_twoColumns_Delete
-  fields: PostsFields_layout_mainColumn_twoColumns_Fields
-}
-
-type PostsFields_layout_mainColumn_twoColumns_Create {
-  permission: Boolean!
-}
-
-type PostsFields_layout_mainColumn_twoColumns_Read {
-  permission: Boolean!
-}
-
-type PostsFields_layout_mainColumn_twoColumns_Update {
-  permission: Boolean!
-}
-
-type PostsFields_layout_mainColumn_twoColumns_Delete {
-  permission: Boolean!
-}
-
-type PostsFields_layout_mainColumn_twoColumns_Fields {
-  col1: PostsFields_layout_mainColumn_twoColumns_col1
-  col2: PostsFields_layout_mainColumn_twoColumns_col2
-}
-
-type PostsFields_layout_mainColumn_twoColumns_col1 {
-  create: PostsFields_layout_mainColumn_twoColumns_col1_Create
-  read: PostsFields_layout_mainColumn_twoColumns_col1_Read
-  update: PostsFields_layout_mainColumn_twoColumns_col1_Update
-  delete: PostsFields_layout_mainColumn_twoColumns_col1_Delete
-}
-
-type PostsFields_layout_mainColumn_twoColumns_col1_Create {
-  permission: Boolean!
-}
-
-type PostsFields_layout_mainColumn_twoColumns_col1_Read {
-  permission: Boolean!
-}
-
-type PostsFields_layout_mainColumn_twoColumns_col1_Update {
-  permission: Boolean!
-}
-
-type PostsFields_layout_mainColumn_twoColumns_col1_Delete {
-  permission: Boolean!
-}
-
-type PostsFields_layout_mainColumn_twoColumns_col2 {
-  create: PostsFields_layout_mainColumn_twoColumns_col2_Create
-  read: PostsFields_layout_mainColumn_twoColumns_col2_Read
-  update: PostsFields_layout_mainColumn_twoColumns_col2_Update
-  delete: PostsFields_layout_mainColumn_twoColumns_col2_Delete
-}
-
-type PostsFields_layout_mainColumn_twoColumns_col2_Create {
-  permission: Boolean!
-}
-
-type PostsFields_layout_mainColumn_twoColumns_col2_Read {
-  permission: Boolean!
-}
-
-type PostsFields_layout_mainColumn_twoColumns_col2_Update {
-  permission: Boolean!
-}
-
-type PostsFields_layout_mainColumn_twoColumns_col2_Delete {
-  permission: Boolean!
-}
-
-type PostsFields_layout_mainColumn_threeColumns {
-  create: PostsFields_layout_mainColumn_threeColumns_Create
-  read: PostsFields_layout_mainColumn_threeColumns_Read
-  update: PostsFields_layout_mainColumn_threeColumns_Update
-  delete: PostsFields_layout_mainColumn_threeColumns_Delete
-  fields: PostsFields_layout_mainColumn_threeColumns_Fields
-}
-
-type PostsFields_layout_mainColumn_threeColumns_Create {
-  permission: Boolean!
-}
-
-type PostsFields_layout_mainColumn_threeColumns_Read {
-  permission: Boolean!
-}
-
-type PostsFields_layout_mainColumn_threeColumns_Update {
-  permission: Boolean!
-}
-
-type PostsFields_layout_mainColumn_threeColumns_Delete {
-  permission: Boolean!
-}
-
-type PostsFields_layout_mainColumn_threeColumns_Fields {
-  col1: PostsFields_layout_mainColumn_threeColumns_col1
-  col2: PostsFields_layout_mainColumn_threeColumns_col2
-  col3: PostsFields_layout_mainColumn_threeColumns_col3
-}
-
-type PostsFields_layout_mainColumn_threeColumns_col1 {
-  create: PostsFields_layout_mainColumn_threeColumns_col1_Create
-  read: PostsFields_layout_mainColumn_threeColumns_col1_Read
-  update: PostsFields_layout_mainColumn_threeColumns_col1_Update
-  delete: PostsFields_layout_mainColumn_threeColumns_col1_Delete
-}
-
-type PostsFields_layout_mainColumn_threeColumns_col1_Create {
-  permission: Boolean!
-}
-
-type PostsFields_layout_mainColumn_threeColumns_col1_Read {
-  permission: Boolean!
-}
-
-type PostsFields_layout_mainColumn_threeColumns_col1_Update {
-  permission: Boolean!
-}
-
-type PostsFields_layout_mainColumn_threeColumns_col1_Delete {
-  permission: Boolean!
-}
-
-type PostsFields_layout_mainColumn_threeColumns_col2 {
-  create: PostsFields_layout_mainColumn_threeColumns_col2_Create
-  read: PostsFields_layout_mainColumn_threeColumns_col2_Read
-  update: PostsFields_layout_mainColumn_threeColumns_col2_Update
-  delete: PostsFields_layout_mainColumn_threeColumns_col2_Delete
-}
-
-type PostsFields_layout_mainColumn_threeColumns_col2_Create {
-  permission: Boolean!
-}
-
-type PostsFields_layout_mainColumn_threeColumns_col2_Read {
-  permission: Boolean!
-}
-
-type PostsFields_layout_mainColumn_threeColumns_col2_Update {
-  permission: Boolean!
-}
-
-type PostsFields_layout_mainColumn_threeColumns_col2_Delete {
-  permission: Boolean!
-}
-
-type PostsFields_layout_mainColumn_threeColumns_col3 {
-  create: PostsFields_layout_mainColumn_threeColumns_col3_Create
-  read: PostsFields_layout_mainColumn_threeColumns_col3_Read
-  update: PostsFields_layout_mainColumn_threeColumns_col3_Update
-  delete: PostsFields_layout_mainColumn_threeColumns_col3_Delete
-}
-
-type PostsFields_layout_mainColumn_threeColumns_col3_Create {
-  permission: Boolean!
-}
-
-type PostsFields_layout_mainColumn_threeColumns_col3_Read {
-  permission: Boolean!
-}
-
-type PostsFields_layout_mainColumn_threeColumns_col3_Update {
-  permission: Boolean!
-}
-
-type PostsFields_layout_mainColumn_threeColumns_col3_Delete {
-  permission: Boolean!
-}
-
-type PostsFields_layout_mainColumn_threeSectionGrid {
-  create: PostsFields_layout_mainColumn_threeSectionGrid_Create
-  read: PostsFields_layout_mainColumn_threeSectionGrid_Read
-  update: PostsFields_layout_mainColumn_threeSectionGrid_Update
-  delete: PostsFields_layout_mainColumn_threeSectionGrid_Delete
-  fields: PostsFields_layout_mainColumn_threeSectionGrid_Fields
-}
-
-type PostsFields_layout_mainColumn_threeSectionGrid_Create {
-  permission: Boolean!
-}
-
-type PostsFields_layout_mainColumn_threeSectionGrid_Read {
-  permission: Boolean!
-}
-
-type PostsFields_layout_mainColumn_threeSectionGrid_Update {
-  permission: Boolean!
-}
-
-type PostsFields_layout_mainColumn_threeSectionGrid_Delete {
-  permission: Boolean!
-}
-
-type PostsFields_layout_mainColumn_threeSectionGrid_Fields {
-  left: PostsFields_layout_mainColumn_threeSectionGrid_left
-  right: PostsFields_layout_mainColumn_threeSectionGrid_right
-}
-
-type PostsFields_layout_mainColumn_threeSectionGrid_left {
-  create: PostsFields_layout_mainColumn_threeSectionGrid_left_Create
-  read: PostsFields_layout_mainColumn_threeSectionGrid_left_Read
-  update: PostsFields_layout_mainColumn_threeSectionGrid_left_Update
-  delete: PostsFields_layout_mainColumn_threeSectionGrid_left_Delete
-}
-
-type PostsFields_layout_mainColumn_threeSectionGrid_left_Create {
-  permission: Boolean!
-}
-
-type PostsFields_layout_mainColumn_threeSectionGrid_left_Read {
+type PostsFields_layout_mainColumn_row1column2_Create {
   permission: Boolean!
 }
 
-type PostsFields_layout_mainColumn_threeSectionGrid_left_Update {
+type PostsFields_layout_mainColumn_row1column2_Read {
   permission: Boolean!
 }
 
-type PostsFields_layout_mainColumn_threeSectionGrid_left_Delete {
+type PostsFields_layout_mainColumn_row1column2_Update {
   permission: Boolean!
 }
 
-type PostsFields_layout_mainColumn_threeSectionGrid_right {
-  create: PostsFields_layout_mainColumn_threeSectionGrid_right_Create
-  read: PostsFields_layout_mainColumn_threeSectionGrid_right_Read
-  update: PostsFields_layout_mainColumn_threeSectionGrid_right_Update
-  delete: PostsFields_layout_mainColumn_threeSectionGrid_right_Delete
-  fields: PostsFields_layout_mainColumn_threeSectionGrid_right_Fields
-}
-
-type PostsFields_layout_mainColumn_threeSectionGrid_right_Create {
-  permission: Boolean!
-}
-
-type PostsFields_layout_mainColumn_threeSectionGrid_right_Read {
-  permission: Boolean!
-}
-
-type PostsFields_layout_mainColumn_threeSectionGrid_right_Update {
-  permission: Boolean!
-}
-
-type PostsFields_layout_mainColumn_threeSectionGrid_right_Delete {
+type PostsFields_layout_mainColumn_row1column2_Delete {
   permission: Boolean!
-}
-
-type PostsFields_layout_mainColumn_threeSectionGrid_right_Fields {
-  rightTop: PostsFields_layout_mainColumn_threeSectionGrid_right_rightTop
-  rightBottom: PostsFields_layout_mainColumn_threeSectionGrid_right_rightBottom
 }
 
-type PostsFields_layout_mainColumn_threeSectionGrid_right_rightTop {
-  create: PostsFields_layout_mainColumn_threeSectionGrid_right_rightTop_Create
-  read: PostsFields_layout_mainColumn_threeSectionGrid_right_rightTop_Read
-  update: PostsFields_layout_mainColumn_threeSectionGrid_right_rightTop_Update
-  delete: PostsFields_layout_mainColumn_threeSectionGrid_right_rightTop_Delete
+type PostsFields_layout_mainColumn_row2column1 {
+  create: PostsFields_layout_mainColumn_row2column1_Create
+  read: PostsFields_layout_mainColumn_row2column1_Read
+  update: PostsFields_layout_mainColumn_row2column1_Update
+  delete: PostsFields_layout_mainColumn_row2column1_Delete
 }
 
-type PostsFields_layout_mainColumn_threeSectionGrid_right_rightTop_Create {
+type PostsFields_layout_mainColumn_row2column1_Create {
   permission: Boolean!
 }
 
-type PostsFields_layout_mainColumn_threeSectionGrid_right_rightTop_Read {
+type PostsFields_layout_mainColumn_row2column1_Read {
   permission: Boolean!
 }
 
-type PostsFields_layout_mainColumn_threeSectionGrid_right_rightTop_Update {
+type PostsFields_layout_mainColumn_row2column1_Update {
   permission: Boolean!
 }
 
-type PostsFields_layout_mainColumn_threeSectionGrid_right_rightTop_Delete {
+type PostsFields_layout_mainColumn_row2column1_Delete {
   permission: Boolean!
 }
 
-type PostsFields_layout_mainColumn_threeSectionGrid_right_rightBottom {
-  create: PostsFields_layout_mainColumn_threeSectionGrid_right_rightBottom_Create
-  read: PostsFields_layout_mainColumn_threeSectionGrid_right_rightBottom_Read
-  update: PostsFields_layout_mainColumn_threeSectionGrid_right_rightBottom_Update
-  delete: PostsFields_layout_mainColumn_threeSectionGrid_right_rightBottom_Delete
+type PostsFields_layout_mainColumn_row2column2 {
+  create: PostsFields_layout_mainColumn_row2column2_Create
+  read: PostsFields_layout_mainColumn_row2column2_Read
+  update: PostsFields_layout_mainColumn_row2column2_Update
+  delete: PostsFields_layout_mainColumn_row2column2_Delete
 }
 
-type PostsFields_layout_mainColumn_threeSectionGrid_right_rightBottom_Create {
+type PostsFields_layout_mainColumn_row2column2_Create {
   permission: Boolean!
 }
 
-type PostsFields_layout_mainColumn_threeSectionGrid_right_rightBottom_Read {
+type PostsFields_layout_mainColumn_row2column2_Read {
   permission: Boolean!
 }
 
-type PostsFields_layout_mainColumn_threeSectionGrid_right_rightBottom_Update {
+type PostsFields_layout_mainColumn_row2column2_Update {
   permission: Boolean!
 }
 
-type PostsFields_layout_mainColumn_threeSectionGrid_right_rightBottom_Delete {
+type PostsFields_layout_mainColumn_row2column2_Delete {
   permission: Boolean!
 }
 
@@ -11904,29 +12942,6 @@ type PostsFields_relatedPosts_Delete {
   permission: Boolean!
 }
 
-type PostsFields_slug {
-  create: PostsFields_slug_Create
-  read: PostsFields_slug_Read
-  update: PostsFields_slug_Update
-  delete: PostsFields_slug_Delete
-}
-
-type PostsFields_slug_Create {
-  permission: Boolean!
-}
-
-type PostsFields_slug_Read {
-  permission: Boolean!
-}
-
-type PostsFields_slug_Update {
-  permission: Boolean!
-}
-
-type PostsFields_slug_Delete {
-  permission: Boolean!
-}
-
 type PostsFields_meta {
   create: PostsFields_meta_Create
   read: PostsFields_meta_Read
@@ -11952,34 +12967,9 @@ type PostsFields_meta_Delete {
 }
 
 type PostsFields_meta_Fields {
-  overview: PostsFields_meta_overview
   title: PostsFields_meta_title
   description: PostsFields_meta_description
   image: PostsFields_meta_image
-  preview: PostsFields_meta_preview
-}
-
-type PostsFields_meta_overview {
-  create: PostsFields_meta_overview_Create
-  read: PostsFields_meta_overview_Read
-  update: PostsFields_meta_overview_Update
-  delete: PostsFields_meta_overview_Delete
-}
-
-type PostsFields_meta_overview_Create {
-  permission: Boolean!
-}
-
-type PostsFields_meta_overview_Read {
-  permission: Boolean!
-}
-
-type PostsFields_meta_overview_Update {
-  permission: Boolean!
-}
-
-type PostsFields_meta_overview_Delete {
-  permission: Boolean!
 }
 
 type PostsFields_meta_title {
@@ -12048,29 +13038,6 @@ type PostsFields_meta_image_Update {
 }
 
 type PostsFields_meta_image_Delete {
-  permission: Boolean!
-}
-
-type PostsFields_meta_preview {
-  create: PostsFields_meta_preview_Create
-  read: PostsFields_meta_preview_Read
-  update: PostsFields_meta_preview_Update
-  delete: PostsFields_meta_preview_Delete
-}
-
-type PostsFields_meta_preview_Create {
-  permission: Boolean!
-}
-
-type PostsFields_meta_preview_Read {
-  permission: Boolean!
-}
-
-type PostsFields_meta_preview_Update {
-  permission: Boolean!
-}
-
-type PostsFields_meta_preview_Delete {
   permission: Boolean!
 }
 
@@ -12463,105 +13430,105 @@ type MediaDeleteAccess {
   where: JSONObject
 }
 
-type categoriesAccess {
-  fields: CategoriesFields
-  create: CategoriesCreateAccess
-  read: CategoriesReadAccess
-  update: CategoriesUpdateAccess
-  delete: CategoriesDeleteAccess
+type categoryAccess {
+  fields: CategoryFields
+  create: CategoryCreateAccess
+  read: CategoryReadAccess
+  update: CategoryUpdateAccess
+  delete: CategoryDeleteAccess
 }
 
-type CategoriesFields {
-  title: CategoriesFields_title
-  updatedAt: CategoriesFields_updatedAt
-  createdAt: CategoriesFields_createdAt
+type CategoryFields {
+  title: CategoryFields_title
+  updatedAt: CategoryFields_updatedAt
+  createdAt: CategoryFields_createdAt
 }
 
-type CategoriesFields_title {
-  create: CategoriesFields_title_Create
-  read: CategoriesFields_title_Read
-  update: CategoriesFields_title_Update
-  delete: CategoriesFields_title_Delete
+type CategoryFields_title {
+  create: CategoryFields_title_Create
+  read: CategoryFields_title_Read
+  update: CategoryFields_title_Update
+  delete: CategoryFields_title_Delete
 }
 
-type CategoriesFields_title_Create {
+type CategoryFields_title_Create {
   permission: Boolean!
 }
 
-type CategoriesFields_title_Read {
+type CategoryFields_title_Read {
   permission: Boolean!
 }
 
-type CategoriesFields_title_Update {
+type CategoryFields_title_Update {
   permission: Boolean!
 }
 
-type CategoriesFields_title_Delete {
+type CategoryFields_title_Delete {
   permission: Boolean!
 }
 
-type CategoriesFields_updatedAt {
-  create: CategoriesFields_updatedAt_Create
-  read: CategoriesFields_updatedAt_Read
-  update: CategoriesFields_updatedAt_Update
-  delete: CategoriesFields_updatedAt_Delete
+type CategoryFields_updatedAt {
+  create: CategoryFields_updatedAt_Create
+  read: CategoryFields_updatedAt_Read
+  update: CategoryFields_updatedAt_Update
+  delete: CategoryFields_updatedAt_Delete
 }
 
-type CategoriesFields_updatedAt_Create {
+type CategoryFields_updatedAt_Create {
   permission: Boolean!
 }
 
-type CategoriesFields_updatedAt_Read {
+type CategoryFields_updatedAt_Read {
   permission: Boolean!
 }
 
-type CategoriesFields_updatedAt_Update {
+type CategoryFields_updatedAt_Update {
   permission: Boolean!
 }
 
-type CategoriesFields_updatedAt_Delete {
+type CategoryFields_updatedAt_Delete {
   permission: Boolean!
 }
 
-type CategoriesFields_createdAt {
-  create: CategoriesFields_createdAt_Create
-  read: CategoriesFields_createdAt_Read
-  update: CategoriesFields_createdAt_Update
-  delete: CategoriesFields_createdAt_Delete
+type CategoryFields_createdAt {
+  create: CategoryFields_createdAt_Create
+  read: CategoryFields_createdAt_Read
+  update: CategoryFields_createdAt_Update
+  delete: CategoryFields_createdAt_Delete
 }
 
-type CategoriesFields_createdAt_Create {
+type CategoryFields_createdAt_Create {
   permission: Boolean!
 }
 
-type CategoriesFields_createdAt_Read {
+type CategoryFields_createdAt_Read {
   permission: Boolean!
 }
 
-type CategoriesFields_createdAt_Update {
+type CategoryFields_createdAt_Update {
   permission: Boolean!
 }
 
-type CategoriesFields_createdAt_Delete {
+type CategoryFields_createdAt_Delete {
   permission: Boolean!
 }
 
-type CategoriesCreateAccess {
-  permission: Boolean!
-  where: JSONObject
-}
-
-type CategoriesReadAccess {
+type CategoryCreateAccess {
   permission: Boolean!
   where: JSONObject
 }
 
-type CategoriesUpdateAccess {
+type CategoryReadAccess {
   permission: Boolean!
   where: JSONObject
 }
 
-type CategoriesDeleteAccess {
+type CategoryUpdateAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type CategoryDeleteAccess {
   permission: Boolean!
   where: JSONObject
 }
@@ -12813,6 +13780,109 @@ type KeywordsUpdateAccess {
 }
 
 type KeywordsDeleteAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type clientsAccess {
+  fields: ClientsFields
+  create: ClientsCreateAccess
+  read: ClientsReadAccess
+  update: ClientsUpdateAccess
+  delete: ClientsDeleteAccess
+}
+
+type ClientsFields {
+  title: ClientsFields_title
+  updatedAt: ClientsFields_updatedAt
+  createdAt: ClientsFields_createdAt
+}
+
+type ClientsFields_title {
+  create: ClientsFields_title_Create
+  read: ClientsFields_title_Read
+  update: ClientsFields_title_Update
+  delete: ClientsFields_title_Delete
+}
+
+type ClientsFields_title_Create {
+  permission: Boolean!
+}
+
+type ClientsFields_title_Read {
+  permission: Boolean!
+}
+
+type ClientsFields_title_Update {
+  permission: Boolean!
+}
+
+type ClientsFields_title_Delete {
+  permission: Boolean!
+}
+
+type ClientsFields_updatedAt {
+  create: ClientsFields_updatedAt_Create
+  read: ClientsFields_updatedAt_Read
+  update: ClientsFields_updatedAt_Update
+  delete: ClientsFields_updatedAt_Delete
+}
+
+type ClientsFields_updatedAt_Create {
+  permission: Boolean!
+}
+
+type ClientsFields_updatedAt_Read {
+  permission: Boolean!
+}
+
+type ClientsFields_updatedAt_Update {
+  permission: Boolean!
+}
+
+type ClientsFields_updatedAt_Delete {
+  permission: Boolean!
+}
+
+type ClientsFields_createdAt {
+  create: ClientsFields_createdAt_Create
+  read: ClientsFields_createdAt_Read
+  update: ClientsFields_createdAt_Update
+  delete: ClientsFields_createdAt_Delete
+}
+
+type ClientsFields_createdAt_Create {
+  permission: Boolean!
+}
+
+type ClientsFields_createdAt_Read {
+  permission: Boolean!
+}
+
+type ClientsFields_createdAt_Update {
+  permission: Boolean!
+}
+
+type ClientsFields_createdAt_Delete {
+  permission: Boolean!
+}
+
+type ClientsCreateAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type ClientsReadAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type ClientsUpdateAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type ClientsDeleteAccess {
   permission: Boolean!
   where: JSONObject
 }
@@ -13848,6 +14918,9 @@ type Mutation {
   createKeyword(data: mutationKeywordInput!, draft: Boolean): Keyword
   updateKeyword(id: Int!, autosave: Boolean, data: mutationKeywordUpdateInput!, draft: Boolean): Keyword
   deleteKeyword(id: Int!): Keyword
+  createClient(data: mutationClientInput!, draft: Boolean): Client
+  updateClient(id: Int!, autosave: Boolean, data: mutationClientUpdateInput!, draft: Boolean): Client
+  deleteClient(id: Int!): Client
   createUser(data: mutationUserInput!, draft: Boolean): User
   updateUser(id: Int!, autosave: Boolean, data: mutationUserUpdateInput!, draft: Boolean): User
   deleteUser(id: Int!): User
@@ -13872,7 +14945,6 @@ input mutationPageInput {
   title: String!
   publishedAt: String
   slug: String
-  hero: mutationPage_HeroInput!
   layout: [mutationPage_LayoutInput]
   meta: mutationPage_MetaInput
   updatedAt: String
@@ -13880,50 +14952,8 @@ input mutationPageInput {
   _status: Page__status_MutationInput
 }
 
-input mutationPage_HeroInput {
-  type: Page_Hero_type_MutationInput!
-  description: JSON
-  links: [mutationPage_Hero_LinksInput]
-}
-
-enum Page_Hero_type_MutationInput {
-  none
-  fixedSidePanel
-  halfPage
-  fullPage
-}
-
-input mutationPage_Hero_LinksInput {
-  link: mutationPage_Hero_Links_LinkInput
-  id: String
-}
-
-input mutationPage_Hero_Links_LinkInput {
-  type: String
-  newTab: Boolean
-  reference: Page_Hero_Links_Link_ReferenceRelationshipInput
-  url: String
-  label: String!
-  appearance: Page_Hero_Links_Link_appearance_MutationInput
-}
-
-input Page_Hero_Links_Link_ReferenceRelationshipInput {
-  relationTo: Page_Hero_Links_Link_ReferenceRelationshipInputRelationTo
-  value: JSON
-}
-
-enum Page_Hero_Links_Link_ReferenceRelationshipInputRelationTo {
-  pages
-}
-
-enum Page_Hero_Links_Link_appearance_MutationInput {
-  default
-  primary
-  secondary
-}
-
 input mutationPage_LayoutInput {
-  fixedSideContent: Boolean
+  sideContentPosition: Page_Layout_sideContentPosition_MutationInput!
   scrollSnap: Boolean
   fullPageHeight: Boolean
   sideColumn: mutationPage_Layout_SideColumnInput!
@@ -13931,62 +14961,112 @@ input mutationPage_LayoutInput {
   id: String
 }
 
+enum Page_Layout_sideContentPosition_MutationInput {
+  scrollSideContent
+  fixedSideContentWhenVisible
+  fixedSideContentAlways
+}
+
 input mutationPage_Layout_SideColumnInput {
-  sideStyle: Page_Layout_SideColumn_sideStyle_MutationInput!
+  style: Page_Layout_SideColumn_style_MutationInput!
+  hero: mutationPage_Layout_SideColumn_HeroInput
+  projectHero: mutationPage_Layout_SideColumn_ProjectHeroInput
   sideContent1: JSON
   sideContent2: JSON
 }
 
-enum Page_Layout_SideColumn_sideStyle_MutationInput {
+enum Page_Layout_SideColumn_style_MutationInput {
   none
+  hero
+  postHero
+  projectHero
   singleLayout
   twoRows
 }
 
-input mutationPage_Layout_MainColumnInput {
-  layoutStyle: Page_Layout_MainColumn_layoutStyle_MutationInput!
-  singleLayout: mutationPage_Layout_MainColumn_SingleLayoutInput
-  twoRows: mutationPage_Layout_MainColumn_TwoRowsInput
-  twoColumns: mutationPage_Layout_MainColumn_TwoColumnsInput
-  threeColumns: mutationPage_Layout_MainColumn_ThreeColumnsInput
-  threeSectionGrid: mutationPage_Layout_MainColumn_ThreeSectionGridInput
+input mutationPage_Layout_SideColumn_HeroInput {
+  media: String
+  description: JSON
+  links: [mutationPage_Layout_SideColumn_Hero_LinksInput]
 }
 
-enum Page_Layout_MainColumn_layoutStyle_MutationInput {
+input mutationPage_Layout_SideColumn_Hero_LinksInput {
+  link: mutationPage_Layout_SideColumn_Hero_Links_LinkInput
+  id: String
+}
+
+input mutationPage_Layout_SideColumn_Hero_Links_LinkInput {
+  type: String
+  newTab: Boolean
+  reference: Page_Layout_SideColumn_Hero_Links_Link_ReferenceRelationshipInput
+  url: String
+  label: String!
+  appearance: Page_Layout_SideColumn_Hero_Links_Link_appearance_MutationInput
+}
+
+input Page_Layout_SideColumn_Hero_Links_Link_ReferenceRelationshipInput {
+  relationTo: Page_Layout_SideColumn_Hero_Links_Link_ReferenceRelationshipInputRelationTo
+  value: JSON
+}
+
+enum Page_Layout_SideColumn_Hero_Links_Link_ReferenceRelationshipInputRelationTo {
+  pages
+}
+
+enum Page_Layout_SideColumn_Hero_Links_Link_appearance_MutationInput {
+  default
+  primary
+  secondary
+}
+
+input mutationPage_Layout_SideColumn_ProjectHeroInput {
+  year: Float
+  client: Int
+  links: [mutationPage_Layout_SideColumn_ProjectHero_LinksInput]
+}
+
+input mutationPage_Layout_SideColumn_ProjectHero_LinksInput {
+  link: mutationPage_Layout_SideColumn_ProjectHero_Links_LinkInput
+  id: String
+}
+
+input mutationPage_Layout_SideColumn_ProjectHero_Links_LinkInput {
+  type: String
+  newTab: Boolean
+  reference: Page_Layout_SideColumn_ProjectHero_Links_Link_ReferenceRelationshipInput
+  url: String
+  label: String!
+  appearance: Page_Layout_SideColumn_ProjectHero_Links_Link_appearance_MutationInput
+}
+
+input Page_Layout_SideColumn_ProjectHero_Links_Link_ReferenceRelationshipInput {
+  relationTo: Page_Layout_SideColumn_ProjectHero_Links_Link_ReferenceRelationshipInputRelationTo
+  value: JSON
+}
+
+enum Page_Layout_SideColumn_ProjectHero_Links_Link_ReferenceRelationshipInputRelationTo {
+  pages
+}
+
+enum Page_Layout_SideColumn_ProjectHero_Links_Link_appearance_MutationInput {
+  default
+  primary
+  secondary
+}
+
+input mutationPage_Layout_MainColumnInput {
+  style: Page_Layout_MainColumn_style_MutationInput!
+  row1column1: JSON
+  row1column2: JSON
+  row2column1: JSON
+  row2column2: JSON
+}
+
+enum Page_Layout_MainColumn_style_MutationInput {
   singleLayout
   twoRows
   twoColumns
   threeSectionGrid
-}
-
-input mutationPage_Layout_MainColumn_SingleLayoutInput {
-  singleLayout1: JSON
-}
-
-input mutationPage_Layout_MainColumn_TwoRowsInput {
-  row1: JSON
-  row2: JSON
-}
-
-input mutationPage_Layout_MainColumn_TwoColumnsInput {
-  col1: JSON
-  col2: JSON
-}
-
-input mutationPage_Layout_MainColumn_ThreeColumnsInput {
-  col1: JSON
-  col2: JSON
-  col3: JSON
-}
-
-input mutationPage_Layout_MainColumn_ThreeSectionGridInput {
-  left: JSON
-  right: mutationPage_Layout_MainColumn_ThreeSectionGrid_RightInput
-}
-
-input mutationPage_Layout_MainColumn_ThreeSectionGrid_RightInput {
-  rightTop: JSON
-  rightBottom: JSON
 }
 
 input mutationPage_MetaInput {
@@ -14004,7 +15084,6 @@ input mutationPageUpdateInput {
   title: String
   publishedAt: String
   slug: String
-  hero: mutationPageUpdate_HeroInput!
   layout: [mutationPageUpdate_LayoutInput]
   meta: mutationPageUpdate_MetaInput
   updatedAt: String
@@ -14012,50 +15091,8 @@ input mutationPageUpdateInput {
   _status: PageUpdate__status_MutationInput
 }
 
-input mutationPageUpdate_HeroInput {
-  type: PageUpdate_Hero_type_MutationInput!
-  description: JSON
-  links: [mutationPageUpdate_Hero_LinksInput]
-}
-
-enum PageUpdate_Hero_type_MutationInput {
-  none
-  fixedSidePanel
-  halfPage
-  fullPage
-}
-
-input mutationPageUpdate_Hero_LinksInput {
-  link: mutationPageUpdate_Hero_Links_LinkInput
-  id: String
-}
-
-input mutationPageUpdate_Hero_Links_LinkInput {
-  type: String
-  newTab: Boolean
-  reference: PageUpdate_Hero_Links_Link_ReferenceRelationshipInput
-  url: String
-  label: String!
-  appearance: PageUpdate_Hero_Links_Link_appearance_MutationInput
-}
-
-input PageUpdate_Hero_Links_Link_ReferenceRelationshipInput {
-  relationTo: PageUpdate_Hero_Links_Link_ReferenceRelationshipInputRelationTo
-  value: JSON
-}
-
-enum PageUpdate_Hero_Links_Link_ReferenceRelationshipInputRelationTo {
-  pages
-}
-
-enum PageUpdate_Hero_Links_Link_appearance_MutationInput {
-  default
-  primary
-  secondary
-}
-
 input mutationPageUpdate_LayoutInput {
-  fixedSideContent: Boolean
+  sideContentPosition: PageUpdate_Layout_sideContentPosition_MutationInput!
   scrollSnap: Boolean
   fullPageHeight: Boolean
   sideColumn: mutationPageUpdate_Layout_SideColumnInput!
@@ -14063,62 +15100,112 @@ input mutationPageUpdate_LayoutInput {
   id: String
 }
 
+enum PageUpdate_Layout_sideContentPosition_MutationInput {
+  scrollSideContent
+  fixedSideContentWhenVisible
+  fixedSideContentAlways
+}
+
 input mutationPageUpdate_Layout_SideColumnInput {
-  sideStyle: PageUpdate_Layout_SideColumn_sideStyle_MutationInput!
+  style: PageUpdate_Layout_SideColumn_style_MutationInput!
+  hero: mutationPageUpdate_Layout_SideColumn_HeroInput
+  projectHero: mutationPageUpdate_Layout_SideColumn_ProjectHeroInput
   sideContent1: JSON
   sideContent2: JSON
 }
 
-enum PageUpdate_Layout_SideColumn_sideStyle_MutationInput {
+enum PageUpdate_Layout_SideColumn_style_MutationInput {
   none
+  hero
+  postHero
+  projectHero
   singleLayout
   twoRows
 }
 
-input mutationPageUpdate_Layout_MainColumnInput {
-  layoutStyle: PageUpdate_Layout_MainColumn_layoutStyle_MutationInput!
-  singleLayout: mutationPageUpdate_Layout_MainColumn_SingleLayoutInput
-  twoRows: mutationPageUpdate_Layout_MainColumn_TwoRowsInput
-  twoColumns: mutationPageUpdate_Layout_MainColumn_TwoColumnsInput
-  threeColumns: mutationPageUpdate_Layout_MainColumn_ThreeColumnsInput
-  threeSectionGrid: mutationPageUpdate_Layout_MainColumn_ThreeSectionGridInput
+input mutationPageUpdate_Layout_SideColumn_HeroInput {
+  media: String
+  description: JSON
+  links: [mutationPageUpdate_Layout_SideColumn_Hero_LinksInput]
 }
 
-enum PageUpdate_Layout_MainColumn_layoutStyle_MutationInput {
+input mutationPageUpdate_Layout_SideColumn_Hero_LinksInput {
+  link: mutationPageUpdate_Layout_SideColumn_Hero_Links_LinkInput
+  id: String
+}
+
+input mutationPageUpdate_Layout_SideColumn_Hero_Links_LinkInput {
+  type: String
+  newTab: Boolean
+  reference: PageUpdate_Layout_SideColumn_Hero_Links_Link_ReferenceRelationshipInput
+  url: String
+  label: String!
+  appearance: PageUpdate_Layout_SideColumn_Hero_Links_Link_appearance_MutationInput
+}
+
+input PageUpdate_Layout_SideColumn_Hero_Links_Link_ReferenceRelationshipInput {
+  relationTo: PageUpdate_Layout_SideColumn_Hero_Links_Link_ReferenceRelationshipInputRelationTo
+  value: JSON
+}
+
+enum PageUpdate_Layout_SideColumn_Hero_Links_Link_ReferenceRelationshipInputRelationTo {
+  pages
+}
+
+enum PageUpdate_Layout_SideColumn_Hero_Links_Link_appearance_MutationInput {
+  default
+  primary
+  secondary
+}
+
+input mutationPageUpdate_Layout_SideColumn_ProjectHeroInput {
+  year: Float
+  client: Int
+  links: [mutationPageUpdate_Layout_SideColumn_ProjectHero_LinksInput]
+}
+
+input mutationPageUpdate_Layout_SideColumn_ProjectHero_LinksInput {
+  link: mutationPageUpdate_Layout_SideColumn_ProjectHero_Links_LinkInput
+  id: String
+}
+
+input mutationPageUpdate_Layout_SideColumn_ProjectHero_Links_LinkInput {
+  type: String
+  newTab: Boolean
+  reference: PageUpdate_Layout_SideColumn_ProjectHero_Links_Link_ReferenceRelationshipInput
+  url: String
+  label: String!
+  appearance: PageUpdate_Layout_SideColumn_ProjectHero_Links_Link_appearance_MutationInput
+}
+
+input PageUpdate_Layout_SideColumn_ProjectHero_Links_Link_ReferenceRelationshipInput {
+  relationTo: PageUpdate_Layout_SideColumn_ProjectHero_Links_Link_ReferenceRelationshipInputRelationTo
+  value: JSON
+}
+
+enum PageUpdate_Layout_SideColumn_ProjectHero_Links_Link_ReferenceRelationshipInputRelationTo {
+  pages
+}
+
+enum PageUpdate_Layout_SideColumn_ProjectHero_Links_Link_appearance_MutationInput {
+  default
+  primary
+  secondary
+}
+
+input mutationPageUpdate_Layout_MainColumnInput {
+  style: PageUpdate_Layout_MainColumn_style_MutationInput!
+  row1column1: JSON
+  row1column2: JSON
+  row2column1: JSON
+  row2column2: JSON
+}
+
+enum PageUpdate_Layout_MainColumn_style_MutationInput {
   singleLayout
   twoRows
   twoColumns
   threeSectionGrid
-}
-
-input mutationPageUpdate_Layout_MainColumn_SingleLayoutInput {
-  singleLayout1: JSON
-}
-
-input mutationPageUpdate_Layout_MainColumn_TwoRowsInput {
-  row1: JSON
-  row2: JSON
-}
-
-input mutationPageUpdate_Layout_MainColumn_TwoColumnsInput {
-  col1: JSON
-  col2: JSON
-}
-
-input mutationPageUpdate_Layout_MainColumn_ThreeColumnsInput {
-  col1: JSON
-  col2: JSON
-  col3: JSON
-}
-
-input mutationPageUpdate_Layout_MainColumn_ThreeSectionGridInput {
-  left: JSON
-  right: mutationPageUpdate_Layout_MainColumn_ThreeSectionGrid_RightInput
-}
-
-input mutationPageUpdate_Layout_MainColumn_ThreeSectionGrid_RightInput {
-  rightTop: JSON
-  rightBottom: JSON
 }
 
 input mutationPageUpdate_MetaInput {
@@ -14134,15 +15221,16 @@ enum PageUpdate__status_MutationInput {
 
 input mutationPostInput {
   title: String!
-  categories: Int
+  description: String!
+  category: Int
   keywords: [Int]
+  slug: String
   publishedAt: String
   authors: [Int]
   populatedAuthors: [mutationPost_PopulatedAuthorsInput]
-  hero: mutationPost_HeroInput!
+  card: mutationPost_CardInput
   layout: [mutationPost_LayoutInput]
   relatedPosts: [Int]
-  slug: String
   meta: mutationPost_MetaInput
   updatedAt: String
   createdAt: String
@@ -14154,50 +15242,15 @@ input mutationPost_PopulatedAuthorsInput {
   name: String
 }
 
-input mutationPost_HeroInput {
-  type: Post_Hero_type_MutationInput!
-  description: JSON
-  links: [mutationPost_Hero_LinksInput]
-}
-
-enum Post_Hero_type_MutationInput {
-  none
-  fixedSidePanel
-  halfPage
-  fullPage
-}
-
-input mutationPost_Hero_LinksInput {
-  link: mutationPost_Hero_Links_LinkInput
-  id: String
-}
-
-input mutationPost_Hero_Links_LinkInput {
-  type: String
-  newTab: Boolean
-  reference: Post_Hero_Links_Link_ReferenceRelationshipInput
-  url: String
-  label: String!
-  appearance: Post_Hero_Links_Link_appearance_MutationInput
-}
-
-input Post_Hero_Links_Link_ReferenceRelationshipInput {
-  relationTo: Post_Hero_Links_Link_ReferenceRelationshipInputRelationTo
-  value: JSON
-}
-
-enum Post_Hero_Links_Link_ReferenceRelationshipInputRelationTo {
-  pages
-}
-
-enum Post_Hero_Links_Link_appearance_MutationInput {
-  default
-  primary
-  secondary
+input mutationPost_CardInput {
+  media: String
+  backgroundColour: String
+  overlayImage: Boolean
+  showDate: Boolean
 }
 
 input mutationPost_LayoutInput {
-  fixedSideContent: Boolean
+  sideContentPosition: Post_Layout_sideContentPosition_MutationInput!
   scrollSnap: Boolean
   fullPageHeight: Boolean
   sideColumn: mutationPost_Layout_SideColumnInput!
@@ -14205,62 +15258,112 @@ input mutationPost_LayoutInput {
   id: String
 }
 
+enum Post_Layout_sideContentPosition_MutationInput {
+  scrollSideContent
+  fixedSideContentWhenVisible
+  fixedSideContentAlways
+}
+
 input mutationPost_Layout_SideColumnInput {
-  sideStyle: Post_Layout_SideColumn_sideStyle_MutationInput!
+  style: Post_Layout_SideColumn_style_MutationInput!
+  hero: mutationPost_Layout_SideColumn_HeroInput
+  projectHero: mutationPost_Layout_SideColumn_ProjectHeroInput
   sideContent1: JSON
   sideContent2: JSON
 }
 
-enum Post_Layout_SideColumn_sideStyle_MutationInput {
+enum Post_Layout_SideColumn_style_MutationInput {
   none
+  hero
+  postHero
+  projectHero
   singleLayout
   twoRows
 }
 
-input mutationPost_Layout_MainColumnInput {
-  layoutStyle: Post_Layout_MainColumn_layoutStyle_MutationInput!
-  singleLayout: mutationPost_Layout_MainColumn_SingleLayoutInput
-  twoRows: mutationPost_Layout_MainColumn_TwoRowsInput
-  twoColumns: mutationPost_Layout_MainColumn_TwoColumnsInput
-  threeColumns: mutationPost_Layout_MainColumn_ThreeColumnsInput
-  threeSectionGrid: mutationPost_Layout_MainColumn_ThreeSectionGridInput
+input mutationPost_Layout_SideColumn_HeroInput {
+  media: String
+  description: JSON
+  links: [mutationPost_Layout_SideColumn_Hero_LinksInput]
 }
 
-enum Post_Layout_MainColumn_layoutStyle_MutationInput {
+input mutationPost_Layout_SideColumn_Hero_LinksInput {
+  link: mutationPost_Layout_SideColumn_Hero_Links_LinkInput
+  id: String
+}
+
+input mutationPost_Layout_SideColumn_Hero_Links_LinkInput {
+  type: String
+  newTab: Boolean
+  reference: Post_Layout_SideColumn_Hero_Links_Link_ReferenceRelationshipInput
+  url: String
+  label: String!
+  appearance: Post_Layout_SideColumn_Hero_Links_Link_appearance_MutationInput
+}
+
+input Post_Layout_SideColumn_Hero_Links_Link_ReferenceRelationshipInput {
+  relationTo: Post_Layout_SideColumn_Hero_Links_Link_ReferenceRelationshipInputRelationTo
+  value: JSON
+}
+
+enum Post_Layout_SideColumn_Hero_Links_Link_ReferenceRelationshipInputRelationTo {
+  pages
+}
+
+enum Post_Layout_SideColumn_Hero_Links_Link_appearance_MutationInput {
+  default
+  primary
+  secondary
+}
+
+input mutationPost_Layout_SideColumn_ProjectHeroInput {
+  year: Float
+  client: Int
+  links: [mutationPost_Layout_SideColumn_ProjectHero_LinksInput]
+}
+
+input mutationPost_Layout_SideColumn_ProjectHero_LinksInput {
+  link: mutationPost_Layout_SideColumn_ProjectHero_Links_LinkInput
+  id: String
+}
+
+input mutationPost_Layout_SideColumn_ProjectHero_Links_LinkInput {
+  type: String
+  newTab: Boolean
+  reference: Post_Layout_SideColumn_ProjectHero_Links_Link_ReferenceRelationshipInput
+  url: String
+  label: String!
+  appearance: Post_Layout_SideColumn_ProjectHero_Links_Link_appearance_MutationInput
+}
+
+input Post_Layout_SideColumn_ProjectHero_Links_Link_ReferenceRelationshipInput {
+  relationTo: Post_Layout_SideColumn_ProjectHero_Links_Link_ReferenceRelationshipInputRelationTo
+  value: JSON
+}
+
+enum Post_Layout_SideColumn_ProjectHero_Links_Link_ReferenceRelationshipInputRelationTo {
+  pages
+}
+
+enum Post_Layout_SideColumn_ProjectHero_Links_Link_appearance_MutationInput {
+  default
+  primary
+  secondary
+}
+
+input mutationPost_Layout_MainColumnInput {
+  style: Post_Layout_MainColumn_style_MutationInput!
+  row1column1: JSON
+  row1column2: JSON
+  row2column1: JSON
+  row2column2: JSON
+}
+
+enum Post_Layout_MainColumn_style_MutationInput {
   singleLayout
   twoRows
   twoColumns
   threeSectionGrid
-}
-
-input mutationPost_Layout_MainColumn_SingleLayoutInput {
-  singleLayout1: JSON
-}
-
-input mutationPost_Layout_MainColumn_TwoRowsInput {
-  row1: JSON
-  row2: JSON
-}
-
-input mutationPost_Layout_MainColumn_TwoColumnsInput {
-  col1: JSON
-  col2: JSON
-}
-
-input mutationPost_Layout_MainColumn_ThreeColumnsInput {
-  col1: JSON
-  col2: JSON
-  col3: JSON
-}
-
-input mutationPost_Layout_MainColumn_ThreeSectionGridInput {
-  left: JSON
-  right: mutationPost_Layout_MainColumn_ThreeSectionGrid_RightInput
-}
-
-input mutationPost_Layout_MainColumn_ThreeSectionGrid_RightInput {
-  rightTop: JSON
-  rightBottom: JSON
 }
 
 input mutationPost_MetaInput {
@@ -14276,15 +15379,16 @@ enum Post__status_MutationInput {
 
 input mutationPostUpdateInput {
   title: String
-  categories: Int
+  description: String
+  category: Int
   keywords: [Int]
+  slug: String
   publishedAt: String
   authors: [Int]
   populatedAuthors: [mutationPostUpdate_PopulatedAuthorsInput]
-  hero: mutationPostUpdate_HeroInput!
+  card: mutationPostUpdate_CardInput
   layout: [mutationPostUpdate_LayoutInput]
   relatedPosts: [Int]
-  slug: String
   meta: mutationPostUpdate_MetaInput
   updatedAt: String
   createdAt: String
@@ -14296,50 +15400,15 @@ input mutationPostUpdate_PopulatedAuthorsInput {
   name: String
 }
 
-input mutationPostUpdate_HeroInput {
-  type: PostUpdate_Hero_type_MutationInput!
-  description: JSON
-  links: [mutationPostUpdate_Hero_LinksInput]
-}
-
-enum PostUpdate_Hero_type_MutationInput {
-  none
-  fixedSidePanel
-  halfPage
-  fullPage
-}
-
-input mutationPostUpdate_Hero_LinksInput {
-  link: mutationPostUpdate_Hero_Links_LinkInput
-  id: String
-}
-
-input mutationPostUpdate_Hero_Links_LinkInput {
-  type: String
-  newTab: Boolean
-  reference: PostUpdate_Hero_Links_Link_ReferenceRelationshipInput
-  url: String
-  label: String!
-  appearance: PostUpdate_Hero_Links_Link_appearance_MutationInput
-}
-
-input PostUpdate_Hero_Links_Link_ReferenceRelationshipInput {
-  relationTo: PostUpdate_Hero_Links_Link_ReferenceRelationshipInputRelationTo
-  value: JSON
-}
-
-enum PostUpdate_Hero_Links_Link_ReferenceRelationshipInputRelationTo {
-  pages
-}
-
-enum PostUpdate_Hero_Links_Link_appearance_MutationInput {
-  default
-  primary
-  secondary
+input mutationPostUpdate_CardInput {
+  media: String
+  backgroundColour: String
+  overlayImage: Boolean
+  showDate: Boolean
 }
 
 input mutationPostUpdate_LayoutInput {
-  fixedSideContent: Boolean
+  sideContentPosition: PostUpdate_Layout_sideContentPosition_MutationInput!
   scrollSnap: Boolean
   fullPageHeight: Boolean
   sideColumn: mutationPostUpdate_Layout_SideColumnInput!
@@ -14347,62 +15416,112 @@ input mutationPostUpdate_LayoutInput {
   id: String
 }
 
+enum PostUpdate_Layout_sideContentPosition_MutationInput {
+  scrollSideContent
+  fixedSideContentWhenVisible
+  fixedSideContentAlways
+}
+
 input mutationPostUpdate_Layout_SideColumnInput {
-  sideStyle: PostUpdate_Layout_SideColumn_sideStyle_MutationInput!
+  style: PostUpdate_Layout_SideColumn_style_MutationInput!
+  hero: mutationPostUpdate_Layout_SideColumn_HeroInput
+  projectHero: mutationPostUpdate_Layout_SideColumn_ProjectHeroInput
   sideContent1: JSON
   sideContent2: JSON
 }
 
-enum PostUpdate_Layout_SideColumn_sideStyle_MutationInput {
+enum PostUpdate_Layout_SideColumn_style_MutationInput {
   none
+  hero
+  postHero
+  projectHero
   singleLayout
   twoRows
 }
 
-input mutationPostUpdate_Layout_MainColumnInput {
-  layoutStyle: PostUpdate_Layout_MainColumn_layoutStyle_MutationInput!
-  singleLayout: mutationPostUpdate_Layout_MainColumn_SingleLayoutInput
-  twoRows: mutationPostUpdate_Layout_MainColumn_TwoRowsInput
-  twoColumns: mutationPostUpdate_Layout_MainColumn_TwoColumnsInput
-  threeColumns: mutationPostUpdate_Layout_MainColumn_ThreeColumnsInput
-  threeSectionGrid: mutationPostUpdate_Layout_MainColumn_ThreeSectionGridInput
+input mutationPostUpdate_Layout_SideColumn_HeroInput {
+  media: String
+  description: JSON
+  links: [mutationPostUpdate_Layout_SideColumn_Hero_LinksInput]
 }
 
-enum PostUpdate_Layout_MainColumn_layoutStyle_MutationInput {
+input mutationPostUpdate_Layout_SideColumn_Hero_LinksInput {
+  link: mutationPostUpdate_Layout_SideColumn_Hero_Links_LinkInput
+  id: String
+}
+
+input mutationPostUpdate_Layout_SideColumn_Hero_Links_LinkInput {
+  type: String
+  newTab: Boolean
+  reference: PostUpdate_Layout_SideColumn_Hero_Links_Link_ReferenceRelationshipInput
+  url: String
+  label: String!
+  appearance: PostUpdate_Layout_SideColumn_Hero_Links_Link_appearance_MutationInput
+}
+
+input PostUpdate_Layout_SideColumn_Hero_Links_Link_ReferenceRelationshipInput {
+  relationTo: PostUpdate_Layout_SideColumn_Hero_Links_Link_ReferenceRelationshipInputRelationTo
+  value: JSON
+}
+
+enum PostUpdate_Layout_SideColumn_Hero_Links_Link_ReferenceRelationshipInputRelationTo {
+  pages
+}
+
+enum PostUpdate_Layout_SideColumn_Hero_Links_Link_appearance_MutationInput {
+  default
+  primary
+  secondary
+}
+
+input mutationPostUpdate_Layout_SideColumn_ProjectHeroInput {
+  year: Float
+  client: Int
+  links: [mutationPostUpdate_Layout_SideColumn_ProjectHero_LinksInput]
+}
+
+input mutationPostUpdate_Layout_SideColumn_ProjectHero_LinksInput {
+  link: mutationPostUpdate_Layout_SideColumn_ProjectHero_Links_LinkInput
+  id: String
+}
+
+input mutationPostUpdate_Layout_SideColumn_ProjectHero_Links_LinkInput {
+  type: String
+  newTab: Boolean
+  reference: PostUpdate_Layout_SideColumn_ProjectHero_Links_Link_ReferenceRelationshipInput
+  url: String
+  label: String!
+  appearance: PostUpdate_Layout_SideColumn_ProjectHero_Links_Link_appearance_MutationInput
+}
+
+input PostUpdate_Layout_SideColumn_ProjectHero_Links_Link_ReferenceRelationshipInput {
+  relationTo: PostUpdate_Layout_SideColumn_ProjectHero_Links_Link_ReferenceRelationshipInputRelationTo
+  value: JSON
+}
+
+enum PostUpdate_Layout_SideColumn_ProjectHero_Links_Link_ReferenceRelationshipInputRelationTo {
+  pages
+}
+
+enum PostUpdate_Layout_SideColumn_ProjectHero_Links_Link_appearance_MutationInput {
+  default
+  primary
+  secondary
+}
+
+input mutationPostUpdate_Layout_MainColumnInput {
+  style: PostUpdate_Layout_MainColumn_style_MutationInput!
+  row1column1: JSON
+  row1column2: JSON
+  row2column1: JSON
+  row2column2: JSON
+}
+
+enum PostUpdate_Layout_MainColumn_style_MutationInput {
   singleLayout
   twoRows
   twoColumns
   threeSectionGrid
-}
-
-input mutationPostUpdate_Layout_MainColumn_SingleLayoutInput {
-  singleLayout1: JSON
-}
-
-input mutationPostUpdate_Layout_MainColumn_TwoRowsInput {
-  row1: JSON
-  row2: JSON
-}
-
-input mutationPostUpdate_Layout_MainColumn_TwoColumnsInput {
-  col1: JSON
-  col2: JSON
-}
-
-input mutationPostUpdate_Layout_MainColumn_ThreeColumnsInput {
-  col1: JSON
-  col2: JSON
-  col3: JSON
-}
-
-input mutationPostUpdate_Layout_MainColumn_ThreeSectionGridInput {
-  left: JSON
-  right: mutationPostUpdate_Layout_MainColumn_ThreeSectionGrid_RightInput
-}
-
-input mutationPostUpdate_Layout_MainColumn_ThreeSectionGrid_RightInput {
-  rightTop: JSON
-  rightBottom: JSON
 }
 
 input mutationPostUpdate_MetaInput {
@@ -14484,6 +15603,18 @@ input mutationKeywordUpdate_BreadcrumbsInput {
   url: String
   label: String
   id: String
+}
+
+input mutationClientInput {
+  title: String
+  updatedAt: String
+  createdAt: String
+}
+
+input mutationClientUpdateInput {
+  title: String
+  updatedAt: String
+  createdAt: String
 }
 
 input mutationUserInput {

--- a/src/payload/hooks/populateArchiveBlock.ts
+++ b/src/payload/hooks/populateArchiveBlock.ts
@@ -21,10 +21,10 @@ export const populateArchiveBlock: AfterReadHook = async ({ doc, req: { payload 
             collection: archiveBlock.relationTo,
             limit: archiveBlock.limit || 10,
             where: {
-              ...(archiveBlock?.categories?.length > 0
+              ...(archiveBlock?.category?.length > 0
                 ? {
-                    categories: {
-                      in: archiveBlock.categories
+                    category: {
+                      in: archiveBlock.category
                         .map(cat => {
                           if (typeof cat === 'string' || typeof cat === 'number') return cat
                           return cat.id

--- a/src/payload/payload-types.ts
+++ b/src/payload/payload-types.ts
@@ -36,7 +36,7 @@ export interface Config {
     pages: Page;
     posts: Post;
     media: Media;
-    categories: Category;
+    category: Category;
     keywords: Keyword;
     clients: Client;
     users: User;
@@ -301,7 +301,7 @@ export interface Post {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "categories".
+ * via the `definition` "category".
  */
 export interface Category {
   id: number;
@@ -494,7 +494,7 @@ export interface ArchiveBlock {
   } | null;
   populateBy?: ('collection' | 'selection') | null;
   relationTo?: 'posts' | null;
-  categories?: (number | Category)[] | null;
+  category?: (number | Category)[] | null;
   limit?: number | null;
   showPageRange?: boolean | null;
   selectedDocs?:

--- a/src/payload/payload.config.ts
+++ b/src/payload/payload.config.ts
@@ -15,7 +15,7 @@ import { Archive } from './blocks/ArchiveBlock'
 import { CallToAction } from './blocks/CallToAction'
 import { Code } from './blocks/Code'
 import { MediaBlock } from './blocks/MediaBlock'
-import Categories from './collections/Categories'
+import Category from './collections/Category'
 import Clients from './collections/Clients'
 import Keywords from './collections/Keywords'
 import { Media } from './collections/Media'
@@ -68,7 +68,7 @@ export default buildConfig({
     },
   }),
   serverURL: process.env.PAYLOAD_PUBLIC_SERVER_URL,
-  collections: [Pages, Posts, Media, Categories, Keywords, Clients, Users],
+  collections: [Pages, Posts, Media, Category, Keywords, Clients, Users],
   globals: [Site, HiddenLayout],
   typescript: {
     outputFile: path.resolve(__dirname, 'payload-types.ts'),


### PR DESCRIPTION
This pull request fixes an issue where archive blocks that specified a category to filter by were not loading. This issue was caused by a name mismatch as the categories field array became a singular category object.

This PR has updated all references to categories and replaced them with the singular category.

Note: that while category is singular for posts, the archive block may filter by one or more categories.