### PR TITLE
bugfix/type error in pageHero mapped keywords

### DIFF
--- a/src/app/_components/Hero/PostHero/index.tsx
+++ b/src/app/_components/Hero/PostHero/index.tsx
@@ -31,7 +31,7 @@ export const PostHero: React.FC<PostHeroProps> = props => {
       <h3 className="my-3 text-md">
         {pageContext.description ? pageContext.description : 'nulls'}
       </h3>
-      <p>{pageContext.keywords.map(keyword => keyword.title).join(', ')}</p>
+      <p>{(pageContext.keywords || []).map(keyword => keyword.title).join(', ')}</p>
     </div>
   )
 }


### PR DESCRIPTION
This bugfix deals with a runtime error in the pageHero component where an error would occour when the page kewords were being mapped before they were loaded into the pageContext. I set it to default to an empty array if keywords is not yet set.