### PR TITLE
Feature/mobile-menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@payloadcms/plugin-redirects": "^1.0.1",
     "@payloadcms/plugin-search": "^1.0.1",
     "@payloadcms/plugin-seo": "^1.0.13",
-    "@payloadcms/richtext-lexical": "^0.5.2",
+    "@payloadcms/richtext-lexical": "^0.7.0",
     "@react-spring/web": "^9.7.3",
     "aws-crt": "^1.19.0",
     "cross-env": "^7.0.3",
@@ -83,6 +83,7 @@
     "postcss-loader": "^7.3.3",
     "prettier": "^2.7.1",
     "tailwindcss": "^3.3.5",
+    "tailwindcss-3d": "^1.0.5",
     "ts-node": "^10.9.1",
     "typescript": "4.8.4"
   }

--- a/src/app/_components/Header/Nav/index.tsx
+++ b/src/app/_components/Header/Nav/index.tsx
@@ -1,14 +1,13 @@
 'use client'
 
-import React, { useState } from 'react'
-import { animated, useSpring } from '@react-spring/web'
-import Link from 'next/link'
-import { usePathname } from 'next/navigation'
+import React, { useEffect, useState } from 'react'
 
 import { Site } from '../../../../payload/payload-types'
+import { useMenuOpen } from '../../../_providers/Context/Page/menuOpenContext'
 import { usePage } from '../../../_providers/Context/Page/pageContext'
 import { Button } from '../../Button'
 import { CMSLink } from '../../Link'
+import { ThemeSelector } from '../../ThemeSelector'
 
 type headerNavProps = {
   siteSettings: Site
@@ -17,56 +16,37 @@ type headerNavProps = {
 export const HeaderNav = ({ siteSettings }: headerNavProps) => {
   const navItems = siteSettings && siteSettings.navItems ? siteSettings.navItems : []
   const { title, category } = usePage()
-  const [menuOpen, setMenuOpen] = useState(false)
+  const { menuOpen, setMenuOpen } = useMenuOpen()
 
-  const navAnimation = useSpring({
-    right: menuOpen ? '0%' : '-100%',
-    config: { tension: 170, friction: 26 },
-  })
+  const toggleMenu = () => {
+    setMenuOpen(!menuOpen)
+  }
 
   return (
     <nav role="navigation" aria-label="Main menu" className="flex static">
-      <button
-        onClick={() => setMenuOpen(true)}
-        className={`lg:hidden text-2xl ${menuOpen && 'hidden'}`}
-      >
+      <button onClick={toggleMenu} className={`visible xl:invisible xl:w-0 text-2xl`}>
         menu
       </button>
-      <animated.div
-        style={navAnimation}
-        className="fixed w-fit top-0 h-screen lg:h-auto right-0 z-20 bg-zinc-800 lg:relative lg:left-0 lg:bg-transparent"
+      <div
+        className={`${
+          menuOpen ? 'opacity-100 right-0' : 'opacity-0 -right-full xl:opacity-100 xl:right-auto'
+        } absolute w-60 xl:w-auto top-32 xl:top-0 sm:top-40 h-screen xl:h-auto xl:relative xl:left-0 xl:bg-transparent transition-all duration-500`}
       >
-        <ul className="lg:flex lg:flex-row gap-4 text-2xl">
-          <li key={0}>
-            <div
-              className={`lg:hidden pl-10 pr-32 lg:px-0 pt-6 lg:pt-0`}
-              onClick={() => setMenuOpen(false)}
-            >
-              <Button
-                className={`border-none last:pr-0 last:mr-0 transition-all ${
-                  title.toLowerCase() === 'home'
-                    ? 'underline dark:underline underline-offset-[14px] dark:text-white'
-                    : ''
-                } hover:underline hover:underline-offset-[14px] dark:hover:text-white `}
-                href="/"
-                appearance="default"
-                label="home"
-              />
-            </div>
-          </li>
+        <ul className="xl:flex xl:flex-row text-2xl">
           {navItems.map(({ link }, i) => {
             link.label = link.label.toLowerCase()
+
             return (
-              <li key={i + 1}>
-                <div className={`pl-10 pr-32 lg:px-0`} onClick={() => setMenuOpen(false)}>
+              <li key={i + 1} style={{ transitionDelay: `${(i + 1) * 300}ms` }}>
+                <div onClick={() => setMenuOpen(false)}>
                   <CMSLink
                     {...link}
-                    className={`border-none last:pr-0 last:mr-0 transition-all ${
-                      title.toLowerCase() === link.label.toLowerCase() ||
-                      (category && category.title.toLowerCase() === link.label.toLowerCase())
-                        ? 'underline dark:underline underline-offset-[14px] dark:text-white'
+                    className={`border-none pl-0 xl:pl-4 last:pr-0 last:mr-0 transition-all ${
+                      title.toLowerCase() === link.label ||
+                      (category && category.title.toLowerCase() === link.label)
+                        ? 'dark:underline underline underline-offset-[14px] text-white'
                         : ''
-                    } hover:underline hover:underline-offset-[14px] dark:hover:text-white `}
+                    } hover:underline hover:underline-offset-[14px] dark:hover:text-white`}
                     appearance="default"
                   />
                 </div>
@@ -74,15 +54,8 @@ export const HeaderNav = ({ siteSettings }: headerNavProps) => {
             )
           })}
         </ul>
-      </animated.div>
-      <div
-        className={`${
-          menuOpen
-            ? 'fixed w-screen h-screen top-0 left-0 z-100 bg-transparent blur-lg'
-            : 'invisible'
-        }`}
-        onClick={() => setMenuOpen(false)}
-      ></div>
+        <ThemeSelector className="xl:hidden  pt-6" />
+      </div>
     </nav>
   )
 }

--- a/src/app/_components/PageContainer/index.tsx
+++ b/src/app/_components/PageContainer/index.tsx
@@ -1,0 +1,39 @@
+'use client'
+
+import { ReactNode } from 'react'
+
+import { useMenuOpen } from '../../_providers/Context/Page/menuOpenContext'
+
+interface Props {
+  children: ReactNode
+}
+
+export const PageContainer = ({ children }) => {
+  const { menuOpen, setMenuOpen } = useMenuOpen()
+
+  const mobile3DTransform = 'rotate-y-[25deg] translate-y-36 -translate-x-64'
+  const tablet3DTransform = 'sm:rotate-y-[15deg] sm:translate-y-44 sm:-translate-x-64'
+  const desktop3DTransform = 'xl:rotate-y-0 xl:translate-y-0 xl:translate-x-0'
+
+  return (
+    <div className="h-full w-full overflow-hidden">
+      <div className="h-screen perspective-750 sm:perspective-1000 transform-style-3d">
+        <div
+          className={`${
+            menuOpen && `${mobile3DTransform} ${tablet3DTransform} ${desktop3DTransform}`
+          } origin-top-right relative flex flex-col w-full h-screen overflow-x-scroll font-sans text-lg text-zinc-600 dark:text-zinc-300 transition-all duration-500`}
+        >
+          <div className="w-full h-full overflow-scroll bg-zinc-300 dark:bg-zinc-900 transition-colors duration-500 drop-shadow-2xl">
+            {children}
+          </div>
+          {menuOpen && (
+            <div
+              className="absolute top-0 left-0 w-screen h-screen z-1000 cursor-pointer"
+              onClick={() => setMenuOpen(false)}
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/_providers/Context/Page/menuOpenContext.tsx
+++ b/src/app/_providers/Context/Page/menuOpenContext.tsx
@@ -1,0 +1,26 @@
+import React, { createContext, ReactNode, useContext, useState } from 'react'
+
+interface MenuOpenType {
+  menuOpen: boolean
+  setMenuOpen: React.Dispatch<React.SetStateAction<boolean>>
+}
+
+const MenuOpenContext = createContext<MenuOpenType>({ menuOpen: false, setMenuOpen: () => {} })
+
+interface MenuOpenProviderProps {
+  children: ReactNode
+}
+
+export const MenuOpenProvider: React.FC<MenuOpenProviderProps> = ({ children }) => {
+  const [menuOpen, setMenuOpen] = useState(false)
+
+  return (
+    <MenuOpenContext.Provider value={{ menuOpen, setMenuOpen }}>
+      {children}
+    </MenuOpenContext.Provider>
+  )
+}
+
+export const useMenuOpen = () => useContext(MenuOpenContext)
+
+export default MenuOpenContext

--- a/src/app/_providers/index.tsx
+++ b/src/app/_providers/index.tsx
@@ -4,6 +4,7 @@ import React from 'react'
 import { ThemeProvider } from 'next-themes'
 
 import { AuthProvider } from '../_providers/Auth'
+import { MenuOpenProvider } from './Context/Page/menuOpenContext'
 import { MouseProvider } from './Context/Page/mouseContext'
 import { PageProvider } from './Context/Page/pageContext'
 
@@ -14,7 +15,9 @@ export const Providers: React.FC<{
     <ThemeProvider attribute="class">
       <AuthProvider>
         <PageProvider>
-          <MouseProvider>{children}</MouseProvider>
+          <MenuOpenProvider>
+            <MouseProvider>{children}</MouseProvider>
+          </MenuOpenProvider>
         </PageProvider>
       </AuthProvider>
     </ThemeProvider>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import { Site } from '../payload/payload-types'
 import { fetchSiteSettings } from './_api/fetchGlobals'
 import { Footer } from './_components/Footer'
 import { Header } from './_components/Header'
+import { PageContainer } from './_components/PageContainer'
 import { TailwindBreakpoints } from './_components/TailwindBreakpoints'
 import { Providers } from './_providers'
 import { mergeOpenGraph } from './_utilities/mergeOpenGraph'
@@ -45,14 +46,18 @@ export default async function RootLayout({ children }: { children: React.ReactNo
       </head>
       <body>
         <Providers>
-          <div className="flex flex-col w-full min-h-screen font-sans text-zinc-600 bg-zinc-300 dark:bg-zinc-900 dark:text-zinc-300 transition-all duration-200">
-            {/* @ts-expect-error */}
-            <Header siteSettings={siteSettings} />
-            {children}
-            {/* @ts-expect-error */}
-            <Footer siteSettings={siteSettings} />
-            {/* <TailwindBreakpoints /> */}
-          </div>
+          {/* @ts-expect-error */}
+          <Header siteSettings={siteSettings} />
+          <PageContainer>
+            <div className="flex flex-col h-full">
+              {/* <SwipeMenu className="" navItems={siteSettings.navItems} /> */}
+              {children}
+              {/* @ts-expect-error */}
+              <Footer siteSettings={siteSettings} />
+              {/* <TailwindBreakpoints /> */}
+            </div>
+          </PageContainer>
+          <div className="fixed w-full h-full top-0 left-0 bg-gradient-to-tr from-zinc-950 to-zinc-700 -z-10" />
         </Providers>
       </body>
     </html>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -91,6 +91,7 @@ module.exports = {
       },
       minHeight: {
         16: '4rem',
+        container: '70rem',
       },
       backgroundImage: {
         'gradient-radial': 'radial-gradient(var(--tw-gradient-stops))',
@@ -101,7 +102,11 @@ module.exports = {
         thumbColor: 'rgba(156, 163, 175, 0.5)',
         thumbBorderRadius: '3px',
       },
+      maxWidth: {
+        container: '80rem',
+        main: '48rem',
+      },
     },
   },
-  plugins: [],
+  plugins: [require('tailwindcss-3d')({ legacy: true })],
 }


### PR DESCRIPTION
The following Pull request implements a mobile and tablet menu that uses 3D transofrm effects on whole page. The majority of these changes relate to CSS styling of componenets with some restructuring to ensure it works correctly.

The tailwindCSS-3D module has been added to the package to provide utiltiy classes for 3D transforms of the main container.

Functionality includes
- A modal overlay on thee transformed container to close the menu when clicked.
- Styling for mobile and tablet breakpoints.
- Slide in animations for menu items
- inclusion of dark mode button, on desktop this is only selectable in the footer.

The 3D transform is positioned differently based on the screen size and ratio. The design has been tested to display correctly on a variety of mobile and tablet screens.