### PR TITLE
Feature/table-of-contents-in-post-hero

### DIFF
--- a/src/app/_components/Hero/PostHero/index.tsx
+++ b/src/app/_components/Hero/PostHero/index.tsx
@@ -2,6 +2,7 @@ import React, { Fragment } from 'react'
 
 import { Hero as HeroType } from '../../../../payload/payload-types'
 import { usePage } from '../../../_providers/Context/Page/pageContext'
+import TableOfContents from '../../TableOfContents'
 
 type PostHeroProps = HeroType & {
   className?: string
@@ -21,17 +22,16 @@ export const PostHero: React.FC<PostHeroProps> = props => {
 
   return (
     <div className={className}>
-      <div className="flex gap-3 ">
-        <h2 className="text-xl text-center xl:text-left">
-          {pageContext.category && typeof pageContext.category === 'object' && (
-            <Fragment>{formatDateIntl(pageContext.publishedAt)}</Fragment>
-          )}
-        </h2>
-      </div>
+      {pageContext.category && typeof pageContext.category === 'object' && (
+        <h2 className="text-2xl">{formatDateIntl(pageContext.publishedAt)}</h2>
+      )}
       <h3 className="my-3 text-md">
         {pageContext.description ? pageContext.description : 'nulls'}
       </h3>
-      <p>{(pageContext.keywords || []).map(keyword => keyword.title).join(', ')}</p>
+      <p className="text-xs">
+        {(pageContext.keywords || []).map(keyword => keyword.title).join(', ')}
+      </p>
+      <TableOfContents />
     </div>
   )
 }

--- a/src/app/_components/Layouts/MainColumn/index.tsx
+++ b/src/app/_components/Layouts/MainColumn/index.tsx
@@ -3,14 +3,16 @@ import React from 'react'
 import { MainColumn as MainColumnType } from '../../../../payload/payload-types'
 import RichText from '../../RichText'
 
-export type MainColumnProps = MainColumnType
+export type MainColumnProps = MainColumnType & {
+  hasTOC?: boolean
+}
 
 export const MainColumn: React.FC<MainColumnProps> = props => {
-  const { style, column1, column2 } = props
+  const { style, column1, column2, hasTOC = false } = props
 
   switch (style) {
     case 'singleLayout':
-      return <RichText className="w-full" content={column1} />
+      return <RichText className="w-full" content={column1} hasTOC />
     case 'twoColumns':
       return (
         <>

--- a/src/app/_components/Layouts/index.tsx
+++ b/src/app/_components/Layouts/index.tsx
@@ -22,6 +22,7 @@ export const Layouts: React.FC<LayoutsProps> = props => {
           const top = index === 0 ? true : false
           const bottom = index === layouts.length - 1 ? true : false
           const sideColumn = layout.sideColumn.style !== 'none'
+          const hasTOC = layout.sideColumn.style === 'postHero'
           return (
             <div key={index}>
               <Layout
@@ -34,7 +35,7 @@ export const Layouts: React.FC<LayoutsProps> = props => {
                   <SideColumn {...layout.sideColumn} position={layout.sideContentPosition} />
                 </Column>
                 <Column position="main">
-                  <MainColumn {...layout.mainColumn} />
+                  <MainColumn {...layout.mainColumn} hasTOC />
                 </Column>
               </Layout>
             </div>

--- a/src/app/_components/RichText/serialize.tsx
+++ b/src/app/_components/RichText/serialize.tsx
@@ -2,6 +2,7 @@
 import React, { Fragment } from 'react'
 import escapeHTML from 'escape-html'
 
+import { TOCItem } from '../../_providers/Context/Page/pageContext'
 import { Blocks } from '../Blocks'
 import { CMSLink } from '../Link'
 import { Media } from '../Media'
@@ -37,13 +38,17 @@ function getTextFormats(formatNumber) {
   return { bold, italic, strikethrough, underline, code, subscript, superscript }
 }
 
-const serialize = (nodes?: any[], i = 1): React.ReactNode => {
+const serialize = (
+  nodes?: any[],
+  collectTOCItem?: (item: TOCItem) => void,
+  i = 1,
+): React.ReactNode => {
   return nodes.map((node, i) => {
     if (!node) {
       return null
     }
     // text styles
-    const paddingTop = ' pt-3'
+    const paddingTop = 'pb-6'
     // set alignment styles
     let textAlignment = ''
     if (typeof node.format === 'string') {
@@ -113,50 +118,66 @@ const serialize = (nodes?: any[], i = 1): React.ReactNode => {
       case 'linebreak':
         return <br key={i} />
       case 'heading':
+        // build table of contents item
+        const id = node.children[0].text.replace(/\s+/g, '-').toLowerCase()
+        const title = node.children[0].text
+        const tocItem: TOCItem = { title, url: `#${id}`, type: node.tag }
+        if (collectTOCItem) {
+          collectTOCItem(tocItem)
+        }
+
+        let heading
         switch (node.tag) {
           case 'h1':
-            return (
-              <h1 className={`text-5xl ${textStyles}`} key={i}>
+            heading = (
+              <h1 key={i} id={id} className={`text-6xl scroll-mt-24 ${textStyles}`}>
                 {serialize(node.children)}
               </h1>
             )
+            break
           case 'h2':
-            return (
-              <h2 className={`text-4xl ${textStyles}`} key={i}>
+            heading = (
+              <h2 key={i} id={id} className={`text-5xl scroll-mt-24 ${textStyles}`}>
                 {serialize(node.children)}
               </h2>
             )
+            break
           case 'h3':
-            return (
-              <h3 className={`text-3xl ${textStyles}`} key={i}>
+            heading = (
+              <h3 key={i} id={id} className={`text-4xl scroll-mt-24 ${textStyles}`}>
                 {serialize(node.children)}
               </h3>
             )
+            break
           case 'h4':
-            return (
-              <h4 className={`text-2xl ${textStyles}`} key={i}>
+            heading = (
+              <h4 key={i} id={id} className={`text-3xl scroll-mt-24 ${textStyles}`}>
                 {serialize(node.children)}
               </h4>
             )
+            break
           case 'h5':
-            return (
-              <h5 className={`text-xl ${textStyles}`} key={i}>
+            heading = (
+              <h5 key={i} id={id} className={`text-2xl scroll-mt-24 ${textStyles}`}>
                 {serialize(node.children)}
               </h5>
             )
+            break
           case 'h6':
-            return (
-              <h6 className={`text-lg ${textStyles}`} key={i}>
+            heading = (
+              <h6 key={i} id={id} className={`text-xl scroll-mt-24 ${textStyles}`}>
                 {serialize(node.children)}
               </h6>
             )
+            break
         }
+        return <div>{heading}</div>
       case 'list':
         switch (node.tag) {
           case 'ul':
             return (
               <div className="w-full flex justify-center xl:justify-start">
-                <ul className="list-disc pl-5 text-left" key={i}>
+                <ul className="list-disc pl-5 pb-6 text-left" key={i}>
                   {serialize(node.children)}
                 </ul>
               </div>
@@ -193,7 +214,11 @@ const serialize = (nodes?: any[], i = 1): React.ReactNode => {
           />
         )
       case 'block':
-        return <Blocks key={i} blocks={[node.fields]} />
+        return (
+          <div className="pb-6">
+            <Blocks key={i} blocks={[node.fields]} />
+          </div>
+        )
     }
   })
 }

--- a/src/app/_components/TableOfContents/index.tsx
+++ b/src/app/_components/TableOfContents/index.tsx
@@ -1,0 +1,42 @@
+import React from 'react'
+
+import { usePage } from '../../_providers/Context/Page/pageContext'
+
+const TableOfContents: React.FC = () => {
+  const { tableOfContents } = usePage()
+
+  if (!tableOfContents || tableOfContents.length === 0) {
+    return null
+  }
+
+  // Calculate the highest level (smallest number) heading in the table of contents
+  const highestLevel = Math.min(
+    ...tableOfContents.map(item => parseInt(item.type.replace('h', ''), 10)),
+  )
+
+  // not visible when not 2 column
+  return (
+    <div className="hidden xl:flex flex-col pt-12">
+      <h5 className="text-2xl py-4">Contents</h5>
+      {tableOfContents.map((item, i) => {
+        // Calculate the indent by its heading type relative to the highest level heading
+        const level = parseInt(item.type.replace('h', ''), 10)
+        const indentation = level - highestLevel // Indent by 2 spaces for each level difference
+        const marginLeftClass = `ml-${indentation}`
+
+        return (
+          <a
+            key={i}
+            href={item.url}
+            className={`${marginLeftClass} hover:underline text-md mt-1`}
+            style={{ marginLeft: `${indentation * 0.5}rem` }}
+          >
+            {item.title}
+          </a>
+        )
+      })}
+    </div>
+  )
+}
+
+export default TableOfContents

--- a/src/app/_providers/Context/Page/pageContext.tsx
+++ b/src/app/_providers/Context/Page/pageContext.tsx
@@ -8,17 +8,27 @@ import { Category, Keyword } from '../../../../payload/payload-types'
 // Settings states are optional covering both contexts
 // eg. Pages and Posts share some common values such as title and description
 // but category or keywords
+
+// for use in Post Hero Side Column
+export interface TOCItem {
+  title: string
+  url: string // the # to the location on the page
+  type: string // eg. h1, h2 etc.
+}
+
 interface PageContextType {
   title: string
   description: string
   publishedAt: Date
   category: Category
   keywords: Keyword[]
+  tableOfContents: TOCItem[]
   setTitle: React.Dispatch<React.SetStateAction<string>>
   setDescription: React.Dispatch<React.SetStateAction<string>>
   setPublishedAt: React.Dispatch<React.SetStateAction<Date>>
   setCategory: React.Dispatch<React.SetStateAction<Category>>
   setKeywords: React.Dispatch<React.SetStateAction<Keyword[]>>
+  setTableOfContents: React.Dispatch<React.SetStateAction<TOCItem[]>>
 }
 
 export const PageContext = createContext<PageContextType>({
@@ -27,11 +37,13 @@ export const PageContext = createContext<PageContextType>({
   publishedAt: undefined,
   category: undefined,
   keywords: [],
+  tableOfContents: [],
   setTitle: () => {},
   setDescription: () => {},
   setPublishedAt: () => {},
   setCategory: () => {},
   setKeywords: () => {},
+  setTableOfContents: () => {},
 })
 
 export const PageProvider = ({ children }) => {
@@ -40,6 +52,7 @@ export const PageProvider = ({ children }) => {
   const [publishedAt, setPublishedAt] = useState<Date>(undefined)
   const [category, setCategory] = useState<Category | null>(undefined)
   const [keywords, setKeywords] = useState<Keyword[]>([])
+  const [tableOfContents, setTableOfContents] = useState<TOCItem[]>([])
 
   return (
     <PageContext.Provider
@@ -54,6 +67,8 @@ export const PageProvider = ({ children }) => {
         setCategory,
         keywords,
         setKeywords,
+        tableOfContents,
+        setTableOfContents,
       }}
     >
       {children}
@@ -69,14 +84,17 @@ export const PageState: React.FC<{
   publishedAt?: string
   category?: Category | null
   keywords?: Keyword[]
+  tableOfContents?: TOCItem[]
 }> = ({
   title = '',
   description = '',
   publishedAt = undefined,
   category = undefined,
   keywords = undefined,
+  tableOfContents = undefined,
 }) => {
-  const { setTitle, setDescription, setPublishedAt, setCategory, setKeywords } = usePage()
+  const { setTitle, setDescription, setPublishedAt, setCategory, setKeywords, setTableOfContents } =
+    usePage()
 
   useEffect(() => {
     setTitle(title)
@@ -91,6 +109,7 @@ export const PageState: React.FC<{
     }
     setCategory(category)
     setKeywords(keywords)
+    setTableOfContents(tableOfContents)
   }, [
     title,
     setTitle,
@@ -102,6 +121,8 @@ export const PageState: React.FC<{
     setKeywords,
     publishedAt,
     setPublishedAt,
+    tableOfContents,
+    setTableOfContents,
   ])
 
   return null


### PR DESCRIPTION
This PR implements a table of contents when the Post Hero side column is used.

This is achieved by tracking instances of headings within the rich text serializer of the first layout saved as an object with a title, a size, and a url to the component (eg. #identifier). This array is then stored in context where it can be used by the post hero side panel.