### PR TITLE
Feature/improvements-to-custom-svg-layouts

### DIFF
--- a/src/app/_api/fetchUpload.ts
+++ b/src/app/_api/fetchUpload.ts
@@ -1,0 +1,23 @@
+import type { Upload } from '../../payload/payload-types'
+import { UPLOAD_BY_ID } from '../_graphql/uploads'
+
+export const fetchUpload = async (id: number): Promise<Upload> => {
+  const response = await fetch(`${process.env.PAYLOAD_PUBLIC_SERVER_URL}/api/payload/graphql`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      query: UPLOAD_BY_ID,
+      variables: { id },
+    }),
+  })
+
+  const jsonResponse = await response.json()
+
+  if (jsonResponse.errors) {
+    throw new Error(jsonResponse.errors[0].message)
+  }
+
+  return jsonResponse.data.media as Upload
+}

--- a/src/app/_api/fetchUploadByFilename.ts
+++ b/src/app/_api/fetchUploadByFilename.ts
@@ -1,13 +1,13 @@
-import { MEDIA_BY_FILENAME } from '../_graphql/media'
+import { UPLOAD_BY_FILENAME } from '../_graphql/uploads'
 
-export const fetchMediaByFilename = async <T>(filename: string): Promise<T> => {
+export const fetchUploadByFilename = async <T>(filename: string): Promise<T> => {
   const response = await fetch(`${process.env.PAYLOAD_PUBLIC_SERVER_URL}/api/payload/graphql`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({
-      query: MEDIA_BY_FILENAME,
+      query: UPLOAD_BY_FILENAME,
       variables: { filename },
     }),
   })

--- a/src/app/_components/Media/Image/SVG/utilities.ts
+++ b/src/app/_components/Media/Image/SVG/utilities.ts
@@ -1,0 +1,78 @@
+// Utility function to parse transform attribute
+export const parseTransform = (transform: string | null): { x: string; y: string } | null => {
+  if (transform?.includes('translate')) {
+    const match = transform.match(/translate\(([^,]+),\s*([^)]+)\)/)
+    if (match) {
+      return { x: match[1], y: match[2] }
+    }
+  }
+  return null
+}
+
+interface CreateForeignObjectProps {
+  text: SVGTextElement
+  x: number | string
+  y: number | string
+  width: number | string
+  height: number | string
+  fontSize: number
+}
+
+// Function to create and insert foreignObject
+export const createForeignObject = ({
+  text,
+  x,
+  y,
+  width,
+  height,
+  fontSize,
+}: CreateForeignObjectProps): void => {
+  const foreignObject = document.createElementNS('http://www.w3.org/2000/svg', 'foreignObject')
+  foreignObject.setAttribute('x', String(x))
+  foreignObject.setAttribute('y', String(y))
+  foreignObject.setAttribute('width', String(width))
+  foreignObject.setAttribute('height', String(height))
+
+  const div = document.createElement('div')
+  div.style.fontSize = `${fontSize}px`
+  div.style.lineHeight = `${fontSize * 1.5}px`
+  div.style.display = 'flex'
+  div.style.flexDirection = 'column'
+  div.textContent = text.textContent
+
+  // Append the div to the foreignObject and replace the text element in the SVG
+  foreignObject.appendChild(div)
+  if (text.parentNode) {
+    text.parentNode.insertBefore(foreignObject, text)
+    text.parentNode.removeChild(text)
+  }
+}
+
+// Function to adjust <image> hrefs
+export const adjustImageHrefs = (images: NodeListOf<SVGImageElement>): void => {
+  images.forEach(img => {
+    const href = img.getAttribute('xlink:href')
+    if (href) {
+      const modifiedHref = `${process.env.NEXT_PUBLIC_SERVER_URL}/media/${href}`
+      img.setAttribute('xlink:href', modifiedHref)
+    }
+  })
+}
+
+// Function to apply theme-based adjustments to styles
+export const applyThemeAdjustments = (
+  styles: NodeListOf<HTMLStyleElement>,
+  theme: string,
+): void => {
+  styles.forEach(style => {
+    let cssText = style.textContent || ''
+    if (theme === 'dark') {
+      cssText = cssText
+        .replace(/#000000/g, '#ffffff')
+        .replace(/#000/g, '#ffffff')
+        .replace(/black/g, 'white')
+        .replace(/rgb\(0,\s*0,\s*0\)/g, 'rgb(255, 255, 255)')
+    }
+    style.textContent = cssText
+  })
+}

--- a/src/app/_components/Media/Video/index.tsx
+++ b/src/app/_components/Media/Video/index.tsx
@@ -2,7 +2,7 @@
 
 import React, { useEffect, useRef } from 'react'
 
-import { Media } from '../../../../payload/payload-types'
+import { Media, Upload } from '../../../../payload/payload-types'
 import { Props as MediaProps } from '../types'
 
 export const Video: React.FC<MediaProps> = props => {
@@ -21,8 +21,13 @@ export const Video: React.FC<MediaProps> = props => {
     }
   }, [])
 
-  if (resource && typeof resource === 'object') {
-    const { filename } = resource as Media
+  if (
+    resource &&
+    typeof resource === 'object' &&
+    resource.media &&
+    typeof resource.media === 'object'
+  ) {
+    const { filename } = resource.media as Upload
 
     return (
       // add video styles

--- a/src/app/_components/Media/index.tsx
+++ b/src/app/_components/Media/index.tsx
@@ -1,5 +1,7 @@
 import React, { Fragment } from 'react'
 
+import { Upload } from '../../../payload/payload-types'
+import { fetchUpload } from '../../_api/fetchUpload'
 import { Image } from './Image'
 import { Props } from './types'
 import { Video } from './Video'
@@ -7,7 +9,14 @@ import { Video } from './Video'
 export const Media: React.FC<Props> = props => {
   const { className, resource, htmlElement = 'div' } = props
 
-  const isVideo = typeof resource === 'object' && resource?.mimeType?.includes('video')
+  if (typeof resource === 'object' && !resource.media) {
+    return null
+  }
+
+  const isVideo =
+    typeof resource === 'object' &&
+    typeof resource.media !== 'number' &&
+    resource.media?.mimeType?.includes('video')
   const Tag = (htmlElement as any) || Fragment
 
   return (

--- a/src/app/_graphql/media.ts
+++ b/src/app/_graphql/media.ts
@@ -1,31 +1,11 @@
+import { UPLOAD } from './uploads'
+
 export const MEDIA_FIELDS = `
-mimeType
-filename
-width
-height
 alt
 caption
+${UPLOAD}
 `
 
 export const MEDIA = `media {
   ${MEDIA_FIELDS}
 }`
-
-export const MEDIA_BY_FILENAME = `
-query MediaByFilename($filename: String!) {
-  media(filter: { filename: $filename }) {
-    mimeType
-    filename
-    width
-    height
-    alt
-    caption
-    sizes {
-      width
-      height
-      filename
-    }
-  }
-}
-${MEDIA_FIELDS}
-`

--- a/src/app/_graphql/meta.ts
+++ b/src/app/_graphql/meta.ts
@@ -1,9 +1,9 @@
-import { MEDIA_FIELDS } from './media'
+import { UPLOAD_FIELDS } from './uploads'
 
 export const META = `meta {
   title
   image {
-    ${MEDIA_FIELDS}
+    ${UPLOAD_FIELDS}
   }
   description
 }`

--- a/src/app/_graphql/uploads.ts
+++ b/src/app/_graphql/uploads.ts
@@ -1,0 +1,110 @@
+const sizesFields = `
+    card {
+      url
+      width
+      height
+      mimeType
+      filesize
+      filename
+    }
+    desktop {
+      url
+      width
+      height
+      mimeType
+      filesize
+      filename
+    }
+    desktopHalf {
+      url
+      width
+      height
+      mimeType
+      filesize
+      filename
+    }
+    tablet {
+      url
+      width
+      height
+      mimeType
+      filesize
+      filename
+    }
+    tabletHalf {
+      url
+      width
+      height
+      mimeType
+      filesize
+      filename
+    }
+    mobile {
+      url
+      width
+      height
+      mimeType
+      filesize
+      filename
+    }
+  `
+
+export const UPLOAD_FIELDS = `
+  id
+  blurhash
+  updatedAt
+  createdAt
+  url
+  filename
+  mimeType
+  filesize
+  width
+  height
+  sizes {
+    ${sizesFields}
+  }
+`
+
+export const UPLOAD = `media {
+  ${UPLOAD_FIELDS}
+}`
+
+export const UPLOAD_BY_FILENAME = `
+query UploadByFilename($filename: String!) {
+    media(filter: { filename: $filename }) {
+      id
+      blurhash
+      updatedAt
+      createdAt
+      url
+      filename
+      mimeType
+      filesize
+      width
+      height
+      sizes {
+        ${sizesFields}
+      }
+    }
+  }
+`
+
+export const UPLOAD_BY_ID = `
+query UploadById($id: ID!) {
+    media(id: $id) {
+      id
+      blurhash
+      updatedAt
+      createdAt
+      url
+      filename
+      mimeType
+      filesize
+      width
+      height
+      sizes {
+        ${sizesFields}
+      }
+    }
+  }
+`

--- a/src/payload/blocks/MediaBlock/index.ts
+++ b/src/payload/blocks/MediaBlock/index.ts
@@ -53,14 +53,14 @@ export const MediaBlock: Block = {
     {
       name: 'media1',
       label: 'Media 1',
-      type: 'upload',
+      type: 'relationship',
       relationTo: 'media',
       required: true,
     },
     {
       name: 'media2',
       label: 'Media 2',
-      type: 'upload',
+      type: 'relationship',
       relationTo: 'media',
       required: true,
       admin: {
@@ -72,7 +72,7 @@ export const MediaBlock: Block = {
     {
       name: 'media3',
       label: 'Media 3',
-      type: 'upload',
+      type: 'relationship',
       relationTo: 'media',
       required: true,
       admin: {

--- a/src/payload/collections/Media/index.ts
+++ b/src/payload/collections/Media/index.ts
@@ -1,0 +1,80 @@
+import type { CollectionConfig } from 'payload/types'
+
+import { CollectionInstructions } from '../../components/CollectionIntro'
+import ThumbnailCell from '../../components/ThumbnailCell'
+
+export const Media: CollectionConfig = {
+  slug: 'media',
+  admin: {
+    useAsTitle: 'alt',
+    defaultColumns: ['media', 'alt', 'caption'],
+  },
+  access: {
+    read: () => true,
+  },
+  fields: [
+    {
+      name: 'alt',
+      label: 'Alt Text',
+      type: 'text',
+      required: true,
+    },
+    {
+      name: 'caption',
+      label: 'Caption',
+      type: 'richText',
+    },
+    {
+      name: 'instructions',
+      type: 'ui',
+      admin: {
+        components: {
+          Field: CollectionInstructions,
+        },
+      },
+    },
+    {
+      type: 'row',
+      fields: [
+        {
+          name: 'media',
+          type: 'upload',
+          relationTo: 'uploads',
+          label: 'Image/Video',
+          required: true,
+          admin: {
+            components: {
+              Cell: ThumbnailCell,
+            },
+          },
+        },
+        {
+          name: 'mediaDark',
+          type: 'upload',
+          relationTo: 'uploads',
+          label: '(Optional) Image for Dark Mode',
+          required: false,
+        },
+      ],
+    },
+    {
+      type: 'row',
+      fields: [
+        {
+          name: 'mediaMobile',
+          type: 'upload',
+          relationTo: 'uploads',
+          label: '(Optional) Image for Mobile',
+          required: false,
+        },
+        {
+          name: 'mediaMobileDark',
+          type: 'upload',
+          relationTo: 'uploads',
+          label: '(Optional) Image for Mobile Dark Mode',
+          required: false,
+        },
+      ],
+    },
+  ],
+}

--- a/src/payload/collections/Posts/index.ts
+++ b/src/payload/collections/Posts/index.ts
@@ -141,7 +141,7 @@ export const Posts: CollectionConfig = {
       fields: [
         {
           name: 'media',
-          type: 'upload',
+          type: 'relationship',
           label: 'Image/Video',
           relationTo: 'media',
           required: false,

--- a/src/payload/collections/Uploads.ts
+++ b/src/payload/collections/Uploads.ts
@@ -1,10 +1,9 @@
-import path from 'path'
 import type { CollectionConfig } from 'payload/types'
 
-export const Media: CollectionConfig = {
-  slug: 'media',
+export const Uploads: CollectionConfig = {
+  slug: 'uploads',
   upload: {
-    staticDir: path.resolve(__dirname, '../../../media'),
+    staticURL: '/media',
     imageSizes: [
       {
         name: 'card',
@@ -47,17 +46,8 @@ export const Media: CollectionConfig = {
   access: {
     read: () => true,
   },
-  fields: [
-    {
-      name: 'alt',
-      label: 'Alt Text',
-      type: 'text',
-      required: true,
-    },
-    {
-      name: 'caption',
-      label: 'Caption',
-      type: 'richText',
-    },
-  ],
+  fields: [],
+  admin: {
+    group: 'Media',
+  },
 }

--- a/src/payload/components/CollectionIntro.tsx
+++ b/src/payload/components/CollectionIntro.tsx
@@ -1,0 +1,7 @@
+import * as React from 'react'
+
+export const CollectionInstructions: React.FC = props => {
+  const instructions =
+    'The main image will be optimized for different resolutions. The dark mode and mobile images can be optionally used when the image does not present well in dark mode or mobile screen sizes.'
+  return <h4>{instructions}</h4>
+}

--- a/src/payload/components/ThumbnailCell.tsx
+++ b/src/payload/components/ThumbnailCell.tsx
@@ -1,0 +1,34 @@
+import React, { useEffect, useState } from 'react'
+import type { Props } from 'payload/components/views/Cell'
+
+const ThumbnailCell: React.FC<Props> = props => {
+  const { cellData = '', rowData } = props
+  const [url, setUrl] = useState('')
+
+  useEffect(() => {
+    if (cellData) {
+      const apiUrl = `${process.env.PAYLOAD_PUBLIC_SERVER_URL}/api/payload/uploads/${cellData}`
+
+      fetch(apiUrl, {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
+        .then(response => response.json())
+        .then(data => {
+          setUrl(data.url)
+        })
+        .catch()
+    }
+  }, [cellData])
+
+  return url ? (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img src={url} style={{ maxWidth: '24em', height: 'auto' }} />
+  ) : (
+    <>No image available</>
+  )
+}
+
+export default ThumbnailCell

--- a/src/payload/fields/layout.ts
+++ b/src/payload/fields/layout.ts
@@ -105,7 +105,7 @@ export const layout: Field = {
               fields: [
                 {
                   name: 'media',
-                  type: 'upload',
+                  type: 'relationship',
                   relationTo: 'media',
                   required: false,
                 },

--- a/src/payload/fields/mediaField.ts
+++ b/src/payload/fields/mediaField.ts
@@ -1,0 +1,12 @@
+import type { Field } from 'payload/types'
+
+// Todo: make a custom component to show the image thumbnail
+// doesn't seem easy right now
+
+export const mediaField: Field = {
+  name: 'media',
+  type: 'relationship',
+  label: 'Image/Video',
+  relationTo: 'media',
+  required: false,
+}

--- a/src/payload/generated-schema.graphql
+++ b/src/payload/generated-schema.graphql
@@ -26,6 +26,9 @@ type Query {
   docAccessUser(id: Int!): usersDocAccess
   meUser: usersMe
   initializedUser: Boolean
+  Upload(id: Int!, draft: Boolean): Upload
+  Uploads(draft: Boolean, where: Upload_where, limit: Int, page: Int, sort: String): Uploads
+  docAccessUpload(id: Int!): uploadsDocAccess
   Redirect(id: Int!, draft: Boolean): Redirect
   Redirects(draft: Boolean, where: Redirect_where, limit: Int, page: Int, sort: String): Redirects
   docAccessRedirect(id: Int!): redirectsDocAccess
@@ -89,15 +92,22 @@ enum SideColumn_style {
 }
 
 type Hero {
-  media(where: Hero_Media_where): Media
+  media: Media
   description(depth: Int): JSON
   links: [LinkGroupField!]
 }
 
 type Media {
   id: Int
+  media(where: Media_Media_where): Upload!
   alt: String!
   caption(depth: Int): JSON
+  updatedAt: DateTime
+  createdAt: DateTime
+}
+
+type Upload {
+  id: Int
   blurhash: String
   updatedAt: DateTime
   createdAt: DateTime
@@ -107,188 +117,714 @@ type Media {
   filesize: Float
   width: Float
   height: Float
+  sizes: Upload_Sizes
+}
+
+type Upload_Sizes {
+  card: Upload_Sizes_Card
+  desktop: Upload_Sizes_Desktop
+  desktopHalf: Upload_Sizes_DesktopHalf
+  tablet: Upload_Sizes_Tablet
+  tabletHalf: Upload_Sizes_TabletHalf
+  mobile: Upload_Sizes_Mobile
+}
+
+type Upload_Sizes_Card {
+  url: String
+  width: Float
+  height: Float
+  mimeType: String
+  filesize: Float
+  filename: String
+}
+
+type Upload_Sizes_Desktop {
+  url: String
+  width: Float
+  height: Float
+  mimeType: String
+  filesize: Float
+  filename: String
+}
+
+type Upload_Sizes_DesktopHalf {
+  url: String
+  width: Float
+  height: Float
+  mimeType: String
+  filesize: Float
+  filename: String
+}
+
+type Upload_Sizes_Tablet {
+  url: String
+  width: Float
+  height: Float
+  mimeType: String
+  filesize: Float
+  filename: String
+}
+
+type Upload_Sizes_TabletHalf {
+  url: String
+  width: Float
+  height: Float
+  mimeType: String
+  filesize: Float
+  filename: String
+}
+
+type Upload_Sizes_Mobile {
+  url: String
+  width: Float
+  height: Float
+  mimeType: String
+  filesize: Float
+  filename: String
+}
+
+input Media_Media_where {
+  blurhash: Media_Media_blurhash_operator
+  updatedAt: Media_Media_updatedAt_operator
+  createdAt: Media_Media_createdAt_operator
+  url: Media_Media_url_operator
+  filename: Media_Media_filename_operator
+  mimeType: Media_Media_mimeType_operator
+  filesize: Media_Media_filesize_operator
+  width: Media_Media_width_operator
+  height: Media_Media_height_operator
+  sizes__card__url: Media_Media_sizes__card__url_operator
+  sizes__card__width: Media_Media_sizes__card__width_operator
+  sizes__card__height: Media_Media_sizes__card__height_operator
+  sizes__card__mimeType: Media_Media_sizes__card__mimeType_operator
+  sizes__card__filesize: Media_Media_sizes__card__filesize_operator
+  sizes__card__filename: Media_Media_sizes__card__filename_operator
+  sizes__desktop__url: Media_Media_sizes__desktop__url_operator
+  sizes__desktop__width: Media_Media_sizes__desktop__width_operator
+  sizes__desktop__height: Media_Media_sizes__desktop__height_operator
+  sizes__desktop__mimeType: Media_Media_sizes__desktop__mimeType_operator
+  sizes__desktop__filesize: Media_Media_sizes__desktop__filesize_operator
+  sizes__desktop__filename: Media_Media_sizes__desktop__filename_operator
+  sizes__desktopHalf__url: Media_Media_sizes__desktopHalf__url_operator
+  sizes__desktopHalf__width: Media_Media_sizes__desktopHalf__width_operator
+  sizes__desktopHalf__height: Media_Media_sizes__desktopHalf__height_operator
+  sizes__desktopHalf__mimeType: Media_Media_sizes__desktopHalf__mimeType_operator
+  sizes__desktopHalf__filesize: Media_Media_sizes__desktopHalf__filesize_operator
+  sizes__desktopHalf__filename: Media_Media_sizes__desktopHalf__filename_operator
+  sizes__tablet__url: Media_Media_sizes__tablet__url_operator
+  sizes__tablet__width: Media_Media_sizes__tablet__width_operator
+  sizes__tablet__height: Media_Media_sizes__tablet__height_operator
+  sizes__tablet__mimeType: Media_Media_sizes__tablet__mimeType_operator
+  sizes__tablet__filesize: Media_Media_sizes__tablet__filesize_operator
+  sizes__tablet__filename: Media_Media_sizes__tablet__filename_operator
+  sizes__tabletHalf__url: Media_Media_sizes__tabletHalf__url_operator
+  sizes__tabletHalf__width: Media_Media_sizes__tabletHalf__width_operator
+  sizes__tabletHalf__height: Media_Media_sizes__tabletHalf__height_operator
+  sizes__tabletHalf__mimeType: Media_Media_sizes__tabletHalf__mimeType_operator
+  sizes__tabletHalf__filesize: Media_Media_sizes__tabletHalf__filesize_operator
+  sizes__tabletHalf__filename: Media_Media_sizes__tabletHalf__filename_operator
+  sizes__mobile__url: Media_Media_sizes__mobile__url_operator
+  sizes__mobile__width: Media_Media_sizes__mobile__width_operator
+  sizes__mobile__height: Media_Media_sizes__mobile__height_operator
+  sizes__mobile__mimeType: Media_Media_sizes__mobile__mimeType_operator
+  sizes__mobile__filesize: Media_Media_sizes__mobile__filesize_operator
+  sizes__mobile__filename: Media_Media_sizes__mobile__filename_operator
+  id: Media_Media_id_operator
+  AND: [Media_Media_where_and]
+  OR: [Media_Media_where_or]
+}
+
+input Media_Media_blurhash_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Media_Media_updatedAt_operator {
+  equals: DateTime
+  not_equals: DateTime
+  greater_than_equal: DateTime
+  greater_than: DateTime
+  less_than_equal: DateTime
+  less_than: DateTime
+  like: DateTime
+  exists: Boolean
+}
+
+input Media_Media_createdAt_operator {
+  equals: DateTime
+  not_equals: DateTime
+  greater_than_equal: DateTime
+  greater_than: DateTime
+  less_than_equal: DateTime
+  less_than: DateTime
+  like: DateTime
+  exists: Boolean
+}
+
+input Media_Media_url_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Media_Media_filename_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Media_Media_mimeType_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Media_Media_filesize_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Media_Media_width_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Media_Media_height_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Media_Media_sizes__card__url_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Media_Media_sizes__card__width_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Media_Media_sizes__card__height_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Media_Media_sizes__card__mimeType_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Media_Media_sizes__card__filesize_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Media_Media_sizes__card__filename_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Media_Media_sizes__desktop__url_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Media_Media_sizes__desktop__width_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Media_Media_sizes__desktop__height_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Media_Media_sizes__desktop__mimeType_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Media_Media_sizes__desktop__filesize_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Media_Media_sizes__desktop__filename_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Media_Media_sizes__desktopHalf__url_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Media_Media_sizes__desktopHalf__width_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Media_Media_sizes__desktopHalf__height_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Media_Media_sizes__desktopHalf__mimeType_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Media_Media_sizes__desktopHalf__filesize_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Media_Media_sizes__desktopHalf__filename_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Media_Media_sizes__tablet__url_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Media_Media_sizes__tablet__width_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Media_Media_sizes__tablet__height_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Media_Media_sizes__tablet__mimeType_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Media_Media_sizes__tablet__filesize_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Media_Media_sizes__tablet__filename_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Media_Media_sizes__tabletHalf__url_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Media_Media_sizes__tabletHalf__width_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Media_Media_sizes__tabletHalf__height_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Media_Media_sizes__tabletHalf__mimeType_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Media_Media_sizes__tabletHalf__filesize_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Media_Media_sizes__tabletHalf__filename_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Media_Media_sizes__mobile__url_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Media_Media_sizes__mobile__width_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Media_Media_sizes__mobile__height_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Media_Media_sizes__mobile__mimeType_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Media_Media_sizes__mobile__filesize_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Media_Media_sizes__mobile__filename_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Media_Media_id_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Media_Media_where_and {
+  blurhash: Media_Media_blurhash_operator
+  updatedAt: Media_Media_updatedAt_operator
+  createdAt: Media_Media_createdAt_operator
+  url: Media_Media_url_operator
+  filename: Media_Media_filename_operator
+  mimeType: Media_Media_mimeType_operator
+  filesize: Media_Media_filesize_operator
+  width: Media_Media_width_operator
+  height: Media_Media_height_operator
+  sizes__card__url: Media_Media_sizes__card__url_operator
+  sizes__card__width: Media_Media_sizes__card__width_operator
+  sizes__card__height: Media_Media_sizes__card__height_operator
+  sizes__card__mimeType: Media_Media_sizes__card__mimeType_operator
+  sizes__card__filesize: Media_Media_sizes__card__filesize_operator
+  sizes__card__filename: Media_Media_sizes__card__filename_operator
+  sizes__desktop__url: Media_Media_sizes__desktop__url_operator
+  sizes__desktop__width: Media_Media_sizes__desktop__width_operator
+  sizes__desktop__height: Media_Media_sizes__desktop__height_operator
+  sizes__desktop__mimeType: Media_Media_sizes__desktop__mimeType_operator
+  sizes__desktop__filesize: Media_Media_sizes__desktop__filesize_operator
+  sizes__desktop__filename: Media_Media_sizes__desktop__filename_operator
+  sizes__desktopHalf__url: Media_Media_sizes__desktopHalf__url_operator
+  sizes__desktopHalf__width: Media_Media_sizes__desktopHalf__width_operator
+  sizes__desktopHalf__height: Media_Media_sizes__desktopHalf__height_operator
+  sizes__desktopHalf__mimeType: Media_Media_sizes__desktopHalf__mimeType_operator
+  sizes__desktopHalf__filesize: Media_Media_sizes__desktopHalf__filesize_operator
+  sizes__desktopHalf__filename: Media_Media_sizes__desktopHalf__filename_operator
+  sizes__tablet__url: Media_Media_sizes__tablet__url_operator
+  sizes__tablet__width: Media_Media_sizes__tablet__width_operator
+  sizes__tablet__height: Media_Media_sizes__tablet__height_operator
+  sizes__tablet__mimeType: Media_Media_sizes__tablet__mimeType_operator
+  sizes__tablet__filesize: Media_Media_sizes__tablet__filesize_operator
+  sizes__tablet__filename: Media_Media_sizes__tablet__filename_operator
+  sizes__tabletHalf__url: Media_Media_sizes__tabletHalf__url_operator
+  sizes__tabletHalf__width: Media_Media_sizes__tabletHalf__width_operator
+  sizes__tabletHalf__height: Media_Media_sizes__tabletHalf__height_operator
+  sizes__tabletHalf__mimeType: Media_Media_sizes__tabletHalf__mimeType_operator
+  sizes__tabletHalf__filesize: Media_Media_sizes__tabletHalf__filesize_operator
+  sizes__tabletHalf__filename: Media_Media_sizes__tabletHalf__filename_operator
+  sizes__mobile__url: Media_Media_sizes__mobile__url_operator
+  sizes__mobile__width: Media_Media_sizes__mobile__width_operator
+  sizes__mobile__height: Media_Media_sizes__mobile__height_operator
+  sizes__mobile__mimeType: Media_Media_sizes__mobile__mimeType_operator
+  sizes__mobile__filesize: Media_Media_sizes__mobile__filesize_operator
+  sizes__mobile__filename: Media_Media_sizes__mobile__filename_operator
+  id: Media_Media_id_operator
+  AND: [Media_Media_where_and]
+  OR: [Media_Media_where_or]
+}
+
+input Media_Media_where_or {
+  blurhash: Media_Media_blurhash_operator
+  updatedAt: Media_Media_updatedAt_operator
+  createdAt: Media_Media_createdAt_operator
+  url: Media_Media_url_operator
+  filename: Media_Media_filename_operator
+  mimeType: Media_Media_mimeType_operator
+  filesize: Media_Media_filesize_operator
+  width: Media_Media_width_operator
+  height: Media_Media_height_operator
+  sizes__card__url: Media_Media_sizes__card__url_operator
+  sizes__card__width: Media_Media_sizes__card__width_operator
+  sizes__card__height: Media_Media_sizes__card__height_operator
+  sizes__card__mimeType: Media_Media_sizes__card__mimeType_operator
+  sizes__card__filesize: Media_Media_sizes__card__filesize_operator
+  sizes__card__filename: Media_Media_sizes__card__filename_operator
+  sizes__desktop__url: Media_Media_sizes__desktop__url_operator
+  sizes__desktop__width: Media_Media_sizes__desktop__width_operator
+  sizes__desktop__height: Media_Media_sizes__desktop__height_operator
+  sizes__desktop__mimeType: Media_Media_sizes__desktop__mimeType_operator
+  sizes__desktop__filesize: Media_Media_sizes__desktop__filesize_operator
+  sizes__desktop__filename: Media_Media_sizes__desktop__filename_operator
+  sizes__desktopHalf__url: Media_Media_sizes__desktopHalf__url_operator
+  sizes__desktopHalf__width: Media_Media_sizes__desktopHalf__width_operator
+  sizes__desktopHalf__height: Media_Media_sizes__desktopHalf__height_operator
+  sizes__desktopHalf__mimeType: Media_Media_sizes__desktopHalf__mimeType_operator
+  sizes__desktopHalf__filesize: Media_Media_sizes__desktopHalf__filesize_operator
+  sizes__desktopHalf__filename: Media_Media_sizes__desktopHalf__filename_operator
+  sizes__tablet__url: Media_Media_sizes__tablet__url_operator
+  sizes__tablet__width: Media_Media_sizes__tablet__width_operator
+  sizes__tablet__height: Media_Media_sizes__tablet__height_operator
+  sizes__tablet__mimeType: Media_Media_sizes__tablet__mimeType_operator
+  sizes__tablet__filesize: Media_Media_sizes__tablet__filesize_operator
+  sizes__tablet__filename: Media_Media_sizes__tablet__filename_operator
+  sizes__tabletHalf__url: Media_Media_sizes__tabletHalf__url_operator
+  sizes__tabletHalf__width: Media_Media_sizes__tabletHalf__width_operator
+  sizes__tabletHalf__height: Media_Media_sizes__tabletHalf__height_operator
+  sizes__tabletHalf__mimeType: Media_Media_sizes__tabletHalf__mimeType_operator
+  sizes__tabletHalf__filesize: Media_Media_sizes__tabletHalf__filesize_operator
+  sizes__tabletHalf__filename: Media_Media_sizes__tabletHalf__filename_operator
+  sizes__mobile__url: Media_Media_sizes__mobile__url_operator
+  sizes__mobile__width: Media_Media_sizes__mobile__width_operator
+  sizes__mobile__height: Media_Media_sizes__mobile__height_operator
+  sizes__mobile__mimeType: Media_Media_sizes__mobile__mimeType_operator
+  sizes__mobile__filesize: Media_Media_sizes__mobile__filesize_operator
+  sizes__mobile__filename: Media_Media_sizes__mobile__filename_operator
+  id: Media_Media_id_operator
+  AND: [Media_Media_where_and]
+  OR: [Media_Media_where_or]
 }
 
 """
 The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
 """
 scalar JSON
-
-input Hero_Media_where {
-  alt: Hero_Media_alt_operator
-  caption: Hero_Media_caption_operator
-  blurhash: Hero_Media_blurhash_operator
-  updatedAt: Hero_Media_updatedAt_operator
-  createdAt: Hero_Media_createdAt_operator
-  url: Hero_Media_url_operator
-  filename: Hero_Media_filename_operator
-  mimeType: Hero_Media_mimeType_operator
-  filesize: Hero_Media_filesize_operator
-  width: Hero_Media_width_operator
-  height: Hero_Media_height_operator
-  id: Hero_Media_id_operator
-  AND: [Hero_Media_where_and]
-  OR: [Hero_Media_where_or]
-}
-
-input Hero_Media_alt_operator {
-  equals: String
-  not_equals: String
-  like: String
-  contains: String
-  in: [String]
-  not_in: [String]
-  all: [String]
-}
-
-input Hero_Media_caption_operator {
-  equals: JSON
-  not_equals: JSON
-  like: JSON
-  contains: JSON
-  exists: Boolean
-}
-
-input Hero_Media_blurhash_operator {
-  equals: String
-  not_equals: String
-  like: String
-  contains: String
-  in: [String]
-  not_in: [String]
-  all: [String]
-  exists: Boolean
-}
-
-input Hero_Media_updatedAt_operator {
-  equals: DateTime
-  not_equals: DateTime
-  greater_than_equal: DateTime
-  greater_than: DateTime
-  less_than_equal: DateTime
-  less_than: DateTime
-  like: DateTime
-  exists: Boolean
-}
-
-input Hero_Media_createdAt_operator {
-  equals: DateTime
-  not_equals: DateTime
-  greater_than_equal: DateTime
-  greater_than: DateTime
-  less_than_equal: DateTime
-  less_than: DateTime
-  like: DateTime
-  exists: Boolean
-}
-
-input Hero_Media_url_operator {
-  equals: String
-  not_equals: String
-  like: String
-  contains: String
-  in: [String]
-  not_in: [String]
-  all: [String]
-  exists: Boolean
-}
-
-input Hero_Media_filename_operator {
-  equals: String
-  not_equals: String
-  like: String
-  contains: String
-  in: [String]
-  not_in: [String]
-  all: [String]
-  exists: Boolean
-}
-
-input Hero_Media_mimeType_operator {
-  equals: String
-  not_equals: String
-  like: String
-  contains: String
-  in: [String]
-  not_in: [String]
-  all: [String]
-  exists: Boolean
-}
-
-input Hero_Media_filesize_operator {
-  equals: Float
-  not_equals: Float
-  greater_than_equal: Float
-  greater_than: Float
-  less_than_equal: Float
-  less_than: Float
-  exists: Boolean
-}
-
-input Hero_Media_width_operator {
-  equals: Float
-  not_equals: Float
-  greater_than_equal: Float
-  greater_than: Float
-  less_than_equal: Float
-  less_than: Float
-  exists: Boolean
-}
-
-input Hero_Media_height_operator {
-  equals: Float
-  not_equals: Float
-  greater_than_equal: Float
-  greater_than: Float
-  less_than_equal: Float
-  less_than: Float
-  exists: Boolean
-}
-
-input Hero_Media_id_operator {
-  equals: String
-  not_equals: String
-  like: String
-  contains: String
-  in: [String]
-  not_in: [String]
-  all: [String]
-  exists: Boolean
-}
-
-input Hero_Media_where_and {
-  alt: Hero_Media_alt_operator
-  caption: Hero_Media_caption_operator
-  blurhash: Hero_Media_blurhash_operator
-  updatedAt: Hero_Media_updatedAt_operator
-  createdAt: Hero_Media_createdAt_operator
-  url: Hero_Media_url_operator
-  filename: Hero_Media_filename_operator
-  mimeType: Hero_Media_mimeType_operator
-  filesize: Hero_Media_filesize_operator
-  width: Hero_Media_width_operator
-  height: Hero_Media_height_operator
-  id: Hero_Media_id_operator
-  AND: [Hero_Media_where_and]
-  OR: [Hero_Media_where_or]
-}
-
-input Hero_Media_where_or {
-  alt: Hero_Media_alt_operator
-  caption: Hero_Media_caption_operator
-  blurhash: Hero_Media_blurhash_operator
-  updatedAt: Hero_Media_updatedAt_operator
-  createdAt: Hero_Media_createdAt_operator
-  url: Hero_Media_url_operator
-  filename: Hero_Media_filename_operator
-  mimeType: Hero_Media_mimeType_operator
-  filesize: Hero_Media_filesize_operator
-  width: Hero_Media_width_operator
-  height: Hero_Media_height_operator
-  id: Hero_Media_id_operator
-  AND: [Hero_Media_where_and]
-  OR: [Hero_Media_where_or]
-}
 
 type LinkGroupField {
   link: LinkField
@@ -329,6 +865,8 @@ enum LinkField_appearance {
 type ProjectHero {
   year: Float
   client: Client
+  usePostDescription: Boolean
+  customDescription(depth: Int): JSON
   links: [LinkGroupField!]
 }
 
@@ -341,28 +879,22 @@ type Client {
 
 type MainColumn {
   style: MainColumn_style
-  row1column1(depth: Int): JSON
-  row1column2(depth: Int): JSON
-  row2column1(depth: Int): JSON
-  row2column2(depth: Int): JSON
+  column1(depth: Int): JSON
+  column2(depth: Int): JSON
 }
 
 enum MainColumn_style {
   singleLayout
-  twoRows
   twoColumns
-  threeSectionGrid
 }
 
 type Page_Meta {
   title: String
   description: String
-  image(where: Page_Meta_Image_where): Media
+  image(where: Page_Meta_Image_where): Upload
 }
 
 input Page_Meta_Image_where {
-  alt: Page_Meta_Image_alt_operator
-  caption: Page_Meta_Image_caption_operator
   blurhash: Page_Meta_Image_blurhash_operator
   updatedAt: Page_Meta_Image_updatedAt_operator
   createdAt: Page_Meta_Image_createdAt_operator
@@ -372,27 +904,45 @@ input Page_Meta_Image_where {
   filesize: Page_Meta_Image_filesize_operator
   width: Page_Meta_Image_width_operator
   height: Page_Meta_Image_height_operator
+  sizes__card__url: Page_Meta_Image_sizes__card__url_operator
+  sizes__card__width: Page_Meta_Image_sizes__card__width_operator
+  sizes__card__height: Page_Meta_Image_sizes__card__height_operator
+  sizes__card__mimeType: Page_Meta_Image_sizes__card__mimeType_operator
+  sizes__card__filesize: Page_Meta_Image_sizes__card__filesize_operator
+  sizes__card__filename: Page_Meta_Image_sizes__card__filename_operator
+  sizes__desktop__url: Page_Meta_Image_sizes__desktop__url_operator
+  sizes__desktop__width: Page_Meta_Image_sizes__desktop__width_operator
+  sizes__desktop__height: Page_Meta_Image_sizes__desktop__height_operator
+  sizes__desktop__mimeType: Page_Meta_Image_sizes__desktop__mimeType_operator
+  sizes__desktop__filesize: Page_Meta_Image_sizes__desktop__filesize_operator
+  sizes__desktop__filename: Page_Meta_Image_sizes__desktop__filename_operator
+  sizes__desktopHalf__url: Page_Meta_Image_sizes__desktopHalf__url_operator
+  sizes__desktopHalf__width: Page_Meta_Image_sizes__desktopHalf__width_operator
+  sizes__desktopHalf__height: Page_Meta_Image_sizes__desktopHalf__height_operator
+  sizes__desktopHalf__mimeType: Page_Meta_Image_sizes__desktopHalf__mimeType_operator
+  sizes__desktopHalf__filesize: Page_Meta_Image_sizes__desktopHalf__filesize_operator
+  sizes__desktopHalf__filename: Page_Meta_Image_sizes__desktopHalf__filename_operator
+  sizes__tablet__url: Page_Meta_Image_sizes__tablet__url_operator
+  sizes__tablet__width: Page_Meta_Image_sizes__tablet__width_operator
+  sizes__tablet__height: Page_Meta_Image_sizes__tablet__height_operator
+  sizes__tablet__mimeType: Page_Meta_Image_sizes__tablet__mimeType_operator
+  sizes__tablet__filesize: Page_Meta_Image_sizes__tablet__filesize_operator
+  sizes__tablet__filename: Page_Meta_Image_sizes__tablet__filename_operator
+  sizes__tabletHalf__url: Page_Meta_Image_sizes__tabletHalf__url_operator
+  sizes__tabletHalf__width: Page_Meta_Image_sizes__tabletHalf__width_operator
+  sizes__tabletHalf__height: Page_Meta_Image_sizes__tabletHalf__height_operator
+  sizes__tabletHalf__mimeType: Page_Meta_Image_sizes__tabletHalf__mimeType_operator
+  sizes__tabletHalf__filesize: Page_Meta_Image_sizes__tabletHalf__filesize_operator
+  sizes__tabletHalf__filename: Page_Meta_Image_sizes__tabletHalf__filename_operator
+  sizes__mobile__url: Page_Meta_Image_sizes__mobile__url_operator
+  sizes__mobile__width: Page_Meta_Image_sizes__mobile__width_operator
+  sizes__mobile__height: Page_Meta_Image_sizes__mobile__height_operator
+  sizes__mobile__mimeType: Page_Meta_Image_sizes__mobile__mimeType_operator
+  sizes__mobile__filesize: Page_Meta_Image_sizes__mobile__filesize_operator
+  sizes__mobile__filename: Page_Meta_Image_sizes__mobile__filename_operator
   id: Page_Meta_Image_id_operator
   AND: [Page_Meta_Image_where_and]
   OR: [Page_Meta_Image_where_or]
-}
-
-input Page_Meta_Image_alt_operator {
-  equals: String
-  not_equals: String
-  like: String
-  contains: String
-  in: [String]
-  not_in: [String]
-  all: [String]
-}
-
-input Page_Meta_Image_caption_operator {
-  equals: JSON
-  not_equals: JSON
-  like: JSON
-  contains: JSON
-  exists: Boolean
 }
 
 input Page_Meta_Image_blurhash_operator {
@@ -491,6 +1041,384 @@ input Page_Meta_Image_height_operator {
   exists: Boolean
 }
 
+input Page_Meta_Image_sizes__card__url_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Page_Meta_Image_sizes__card__width_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Page_Meta_Image_sizes__card__height_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Page_Meta_Image_sizes__card__mimeType_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Page_Meta_Image_sizes__card__filesize_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Page_Meta_Image_sizes__card__filename_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Page_Meta_Image_sizes__desktop__url_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Page_Meta_Image_sizes__desktop__width_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Page_Meta_Image_sizes__desktop__height_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Page_Meta_Image_sizes__desktop__mimeType_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Page_Meta_Image_sizes__desktop__filesize_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Page_Meta_Image_sizes__desktop__filename_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Page_Meta_Image_sizes__desktopHalf__url_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Page_Meta_Image_sizes__desktopHalf__width_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Page_Meta_Image_sizes__desktopHalf__height_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Page_Meta_Image_sizes__desktopHalf__mimeType_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Page_Meta_Image_sizes__desktopHalf__filesize_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Page_Meta_Image_sizes__desktopHalf__filename_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Page_Meta_Image_sizes__tablet__url_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Page_Meta_Image_sizes__tablet__width_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Page_Meta_Image_sizes__tablet__height_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Page_Meta_Image_sizes__tablet__mimeType_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Page_Meta_Image_sizes__tablet__filesize_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Page_Meta_Image_sizes__tablet__filename_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Page_Meta_Image_sizes__tabletHalf__url_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Page_Meta_Image_sizes__tabletHalf__width_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Page_Meta_Image_sizes__tabletHalf__height_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Page_Meta_Image_sizes__tabletHalf__mimeType_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Page_Meta_Image_sizes__tabletHalf__filesize_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Page_Meta_Image_sizes__tabletHalf__filename_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Page_Meta_Image_sizes__mobile__url_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Page_Meta_Image_sizes__mobile__width_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Page_Meta_Image_sizes__mobile__height_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Page_Meta_Image_sizes__mobile__mimeType_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Page_Meta_Image_sizes__mobile__filesize_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Page_Meta_Image_sizes__mobile__filename_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
 input Page_Meta_Image_id_operator {
   equals: String
   not_equals: String
@@ -503,8 +1431,6 @@ input Page_Meta_Image_id_operator {
 }
 
 input Page_Meta_Image_where_and {
-  alt: Page_Meta_Image_alt_operator
-  caption: Page_Meta_Image_caption_operator
   blurhash: Page_Meta_Image_blurhash_operator
   updatedAt: Page_Meta_Image_updatedAt_operator
   createdAt: Page_Meta_Image_createdAt_operator
@@ -514,14 +1440,48 @@ input Page_Meta_Image_where_and {
   filesize: Page_Meta_Image_filesize_operator
   width: Page_Meta_Image_width_operator
   height: Page_Meta_Image_height_operator
+  sizes__card__url: Page_Meta_Image_sizes__card__url_operator
+  sizes__card__width: Page_Meta_Image_sizes__card__width_operator
+  sizes__card__height: Page_Meta_Image_sizes__card__height_operator
+  sizes__card__mimeType: Page_Meta_Image_sizes__card__mimeType_operator
+  sizes__card__filesize: Page_Meta_Image_sizes__card__filesize_operator
+  sizes__card__filename: Page_Meta_Image_sizes__card__filename_operator
+  sizes__desktop__url: Page_Meta_Image_sizes__desktop__url_operator
+  sizes__desktop__width: Page_Meta_Image_sizes__desktop__width_operator
+  sizes__desktop__height: Page_Meta_Image_sizes__desktop__height_operator
+  sizes__desktop__mimeType: Page_Meta_Image_sizes__desktop__mimeType_operator
+  sizes__desktop__filesize: Page_Meta_Image_sizes__desktop__filesize_operator
+  sizes__desktop__filename: Page_Meta_Image_sizes__desktop__filename_operator
+  sizes__desktopHalf__url: Page_Meta_Image_sizes__desktopHalf__url_operator
+  sizes__desktopHalf__width: Page_Meta_Image_sizes__desktopHalf__width_operator
+  sizes__desktopHalf__height: Page_Meta_Image_sizes__desktopHalf__height_operator
+  sizes__desktopHalf__mimeType: Page_Meta_Image_sizes__desktopHalf__mimeType_operator
+  sizes__desktopHalf__filesize: Page_Meta_Image_sizes__desktopHalf__filesize_operator
+  sizes__desktopHalf__filename: Page_Meta_Image_sizes__desktopHalf__filename_operator
+  sizes__tablet__url: Page_Meta_Image_sizes__tablet__url_operator
+  sizes__tablet__width: Page_Meta_Image_sizes__tablet__width_operator
+  sizes__tablet__height: Page_Meta_Image_sizes__tablet__height_operator
+  sizes__tablet__mimeType: Page_Meta_Image_sizes__tablet__mimeType_operator
+  sizes__tablet__filesize: Page_Meta_Image_sizes__tablet__filesize_operator
+  sizes__tablet__filename: Page_Meta_Image_sizes__tablet__filename_operator
+  sizes__tabletHalf__url: Page_Meta_Image_sizes__tabletHalf__url_operator
+  sizes__tabletHalf__width: Page_Meta_Image_sizes__tabletHalf__width_operator
+  sizes__tabletHalf__height: Page_Meta_Image_sizes__tabletHalf__height_operator
+  sizes__tabletHalf__mimeType: Page_Meta_Image_sizes__tabletHalf__mimeType_operator
+  sizes__tabletHalf__filesize: Page_Meta_Image_sizes__tabletHalf__filesize_operator
+  sizes__tabletHalf__filename: Page_Meta_Image_sizes__tabletHalf__filename_operator
+  sizes__mobile__url: Page_Meta_Image_sizes__mobile__url_operator
+  sizes__mobile__width: Page_Meta_Image_sizes__mobile__width_operator
+  sizes__mobile__height: Page_Meta_Image_sizes__mobile__height_operator
+  sizes__mobile__mimeType: Page_Meta_Image_sizes__mobile__mimeType_operator
+  sizes__mobile__filesize: Page_Meta_Image_sizes__mobile__filesize_operator
+  sizes__mobile__filename: Page_Meta_Image_sizes__mobile__filename_operator
   id: Page_Meta_Image_id_operator
   AND: [Page_Meta_Image_where_and]
   OR: [Page_Meta_Image_where_or]
 }
 
 input Page_Meta_Image_where_or {
-  alt: Page_Meta_Image_alt_operator
-  caption: Page_Meta_Image_caption_operator
   blurhash: Page_Meta_Image_blurhash_operator
   updatedAt: Page_Meta_Image_updatedAt_operator
   createdAt: Page_Meta_Image_createdAt_operator
@@ -531,6 +1491,42 @@ input Page_Meta_Image_where_or {
   filesize: Page_Meta_Image_filesize_operator
   width: Page_Meta_Image_width_operator
   height: Page_Meta_Image_height_operator
+  sizes__card__url: Page_Meta_Image_sizes__card__url_operator
+  sizes__card__width: Page_Meta_Image_sizes__card__width_operator
+  sizes__card__height: Page_Meta_Image_sizes__card__height_operator
+  sizes__card__mimeType: Page_Meta_Image_sizes__card__mimeType_operator
+  sizes__card__filesize: Page_Meta_Image_sizes__card__filesize_operator
+  sizes__card__filename: Page_Meta_Image_sizes__card__filename_operator
+  sizes__desktop__url: Page_Meta_Image_sizes__desktop__url_operator
+  sizes__desktop__width: Page_Meta_Image_sizes__desktop__width_operator
+  sizes__desktop__height: Page_Meta_Image_sizes__desktop__height_operator
+  sizes__desktop__mimeType: Page_Meta_Image_sizes__desktop__mimeType_operator
+  sizes__desktop__filesize: Page_Meta_Image_sizes__desktop__filesize_operator
+  sizes__desktop__filename: Page_Meta_Image_sizes__desktop__filename_operator
+  sizes__desktopHalf__url: Page_Meta_Image_sizes__desktopHalf__url_operator
+  sizes__desktopHalf__width: Page_Meta_Image_sizes__desktopHalf__width_operator
+  sizes__desktopHalf__height: Page_Meta_Image_sizes__desktopHalf__height_operator
+  sizes__desktopHalf__mimeType: Page_Meta_Image_sizes__desktopHalf__mimeType_operator
+  sizes__desktopHalf__filesize: Page_Meta_Image_sizes__desktopHalf__filesize_operator
+  sizes__desktopHalf__filename: Page_Meta_Image_sizes__desktopHalf__filename_operator
+  sizes__tablet__url: Page_Meta_Image_sizes__tablet__url_operator
+  sizes__tablet__width: Page_Meta_Image_sizes__tablet__width_operator
+  sizes__tablet__height: Page_Meta_Image_sizes__tablet__height_operator
+  sizes__tablet__mimeType: Page_Meta_Image_sizes__tablet__mimeType_operator
+  sizes__tablet__filesize: Page_Meta_Image_sizes__tablet__filesize_operator
+  sizes__tablet__filename: Page_Meta_Image_sizes__tablet__filename_operator
+  sizes__tabletHalf__url: Page_Meta_Image_sizes__tabletHalf__url_operator
+  sizes__tabletHalf__width: Page_Meta_Image_sizes__tabletHalf__width_operator
+  sizes__tabletHalf__height: Page_Meta_Image_sizes__tabletHalf__height_operator
+  sizes__tabletHalf__mimeType: Page_Meta_Image_sizes__tabletHalf__mimeType_operator
+  sizes__tabletHalf__filesize: Page_Meta_Image_sizes__tabletHalf__filesize_operator
+  sizes__tabletHalf__filename: Page_Meta_Image_sizes__tabletHalf__filename_operator
+  sizes__mobile__url: Page_Meta_Image_sizes__mobile__url_operator
+  sizes__mobile__width: Page_Meta_Image_sizes__mobile__width_operator
+  sizes__mobile__height: Page_Meta_Image_sizes__mobile__height_operator
+  sizes__mobile__mimeType: Page_Meta_Image_sizes__mobile__mimeType_operator
+  sizes__mobile__filesize: Page_Meta_Image_sizes__mobile__filesize_operator
+  sizes__mobile__filename: Page_Meta_Image_sizes__mobile__filename_operator
   id: Page_Meta_Image_id_operator
   AND: [Page_Meta_Image_where_and]
   OR: [Page_Meta_Image_where_or]
@@ -574,6 +1570,8 @@ input Page_where {
   layout__sideColumn__hero__links__id: Page_layout__sideColumn__hero__links__id_operator
   layout__sideColumn__projectHero__year: Page_layout__sideColumn__projectHero__year_operator
   layout__sideColumn__projectHero__client: Page_layout__sideColumn__projectHero__client_operator
+  layout__sideColumn__projectHero__usePostDescription: Page_layout__sideColumn__projectHero__usePostDescription_operator
+  layout__sideColumn__projectHero__customDescription: Page_layout__sideColumn__projectHero__customDescription_operator
   layout__sideColumn__projectHero__links__link__type: Page_layout__sideColumn__projectHero__links__link__type_operator
   layout__sideColumn__projectHero__links__link__newTab: Page_layout__sideColumn__projectHero__links__link__newTab_operator
   layout__sideColumn__projectHero__links__link__reference: Page_layout__sideColumn__projectHero__links__link__reference_Relation
@@ -584,10 +1582,8 @@ input Page_where {
   layout__sideColumn__sideContent1: Page_layout__sideColumn__sideContent1_operator
   layout__sideColumn__sideContent2: Page_layout__sideColumn__sideContent2_operator
   layout__mainColumn__style: Page_layout__mainColumn__style_operator
-  layout__mainColumn__row1column1: Page_layout__mainColumn__row1column1_operator
-  layout__mainColumn__row1column2: Page_layout__mainColumn__row1column2_operator
-  layout__mainColumn__row2column1: Page_layout__mainColumn__row2column1_operator
-  layout__mainColumn__row2column2: Page_layout__mainColumn__row2column2_operator
+  layout__mainColumn__column1: Page_layout__mainColumn__column1_operator
+  layout__mainColumn__column2: Page_layout__mainColumn__column2_operator
   layout__id: Page_layout__id_operator
   meta__title: Page_meta__title_operator
   meta__description: Page_meta__description_operator
@@ -676,8 +1672,11 @@ enum Page_layout__sideColumn__style_Input {
 }
 
 input Page_layout__sideColumn__hero__media_operator {
-  equals: String
-  not_equals: String
+  equals: JSON
+  not_equals: JSON
+  in: [JSON]
+  not_in: [JSON]
+  all: [JSON]
   exists: Boolean
 }
 
@@ -782,6 +1781,20 @@ input Page_layout__sideColumn__projectHero__client_operator {
   exists: Boolean
 }
 
+input Page_layout__sideColumn__projectHero__usePostDescription_operator {
+  equals: Boolean
+  not_equals: Boolean
+  exists: Boolean
+}
+
+input Page_layout__sideColumn__projectHero__customDescription_operator {
+  equals: JSON
+  not_equals: JSON
+  like: JSON
+  contains: JSON
+  exists: Boolean
+}
+
 input Page_layout__sideColumn__projectHero__links__link__type_operator {
   equals: Page_layout__sideColumn__projectHero__links__link__type_Input
   not_equals: Page_layout__sideColumn__projectHero__links__link__type_Input
@@ -882,12 +1895,10 @@ input Page_layout__mainColumn__style_operator {
 
 enum Page_layout__mainColumn__style_Input {
   singleLayout
-  twoRows
   twoColumns
-  threeSectionGrid
 }
 
-input Page_layout__mainColumn__row1column1_operator {
+input Page_layout__mainColumn__column1_operator {
   equals: JSON
   not_equals: JSON
   like: JSON
@@ -895,23 +1906,7 @@ input Page_layout__mainColumn__row1column1_operator {
   exists: Boolean
 }
 
-input Page_layout__mainColumn__row1column2_operator {
-  equals: JSON
-  not_equals: JSON
-  like: JSON
-  contains: JSON
-  exists: Boolean
-}
-
-input Page_layout__mainColumn__row2column1_operator {
-  equals: JSON
-  not_equals: JSON
-  like: JSON
-  contains: JSON
-  exists: Boolean
-}
-
-input Page_layout__mainColumn__row2column2_operator {
+input Page_layout__mainColumn__column2_operator {
   equals: JSON
   not_equals: JSON
   like: JSON
@@ -1020,6 +2015,8 @@ input Page_where_and {
   layout__sideColumn__hero__links__id: Page_layout__sideColumn__hero__links__id_operator
   layout__sideColumn__projectHero__year: Page_layout__sideColumn__projectHero__year_operator
   layout__sideColumn__projectHero__client: Page_layout__sideColumn__projectHero__client_operator
+  layout__sideColumn__projectHero__usePostDescription: Page_layout__sideColumn__projectHero__usePostDescription_operator
+  layout__sideColumn__projectHero__customDescription: Page_layout__sideColumn__projectHero__customDescription_operator
   layout__sideColumn__projectHero__links__link__type: Page_layout__sideColumn__projectHero__links__link__type_operator
   layout__sideColumn__projectHero__links__link__newTab: Page_layout__sideColumn__projectHero__links__link__newTab_operator
   layout__sideColumn__projectHero__links__link__reference: Page_layout__sideColumn__projectHero__links__link__reference_Relation
@@ -1030,10 +2027,8 @@ input Page_where_and {
   layout__sideColumn__sideContent1: Page_layout__sideColumn__sideContent1_operator
   layout__sideColumn__sideContent2: Page_layout__sideColumn__sideContent2_operator
   layout__mainColumn__style: Page_layout__mainColumn__style_operator
-  layout__mainColumn__row1column1: Page_layout__mainColumn__row1column1_operator
-  layout__mainColumn__row1column2: Page_layout__mainColumn__row1column2_operator
-  layout__mainColumn__row2column1: Page_layout__mainColumn__row2column1_operator
-  layout__mainColumn__row2column2: Page_layout__mainColumn__row2column2_operator
+  layout__mainColumn__column1: Page_layout__mainColumn__column1_operator
+  layout__mainColumn__column2: Page_layout__mainColumn__column2_operator
   layout__id: Page_layout__id_operator
   meta__title: Page_meta__title_operator
   meta__description: Page_meta__description_operator
@@ -1065,6 +2060,8 @@ input Page_where_or {
   layout__sideColumn__hero__links__id: Page_layout__sideColumn__hero__links__id_operator
   layout__sideColumn__projectHero__year: Page_layout__sideColumn__projectHero__year_operator
   layout__sideColumn__projectHero__client: Page_layout__sideColumn__projectHero__client_operator
+  layout__sideColumn__projectHero__usePostDescription: Page_layout__sideColumn__projectHero__usePostDescription_operator
+  layout__sideColumn__projectHero__customDescription: Page_layout__sideColumn__projectHero__customDescription_operator
   layout__sideColumn__projectHero__links__link__type: Page_layout__sideColumn__projectHero__links__link__type_operator
   layout__sideColumn__projectHero__links__link__newTab: Page_layout__sideColumn__projectHero__links__link__newTab_operator
   layout__sideColumn__projectHero__links__link__reference: Page_layout__sideColumn__projectHero__links__link__reference_Relation
@@ -1075,10 +2072,8 @@ input Page_where_or {
   layout__sideColumn__sideContent1: Page_layout__sideColumn__sideContent1_operator
   layout__sideColumn__sideContent2: Page_layout__sideColumn__sideContent2_operator
   layout__mainColumn__style: Page_layout__mainColumn__style_operator
-  layout__mainColumn__row1column1: Page_layout__mainColumn__row1column1_operator
-  layout__mainColumn__row1column2: Page_layout__mainColumn__row1column2_operator
-  layout__mainColumn__row2column1: Page_layout__mainColumn__row2column1_operator
-  layout__mainColumn__row2column2: Page_layout__mainColumn__row2column2_operator
+  layout__mainColumn__column1: Page_layout__mainColumn__column1_operator
+  layout__mainColumn__column2: Page_layout__mainColumn__column2_operator
   layout__id: Page_layout__id_operator
   meta__title: Page_meta__title_operator
   meta__description: Page_meta__description_operator
@@ -1663,6 +2658,8 @@ type PagesDocAccessFields_layout_sideColumn_projectHero_Delete {
 type PagesDocAccessFields_layout_sideColumn_projectHero_Fields {
   year: PagesDocAccessFields_layout_sideColumn_projectHero_year
   client: PagesDocAccessFields_layout_sideColumn_projectHero_client
+  usePostDescription: PagesDocAccessFields_layout_sideColumn_projectHero_usePostDescription
+  customDescription: PagesDocAccessFields_layout_sideColumn_projectHero_customDescription
   links: PagesDocAccessFields_layout_sideColumn_projectHero_links
 }
 
@@ -1709,6 +2706,52 @@ type PagesDocAccessFields_layout_sideColumn_projectHero_client_Update {
 }
 
 type PagesDocAccessFields_layout_sideColumn_projectHero_client_Delete {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_projectHero_usePostDescription {
+  create: PagesDocAccessFields_layout_sideColumn_projectHero_usePostDescription_Create
+  read: PagesDocAccessFields_layout_sideColumn_projectHero_usePostDescription_Read
+  update: PagesDocAccessFields_layout_sideColumn_projectHero_usePostDescription_Update
+  delete: PagesDocAccessFields_layout_sideColumn_projectHero_usePostDescription_Delete
+}
+
+type PagesDocAccessFields_layout_sideColumn_projectHero_usePostDescription_Create {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_projectHero_usePostDescription_Read {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_projectHero_usePostDescription_Update {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_projectHero_usePostDescription_Delete {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_projectHero_customDescription {
+  create: PagesDocAccessFields_layout_sideColumn_projectHero_customDescription_Create
+  read: PagesDocAccessFields_layout_sideColumn_projectHero_customDescription_Read
+  update: PagesDocAccessFields_layout_sideColumn_projectHero_customDescription_Update
+  delete: PagesDocAccessFields_layout_sideColumn_projectHero_customDescription_Delete
+}
+
+type PagesDocAccessFields_layout_sideColumn_projectHero_customDescription_Create {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_projectHero_customDescription_Read {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_projectHero_customDescription_Update {
+  permission: Boolean!
+}
+
+type PagesDocAccessFields_layout_sideColumn_projectHero_customDescription_Delete {
   permission: Boolean!
 }
 
@@ -2007,10 +3050,8 @@ type PagesDocAccessFields_layout_mainColumn_Delete {
 
 type PagesDocAccessFields_layout_mainColumn_Fields {
   style: PagesDocAccessFields_layout_mainColumn_style
-  row1column1: PagesDocAccessFields_layout_mainColumn_row1column1
-  row1column2: PagesDocAccessFields_layout_mainColumn_row1column2
-  row2column1: PagesDocAccessFields_layout_mainColumn_row2column1
-  row2column2: PagesDocAccessFields_layout_mainColumn_row2column2
+  column1: PagesDocAccessFields_layout_mainColumn_column1
+  column2: PagesDocAccessFields_layout_mainColumn_column2
 }
 
 type PagesDocAccessFields_layout_mainColumn_style {
@@ -2036,95 +3077,49 @@ type PagesDocAccessFields_layout_mainColumn_style_Delete {
   permission: Boolean!
 }
 
-type PagesDocAccessFields_layout_mainColumn_row1column1 {
-  create: PagesDocAccessFields_layout_mainColumn_row1column1_Create
-  read: PagesDocAccessFields_layout_mainColumn_row1column1_Read
-  update: PagesDocAccessFields_layout_mainColumn_row1column1_Update
-  delete: PagesDocAccessFields_layout_mainColumn_row1column1_Delete
+type PagesDocAccessFields_layout_mainColumn_column1 {
+  create: PagesDocAccessFields_layout_mainColumn_column1_Create
+  read: PagesDocAccessFields_layout_mainColumn_column1_Read
+  update: PagesDocAccessFields_layout_mainColumn_column1_Update
+  delete: PagesDocAccessFields_layout_mainColumn_column1_Delete
 }
 
-type PagesDocAccessFields_layout_mainColumn_row1column1_Create {
+type PagesDocAccessFields_layout_mainColumn_column1_Create {
   permission: Boolean!
 }
 
-type PagesDocAccessFields_layout_mainColumn_row1column1_Read {
+type PagesDocAccessFields_layout_mainColumn_column1_Read {
   permission: Boolean!
 }
 
-type PagesDocAccessFields_layout_mainColumn_row1column1_Update {
+type PagesDocAccessFields_layout_mainColumn_column1_Update {
   permission: Boolean!
 }
 
-type PagesDocAccessFields_layout_mainColumn_row1column1_Delete {
+type PagesDocAccessFields_layout_mainColumn_column1_Delete {
   permission: Boolean!
 }
 
-type PagesDocAccessFields_layout_mainColumn_row1column2 {
-  create: PagesDocAccessFields_layout_mainColumn_row1column2_Create
-  read: PagesDocAccessFields_layout_mainColumn_row1column2_Read
-  update: PagesDocAccessFields_layout_mainColumn_row1column2_Update
-  delete: PagesDocAccessFields_layout_mainColumn_row1column2_Delete
+type PagesDocAccessFields_layout_mainColumn_column2 {
+  create: PagesDocAccessFields_layout_mainColumn_column2_Create
+  read: PagesDocAccessFields_layout_mainColumn_column2_Read
+  update: PagesDocAccessFields_layout_mainColumn_column2_Update
+  delete: PagesDocAccessFields_layout_mainColumn_column2_Delete
 }
 
-type PagesDocAccessFields_layout_mainColumn_row1column2_Create {
+type PagesDocAccessFields_layout_mainColumn_column2_Create {
   permission: Boolean!
 }
 
-type PagesDocAccessFields_layout_mainColumn_row1column2_Read {
+type PagesDocAccessFields_layout_mainColumn_column2_Read {
   permission: Boolean!
 }
 
-type PagesDocAccessFields_layout_mainColumn_row1column2_Update {
+type PagesDocAccessFields_layout_mainColumn_column2_Update {
   permission: Boolean!
 }
 
-type PagesDocAccessFields_layout_mainColumn_row1column2_Delete {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_layout_mainColumn_row2column1 {
-  create: PagesDocAccessFields_layout_mainColumn_row2column1_Create
-  read: PagesDocAccessFields_layout_mainColumn_row2column1_Read
-  update: PagesDocAccessFields_layout_mainColumn_row2column1_Update
-  delete: PagesDocAccessFields_layout_mainColumn_row2column1_Delete
-}
-
-type PagesDocAccessFields_layout_mainColumn_row2column1_Create {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_layout_mainColumn_row2column1_Read {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_layout_mainColumn_row2column1_Update {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_layout_mainColumn_row2column1_Delete {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_layout_mainColumn_row2column2 {
-  create: PagesDocAccessFields_layout_mainColumn_row2column2_Create
-  read: PagesDocAccessFields_layout_mainColumn_row2column2_Read
-  update: PagesDocAccessFields_layout_mainColumn_row2column2_Update
-  delete: PagesDocAccessFields_layout_mainColumn_row2column2_Delete
-}
-
-type PagesDocAccessFields_layout_mainColumn_row2column2_Create {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_layout_mainColumn_row2column2_Read {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_layout_mainColumn_row2column2_Update {
-  permission: Boolean!
-}
-
-type PagesDocAccessFields_layout_mainColumn_row2column2_Delete {
+type PagesDocAccessFields_layout_mainColumn_column2_Delete {
   permission: Boolean!
 }
 
@@ -2372,12 +3367,10 @@ type PageVersion_Version {
 type PageVersion_Version_Meta {
   title: String
   description: String
-  image(where: PageVersion_Version_Meta_Image_where): Media
+  image(where: PageVersion_Version_Meta_Image_where): Upload
 }
 
 input PageVersion_Version_Meta_Image_where {
-  alt: PageVersion_Version_Meta_Image_alt_operator
-  caption: PageVersion_Version_Meta_Image_caption_operator
   blurhash: PageVersion_Version_Meta_Image_blurhash_operator
   updatedAt: PageVersion_Version_Meta_Image_updatedAt_operator
   createdAt: PageVersion_Version_Meta_Image_createdAt_operator
@@ -2387,27 +3380,45 @@ input PageVersion_Version_Meta_Image_where {
   filesize: PageVersion_Version_Meta_Image_filesize_operator
   width: PageVersion_Version_Meta_Image_width_operator
   height: PageVersion_Version_Meta_Image_height_operator
+  sizes__card__url: PageVersion_Version_Meta_Image_sizes__card__url_operator
+  sizes__card__width: PageVersion_Version_Meta_Image_sizes__card__width_operator
+  sizes__card__height: PageVersion_Version_Meta_Image_sizes__card__height_operator
+  sizes__card__mimeType: PageVersion_Version_Meta_Image_sizes__card__mimeType_operator
+  sizes__card__filesize: PageVersion_Version_Meta_Image_sizes__card__filesize_operator
+  sizes__card__filename: PageVersion_Version_Meta_Image_sizes__card__filename_operator
+  sizes__desktop__url: PageVersion_Version_Meta_Image_sizes__desktop__url_operator
+  sizes__desktop__width: PageVersion_Version_Meta_Image_sizes__desktop__width_operator
+  sizes__desktop__height: PageVersion_Version_Meta_Image_sizes__desktop__height_operator
+  sizes__desktop__mimeType: PageVersion_Version_Meta_Image_sizes__desktop__mimeType_operator
+  sizes__desktop__filesize: PageVersion_Version_Meta_Image_sizes__desktop__filesize_operator
+  sizes__desktop__filename: PageVersion_Version_Meta_Image_sizes__desktop__filename_operator
+  sizes__desktopHalf__url: PageVersion_Version_Meta_Image_sizes__desktopHalf__url_operator
+  sizes__desktopHalf__width: PageVersion_Version_Meta_Image_sizes__desktopHalf__width_operator
+  sizes__desktopHalf__height: PageVersion_Version_Meta_Image_sizes__desktopHalf__height_operator
+  sizes__desktopHalf__mimeType: PageVersion_Version_Meta_Image_sizes__desktopHalf__mimeType_operator
+  sizes__desktopHalf__filesize: PageVersion_Version_Meta_Image_sizes__desktopHalf__filesize_operator
+  sizes__desktopHalf__filename: PageVersion_Version_Meta_Image_sizes__desktopHalf__filename_operator
+  sizes__tablet__url: PageVersion_Version_Meta_Image_sizes__tablet__url_operator
+  sizes__tablet__width: PageVersion_Version_Meta_Image_sizes__tablet__width_operator
+  sizes__tablet__height: PageVersion_Version_Meta_Image_sizes__tablet__height_operator
+  sizes__tablet__mimeType: PageVersion_Version_Meta_Image_sizes__tablet__mimeType_operator
+  sizes__tablet__filesize: PageVersion_Version_Meta_Image_sizes__tablet__filesize_operator
+  sizes__tablet__filename: PageVersion_Version_Meta_Image_sizes__tablet__filename_operator
+  sizes__tabletHalf__url: PageVersion_Version_Meta_Image_sizes__tabletHalf__url_operator
+  sizes__tabletHalf__width: PageVersion_Version_Meta_Image_sizes__tabletHalf__width_operator
+  sizes__tabletHalf__height: PageVersion_Version_Meta_Image_sizes__tabletHalf__height_operator
+  sizes__tabletHalf__mimeType: PageVersion_Version_Meta_Image_sizes__tabletHalf__mimeType_operator
+  sizes__tabletHalf__filesize: PageVersion_Version_Meta_Image_sizes__tabletHalf__filesize_operator
+  sizes__tabletHalf__filename: PageVersion_Version_Meta_Image_sizes__tabletHalf__filename_operator
+  sizes__mobile__url: PageVersion_Version_Meta_Image_sizes__mobile__url_operator
+  sizes__mobile__width: PageVersion_Version_Meta_Image_sizes__mobile__width_operator
+  sizes__mobile__height: PageVersion_Version_Meta_Image_sizes__mobile__height_operator
+  sizes__mobile__mimeType: PageVersion_Version_Meta_Image_sizes__mobile__mimeType_operator
+  sizes__mobile__filesize: PageVersion_Version_Meta_Image_sizes__mobile__filesize_operator
+  sizes__mobile__filename: PageVersion_Version_Meta_Image_sizes__mobile__filename_operator
   id: PageVersion_Version_Meta_Image_id_operator
   AND: [PageVersion_Version_Meta_Image_where_and]
   OR: [PageVersion_Version_Meta_Image_where_or]
-}
-
-input PageVersion_Version_Meta_Image_alt_operator {
-  equals: String
-  not_equals: String
-  like: String
-  contains: String
-  in: [String]
-  not_in: [String]
-  all: [String]
-}
-
-input PageVersion_Version_Meta_Image_caption_operator {
-  equals: JSON
-  not_equals: JSON
-  like: JSON
-  contains: JSON
-  exists: Boolean
 }
 
 input PageVersion_Version_Meta_Image_blurhash_operator {
@@ -2506,6 +3517,384 @@ input PageVersion_Version_Meta_Image_height_operator {
   exists: Boolean
 }
 
+input PageVersion_Version_Meta_Image_sizes__card__url_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input PageVersion_Version_Meta_Image_sizes__card__width_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input PageVersion_Version_Meta_Image_sizes__card__height_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input PageVersion_Version_Meta_Image_sizes__card__mimeType_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input PageVersion_Version_Meta_Image_sizes__card__filesize_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input PageVersion_Version_Meta_Image_sizes__card__filename_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input PageVersion_Version_Meta_Image_sizes__desktop__url_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input PageVersion_Version_Meta_Image_sizes__desktop__width_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input PageVersion_Version_Meta_Image_sizes__desktop__height_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input PageVersion_Version_Meta_Image_sizes__desktop__mimeType_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input PageVersion_Version_Meta_Image_sizes__desktop__filesize_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input PageVersion_Version_Meta_Image_sizes__desktop__filename_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input PageVersion_Version_Meta_Image_sizes__desktopHalf__url_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input PageVersion_Version_Meta_Image_sizes__desktopHalf__width_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input PageVersion_Version_Meta_Image_sizes__desktopHalf__height_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input PageVersion_Version_Meta_Image_sizes__desktopHalf__mimeType_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input PageVersion_Version_Meta_Image_sizes__desktopHalf__filesize_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input PageVersion_Version_Meta_Image_sizes__desktopHalf__filename_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input PageVersion_Version_Meta_Image_sizes__tablet__url_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input PageVersion_Version_Meta_Image_sizes__tablet__width_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input PageVersion_Version_Meta_Image_sizes__tablet__height_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input PageVersion_Version_Meta_Image_sizes__tablet__mimeType_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input PageVersion_Version_Meta_Image_sizes__tablet__filesize_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input PageVersion_Version_Meta_Image_sizes__tablet__filename_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input PageVersion_Version_Meta_Image_sizes__tabletHalf__url_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input PageVersion_Version_Meta_Image_sizes__tabletHalf__width_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input PageVersion_Version_Meta_Image_sizes__tabletHalf__height_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input PageVersion_Version_Meta_Image_sizes__tabletHalf__mimeType_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input PageVersion_Version_Meta_Image_sizes__tabletHalf__filesize_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input PageVersion_Version_Meta_Image_sizes__tabletHalf__filename_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input PageVersion_Version_Meta_Image_sizes__mobile__url_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input PageVersion_Version_Meta_Image_sizes__mobile__width_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input PageVersion_Version_Meta_Image_sizes__mobile__height_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input PageVersion_Version_Meta_Image_sizes__mobile__mimeType_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input PageVersion_Version_Meta_Image_sizes__mobile__filesize_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input PageVersion_Version_Meta_Image_sizes__mobile__filename_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
 input PageVersion_Version_Meta_Image_id_operator {
   equals: String
   not_equals: String
@@ -2518,8 +3907,6 @@ input PageVersion_Version_Meta_Image_id_operator {
 }
 
 input PageVersion_Version_Meta_Image_where_and {
-  alt: PageVersion_Version_Meta_Image_alt_operator
-  caption: PageVersion_Version_Meta_Image_caption_operator
   blurhash: PageVersion_Version_Meta_Image_blurhash_operator
   updatedAt: PageVersion_Version_Meta_Image_updatedAt_operator
   createdAt: PageVersion_Version_Meta_Image_createdAt_operator
@@ -2529,14 +3916,48 @@ input PageVersion_Version_Meta_Image_where_and {
   filesize: PageVersion_Version_Meta_Image_filesize_operator
   width: PageVersion_Version_Meta_Image_width_operator
   height: PageVersion_Version_Meta_Image_height_operator
+  sizes__card__url: PageVersion_Version_Meta_Image_sizes__card__url_operator
+  sizes__card__width: PageVersion_Version_Meta_Image_sizes__card__width_operator
+  sizes__card__height: PageVersion_Version_Meta_Image_sizes__card__height_operator
+  sizes__card__mimeType: PageVersion_Version_Meta_Image_sizes__card__mimeType_operator
+  sizes__card__filesize: PageVersion_Version_Meta_Image_sizes__card__filesize_operator
+  sizes__card__filename: PageVersion_Version_Meta_Image_sizes__card__filename_operator
+  sizes__desktop__url: PageVersion_Version_Meta_Image_sizes__desktop__url_operator
+  sizes__desktop__width: PageVersion_Version_Meta_Image_sizes__desktop__width_operator
+  sizes__desktop__height: PageVersion_Version_Meta_Image_sizes__desktop__height_operator
+  sizes__desktop__mimeType: PageVersion_Version_Meta_Image_sizes__desktop__mimeType_operator
+  sizes__desktop__filesize: PageVersion_Version_Meta_Image_sizes__desktop__filesize_operator
+  sizes__desktop__filename: PageVersion_Version_Meta_Image_sizes__desktop__filename_operator
+  sizes__desktopHalf__url: PageVersion_Version_Meta_Image_sizes__desktopHalf__url_operator
+  sizes__desktopHalf__width: PageVersion_Version_Meta_Image_sizes__desktopHalf__width_operator
+  sizes__desktopHalf__height: PageVersion_Version_Meta_Image_sizes__desktopHalf__height_operator
+  sizes__desktopHalf__mimeType: PageVersion_Version_Meta_Image_sizes__desktopHalf__mimeType_operator
+  sizes__desktopHalf__filesize: PageVersion_Version_Meta_Image_sizes__desktopHalf__filesize_operator
+  sizes__desktopHalf__filename: PageVersion_Version_Meta_Image_sizes__desktopHalf__filename_operator
+  sizes__tablet__url: PageVersion_Version_Meta_Image_sizes__tablet__url_operator
+  sizes__tablet__width: PageVersion_Version_Meta_Image_sizes__tablet__width_operator
+  sizes__tablet__height: PageVersion_Version_Meta_Image_sizes__tablet__height_operator
+  sizes__tablet__mimeType: PageVersion_Version_Meta_Image_sizes__tablet__mimeType_operator
+  sizes__tablet__filesize: PageVersion_Version_Meta_Image_sizes__tablet__filesize_operator
+  sizes__tablet__filename: PageVersion_Version_Meta_Image_sizes__tablet__filename_operator
+  sizes__tabletHalf__url: PageVersion_Version_Meta_Image_sizes__tabletHalf__url_operator
+  sizes__tabletHalf__width: PageVersion_Version_Meta_Image_sizes__tabletHalf__width_operator
+  sizes__tabletHalf__height: PageVersion_Version_Meta_Image_sizes__tabletHalf__height_operator
+  sizes__tabletHalf__mimeType: PageVersion_Version_Meta_Image_sizes__tabletHalf__mimeType_operator
+  sizes__tabletHalf__filesize: PageVersion_Version_Meta_Image_sizes__tabletHalf__filesize_operator
+  sizes__tabletHalf__filename: PageVersion_Version_Meta_Image_sizes__tabletHalf__filename_operator
+  sizes__mobile__url: PageVersion_Version_Meta_Image_sizes__mobile__url_operator
+  sizes__mobile__width: PageVersion_Version_Meta_Image_sizes__mobile__width_operator
+  sizes__mobile__height: PageVersion_Version_Meta_Image_sizes__mobile__height_operator
+  sizes__mobile__mimeType: PageVersion_Version_Meta_Image_sizes__mobile__mimeType_operator
+  sizes__mobile__filesize: PageVersion_Version_Meta_Image_sizes__mobile__filesize_operator
+  sizes__mobile__filename: PageVersion_Version_Meta_Image_sizes__mobile__filename_operator
   id: PageVersion_Version_Meta_Image_id_operator
   AND: [PageVersion_Version_Meta_Image_where_and]
   OR: [PageVersion_Version_Meta_Image_where_or]
 }
 
 input PageVersion_Version_Meta_Image_where_or {
-  alt: PageVersion_Version_Meta_Image_alt_operator
-  caption: PageVersion_Version_Meta_Image_caption_operator
   blurhash: PageVersion_Version_Meta_Image_blurhash_operator
   updatedAt: PageVersion_Version_Meta_Image_updatedAt_operator
   createdAt: PageVersion_Version_Meta_Image_createdAt_operator
@@ -2546,6 +3967,42 @@ input PageVersion_Version_Meta_Image_where_or {
   filesize: PageVersion_Version_Meta_Image_filesize_operator
   width: PageVersion_Version_Meta_Image_width_operator
   height: PageVersion_Version_Meta_Image_height_operator
+  sizes__card__url: PageVersion_Version_Meta_Image_sizes__card__url_operator
+  sizes__card__width: PageVersion_Version_Meta_Image_sizes__card__width_operator
+  sizes__card__height: PageVersion_Version_Meta_Image_sizes__card__height_operator
+  sizes__card__mimeType: PageVersion_Version_Meta_Image_sizes__card__mimeType_operator
+  sizes__card__filesize: PageVersion_Version_Meta_Image_sizes__card__filesize_operator
+  sizes__card__filename: PageVersion_Version_Meta_Image_sizes__card__filename_operator
+  sizes__desktop__url: PageVersion_Version_Meta_Image_sizes__desktop__url_operator
+  sizes__desktop__width: PageVersion_Version_Meta_Image_sizes__desktop__width_operator
+  sizes__desktop__height: PageVersion_Version_Meta_Image_sizes__desktop__height_operator
+  sizes__desktop__mimeType: PageVersion_Version_Meta_Image_sizes__desktop__mimeType_operator
+  sizes__desktop__filesize: PageVersion_Version_Meta_Image_sizes__desktop__filesize_operator
+  sizes__desktop__filename: PageVersion_Version_Meta_Image_sizes__desktop__filename_operator
+  sizes__desktopHalf__url: PageVersion_Version_Meta_Image_sizes__desktopHalf__url_operator
+  sizes__desktopHalf__width: PageVersion_Version_Meta_Image_sizes__desktopHalf__width_operator
+  sizes__desktopHalf__height: PageVersion_Version_Meta_Image_sizes__desktopHalf__height_operator
+  sizes__desktopHalf__mimeType: PageVersion_Version_Meta_Image_sizes__desktopHalf__mimeType_operator
+  sizes__desktopHalf__filesize: PageVersion_Version_Meta_Image_sizes__desktopHalf__filesize_operator
+  sizes__desktopHalf__filename: PageVersion_Version_Meta_Image_sizes__desktopHalf__filename_operator
+  sizes__tablet__url: PageVersion_Version_Meta_Image_sizes__tablet__url_operator
+  sizes__tablet__width: PageVersion_Version_Meta_Image_sizes__tablet__width_operator
+  sizes__tablet__height: PageVersion_Version_Meta_Image_sizes__tablet__height_operator
+  sizes__tablet__mimeType: PageVersion_Version_Meta_Image_sizes__tablet__mimeType_operator
+  sizes__tablet__filesize: PageVersion_Version_Meta_Image_sizes__tablet__filesize_operator
+  sizes__tablet__filename: PageVersion_Version_Meta_Image_sizes__tablet__filename_operator
+  sizes__tabletHalf__url: PageVersion_Version_Meta_Image_sizes__tabletHalf__url_operator
+  sizes__tabletHalf__width: PageVersion_Version_Meta_Image_sizes__tabletHalf__width_operator
+  sizes__tabletHalf__height: PageVersion_Version_Meta_Image_sizes__tabletHalf__height_operator
+  sizes__tabletHalf__mimeType: PageVersion_Version_Meta_Image_sizes__tabletHalf__mimeType_operator
+  sizes__tabletHalf__filesize: PageVersion_Version_Meta_Image_sizes__tabletHalf__filesize_operator
+  sizes__tabletHalf__filename: PageVersion_Version_Meta_Image_sizes__tabletHalf__filename_operator
+  sizes__mobile__url: PageVersion_Version_Meta_Image_sizes__mobile__url_operator
+  sizes__mobile__width: PageVersion_Version_Meta_Image_sizes__mobile__width_operator
+  sizes__mobile__height: PageVersion_Version_Meta_Image_sizes__mobile__height_operator
+  sizes__mobile__mimeType: PageVersion_Version_Meta_Image_sizes__mobile__mimeType_operator
+  sizes__mobile__filesize: PageVersion_Version_Meta_Image_sizes__mobile__filesize_operator
+  sizes__mobile__filename: PageVersion_Version_Meta_Image_sizes__mobile__filename_operator
   id: PageVersion_Version_Meta_Image_id_operator
   AND: [PageVersion_Version_Meta_Image_where_and]
   OR: [PageVersion_Version_Meta_Image_where_or]
@@ -2590,6 +4047,8 @@ input versionsPage_where {
   version__layout__sideColumn__hero__links__id: versionsPage_version__layout__sideColumn__hero__links__id_operator
   version__layout__sideColumn__projectHero__year: versionsPage_version__layout__sideColumn__projectHero__year_operator
   version__layout__sideColumn__projectHero__client: versionsPage_version__layout__sideColumn__projectHero__client_operator
+  version__layout__sideColumn__projectHero__usePostDescription: versionsPage_version__layout__sideColumn__projectHero__usePostDescription_operator
+  version__layout__sideColumn__projectHero__customDescription: versionsPage_version__layout__sideColumn__projectHero__customDescription_operator
   version__layout__sideColumn__projectHero__links__link__type: versionsPage_version__layout__sideColumn__projectHero__links__link__type_operator
   version__layout__sideColumn__projectHero__links__link__newTab: versionsPage_version__layout__sideColumn__projectHero__links__link__newTab_operator
   version__layout__sideColumn__projectHero__links__link__reference: versionsPage_version__layout__sideColumn__projectHero__links__link__reference_Relation
@@ -2600,10 +4059,8 @@ input versionsPage_where {
   version__layout__sideColumn__sideContent1: versionsPage_version__layout__sideColumn__sideContent1_operator
   version__layout__sideColumn__sideContent2: versionsPage_version__layout__sideColumn__sideContent2_operator
   version__layout__mainColumn__style: versionsPage_version__layout__mainColumn__style_operator
-  version__layout__mainColumn__row1column1: versionsPage_version__layout__mainColumn__row1column1_operator
-  version__layout__mainColumn__row1column2: versionsPage_version__layout__mainColumn__row1column2_operator
-  version__layout__mainColumn__row2column1: versionsPage_version__layout__mainColumn__row2column1_operator
-  version__layout__mainColumn__row2column2: versionsPage_version__layout__mainColumn__row2column2_operator
+  version__layout__mainColumn__column1: versionsPage_version__layout__mainColumn__column1_operator
+  version__layout__mainColumn__column2: versionsPage_version__layout__mainColumn__column2_operator
   version__layout__id: versionsPage_version__layout__id_operator
   version__meta__title: versionsPage_version__meta__title_operator
   version__meta__description: versionsPage_version__meta__description_operator
@@ -2704,8 +4161,11 @@ enum versionsPage_version__layout__sideColumn__style_Input {
 }
 
 input versionsPage_version__layout__sideColumn__hero__media_operator {
-  equals: String
-  not_equals: String
+  equals: JSON
+  not_equals: JSON
+  in: [JSON]
+  not_in: [JSON]
+  all: [JSON]
   exists: Boolean
 }
 
@@ -2810,6 +4270,20 @@ input versionsPage_version__layout__sideColumn__projectHero__client_operator {
   exists: Boolean
 }
 
+input versionsPage_version__layout__sideColumn__projectHero__usePostDescription_operator {
+  equals: Boolean
+  not_equals: Boolean
+  exists: Boolean
+}
+
+input versionsPage_version__layout__sideColumn__projectHero__customDescription_operator {
+  equals: JSON
+  not_equals: JSON
+  like: JSON
+  contains: JSON
+  exists: Boolean
+}
+
 input versionsPage_version__layout__sideColumn__projectHero__links__link__type_operator {
   equals: versionsPage_version__layout__sideColumn__projectHero__links__link__type_Input
   not_equals: versionsPage_version__layout__sideColumn__projectHero__links__link__type_Input
@@ -2910,12 +4384,10 @@ input versionsPage_version__layout__mainColumn__style_operator {
 
 enum versionsPage_version__layout__mainColumn__style_Input {
   singleLayout
-  twoRows
   twoColumns
-  threeSectionGrid
 }
 
-input versionsPage_version__layout__mainColumn__row1column1_operator {
+input versionsPage_version__layout__mainColumn__column1_operator {
   equals: JSON
   not_equals: JSON
   like: JSON
@@ -2923,23 +4395,7 @@ input versionsPage_version__layout__mainColumn__row1column1_operator {
   exists: Boolean
 }
 
-input versionsPage_version__layout__mainColumn__row1column2_operator {
-  equals: JSON
-  not_equals: JSON
-  like: JSON
-  contains: JSON
-  exists: Boolean
-}
-
-input versionsPage_version__layout__mainColumn__row2column1_operator {
-  equals: JSON
-  not_equals: JSON
-  like: JSON
-  contains: JSON
-  exists: Boolean
-}
-
-input versionsPage_version__layout__mainColumn__row2column2_operator {
+input versionsPage_version__layout__mainColumn__column2_operator {
   equals: JSON
   not_equals: JSON
   like: JSON
@@ -3077,6 +4533,8 @@ input versionsPage_where_and {
   version__layout__sideColumn__hero__links__id: versionsPage_version__layout__sideColumn__hero__links__id_operator
   version__layout__sideColumn__projectHero__year: versionsPage_version__layout__sideColumn__projectHero__year_operator
   version__layout__sideColumn__projectHero__client: versionsPage_version__layout__sideColumn__projectHero__client_operator
+  version__layout__sideColumn__projectHero__usePostDescription: versionsPage_version__layout__sideColumn__projectHero__usePostDescription_operator
+  version__layout__sideColumn__projectHero__customDescription: versionsPage_version__layout__sideColumn__projectHero__customDescription_operator
   version__layout__sideColumn__projectHero__links__link__type: versionsPage_version__layout__sideColumn__projectHero__links__link__type_operator
   version__layout__sideColumn__projectHero__links__link__newTab: versionsPage_version__layout__sideColumn__projectHero__links__link__newTab_operator
   version__layout__sideColumn__projectHero__links__link__reference: versionsPage_version__layout__sideColumn__projectHero__links__link__reference_Relation
@@ -3087,10 +4545,8 @@ input versionsPage_where_and {
   version__layout__sideColumn__sideContent1: versionsPage_version__layout__sideColumn__sideContent1_operator
   version__layout__sideColumn__sideContent2: versionsPage_version__layout__sideColumn__sideContent2_operator
   version__layout__mainColumn__style: versionsPage_version__layout__mainColumn__style_operator
-  version__layout__mainColumn__row1column1: versionsPage_version__layout__mainColumn__row1column1_operator
-  version__layout__mainColumn__row1column2: versionsPage_version__layout__mainColumn__row1column2_operator
-  version__layout__mainColumn__row2column1: versionsPage_version__layout__mainColumn__row2column1_operator
-  version__layout__mainColumn__row2column2: versionsPage_version__layout__mainColumn__row2column2_operator
+  version__layout__mainColumn__column1: versionsPage_version__layout__mainColumn__column1_operator
+  version__layout__mainColumn__column2: versionsPage_version__layout__mainColumn__column2_operator
   version__layout__id: versionsPage_version__layout__id_operator
   version__meta__title: versionsPage_version__meta__title_operator
   version__meta__description: versionsPage_version__meta__description_operator
@@ -3126,6 +4582,8 @@ input versionsPage_where_or {
   version__layout__sideColumn__hero__links__id: versionsPage_version__layout__sideColumn__hero__links__id_operator
   version__layout__sideColumn__projectHero__year: versionsPage_version__layout__sideColumn__projectHero__year_operator
   version__layout__sideColumn__projectHero__client: versionsPage_version__layout__sideColumn__projectHero__client_operator
+  version__layout__sideColumn__projectHero__usePostDescription: versionsPage_version__layout__sideColumn__projectHero__usePostDescription_operator
+  version__layout__sideColumn__projectHero__customDescription: versionsPage_version__layout__sideColumn__projectHero__customDescription_operator
   version__layout__sideColumn__projectHero__links__link__type: versionsPage_version__layout__sideColumn__projectHero__links__link__type_operator
   version__layout__sideColumn__projectHero__links__link__newTab: versionsPage_version__layout__sideColumn__projectHero__links__link__newTab_operator
   version__layout__sideColumn__projectHero__links__link__reference: versionsPage_version__layout__sideColumn__projectHero__links__link__reference_Relation
@@ -3136,10 +4594,8 @@ input versionsPage_where_or {
   version__layout__sideColumn__sideContent1: versionsPage_version__layout__sideColumn__sideContent1_operator
   version__layout__sideColumn__sideContent2: versionsPage_version__layout__sideColumn__sideContent2_operator
   version__layout__mainColumn__style: versionsPage_version__layout__mainColumn__style_operator
-  version__layout__mainColumn__row1column1: versionsPage_version__layout__mainColumn__row1column1_operator
-  version__layout__mainColumn__row1column2: versionsPage_version__layout__mainColumn__row1column2_operator
-  version__layout__mainColumn__row2column1: versionsPage_version__layout__mainColumn__row2column1_operator
-  version__layout__mainColumn__row2column2: versionsPage_version__layout__mainColumn__row2column2_operator
+  version__layout__mainColumn__column1: versionsPage_version__layout__mainColumn__column1_operator
+  version__layout__mainColumn__column2: versionsPage_version__layout__mainColumn__column2_operator
   version__layout__id: versionsPage_version__layout__id_operator
   version__meta__title: versionsPage_version__meta__title_operator
   version__meta__description: versionsPage_version__meta__description_operator
@@ -3229,197 +4685,19 @@ type Post_PopulatedAuthors {
 }
 
 type Post_Card {
-  media(where: Post_Card_Media_where): Media
+  media: Media
   backgroundColour: String
   overlayImage: Boolean
   showDate: Boolean
 }
 
-input Post_Card_Media_where {
-  alt: Post_Card_Media_alt_operator
-  caption: Post_Card_Media_caption_operator
-  blurhash: Post_Card_Media_blurhash_operator
-  updatedAt: Post_Card_Media_updatedAt_operator
-  createdAt: Post_Card_Media_createdAt_operator
-  url: Post_Card_Media_url_operator
-  filename: Post_Card_Media_filename_operator
-  mimeType: Post_Card_Media_mimeType_operator
-  filesize: Post_Card_Media_filesize_operator
-  width: Post_Card_Media_width_operator
-  height: Post_Card_Media_height_operator
-  id: Post_Card_Media_id_operator
-  AND: [Post_Card_Media_where_and]
-  OR: [Post_Card_Media_where_or]
-}
-
-input Post_Card_Media_alt_operator {
-  equals: String
-  not_equals: String
-  like: String
-  contains: String
-  in: [String]
-  not_in: [String]
-  all: [String]
-}
-
-input Post_Card_Media_caption_operator {
-  equals: JSON
-  not_equals: JSON
-  like: JSON
-  contains: JSON
-  exists: Boolean
-}
-
-input Post_Card_Media_blurhash_operator {
-  equals: String
-  not_equals: String
-  like: String
-  contains: String
-  in: [String]
-  not_in: [String]
-  all: [String]
-  exists: Boolean
-}
-
-input Post_Card_Media_updatedAt_operator {
-  equals: DateTime
-  not_equals: DateTime
-  greater_than_equal: DateTime
-  greater_than: DateTime
-  less_than_equal: DateTime
-  less_than: DateTime
-  like: DateTime
-  exists: Boolean
-}
-
-input Post_Card_Media_createdAt_operator {
-  equals: DateTime
-  not_equals: DateTime
-  greater_than_equal: DateTime
-  greater_than: DateTime
-  less_than_equal: DateTime
-  less_than: DateTime
-  like: DateTime
-  exists: Boolean
-}
-
-input Post_Card_Media_url_operator {
-  equals: String
-  not_equals: String
-  like: String
-  contains: String
-  in: [String]
-  not_in: [String]
-  all: [String]
-  exists: Boolean
-}
-
-input Post_Card_Media_filename_operator {
-  equals: String
-  not_equals: String
-  like: String
-  contains: String
-  in: [String]
-  not_in: [String]
-  all: [String]
-  exists: Boolean
-}
-
-input Post_Card_Media_mimeType_operator {
-  equals: String
-  not_equals: String
-  like: String
-  contains: String
-  in: [String]
-  not_in: [String]
-  all: [String]
-  exists: Boolean
-}
-
-input Post_Card_Media_filesize_operator {
-  equals: Float
-  not_equals: Float
-  greater_than_equal: Float
-  greater_than: Float
-  less_than_equal: Float
-  less_than: Float
-  exists: Boolean
-}
-
-input Post_Card_Media_width_operator {
-  equals: Float
-  not_equals: Float
-  greater_than_equal: Float
-  greater_than: Float
-  less_than_equal: Float
-  less_than: Float
-  exists: Boolean
-}
-
-input Post_Card_Media_height_operator {
-  equals: Float
-  not_equals: Float
-  greater_than_equal: Float
-  greater_than: Float
-  less_than_equal: Float
-  less_than: Float
-  exists: Boolean
-}
-
-input Post_Card_Media_id_operator {
-  equals: String
-  not_equals: String
-  like: String
-  contains: String
-  in: [String]
-  not_in: [String]
-  all: [String]
-  exists: Boolean
-}
-
-input Post_Card_Media_where_and {
-  alt: Post_Card_Media_alt_operator
-  caption: Post_Card_Media_caption_operator
-  blurhash: Post_Card_Media_blurhash_operator
-  updatedAt: Post_Card_Media_updatedAt_operator
-  createdAt: Post_Card_Media_createdAt_operator
-  url: Post_Card_Media_url_operator
-  filename: Post_Card_Media_filename_operator
-  mimeType: Post_Card_Media_mimeType_operator
-  filesize: Post_Card_Media_filesize_operator
-  width: Post_Card_Media_width_operator
-  height: Post_Card_Media_height_operator
-  id: Post_Card_Media_id_operator
-  AND: [Post_Card_Media_where_and]
-  OR: [Post_Card_Media_where_or]
-}
-
-input Post_Card_Media_where_or {
-  alt: Post_Card_Media_alt_operator
-  caption: Post_Card_Media_caption_operator
-  blurhash: Post_Card_Media_blurhash_operator
-  updatedAt: Post_Card_Media_updatedAt_operator
-  createdAt: Post_Card_Media_createdAt_operator
-  url: Post_Card_Media_url_operator
-  filename: Post_Card_Media_filename_operator
-  mimeType: Post_Card_Media_mimeType_operator
-  filesize: Post_Card_Media_filesize_operator
-  width: Post_Card_Media_width_operator
-  height: Post_Card_Media_height_operator
-  id: Post_Card_Media_id_operator
-  AND: [Post_Card_Media_where_and]
-  OR: [Post_Card_Media_where_or]
-}
-
 type Post_Meta {
   title: String
   description: String
-  image(where: Post_Meta_Image_where): Media
+  image(where: Post_Meta_Image_where): Upload
 }
 
 input Post_Meta_Image_where {
-  alt: Post_Meta_Image_alt_operator
-  caption: Post_Meta_Image_caption_operator
   blurhash: Post_Meta_Image_blurhash_operator
   updatedAt: Post_Meta_Image_updatedAt_operator
   createdAt: Post_Meta_Image_createdAt_operator
@@ -3429,27 +4707,45 @@ input Post_Meta_Image_where {
   filesize: Post_Meta_Image_filesize_operator
   width: Post_Meta_Image_width_operator
   height: Post_Meta_Image_height_operator
+  sizes__card__url: Post_Meta_Image_sizes__card__url_operator
+  sizes__card__width: Post_Meta_Image_sizes__card__width_operator
+  sizes__card__height: Post_Meta_Image_sizes__card__height_operator
+  sizes__card__mimeType: Post_Meta_Image_sizes__card__mimeType_operator
+  sizes__card__filesize: Post_Meta_Image_sizes__card__filesize_operator
+  sizes__card__filename: Post_Meta_Image_sizes__card__filename_operator
+  sizes__desktop__url: Post_Meta_Image_sizes__desktop__url_operator
+  sizes__desktop__width: Post_Meta_Image_sizes__desktop__width_operator
+  sizes__desktop__height: Post_Meta_Image_sizes__desktop__height_operator
+  sizes__desktop__mimeType: Post_Meta_Image_sizes__desktop__mimeType_operator
+  sizes__desktop__filesize: Post_Meta_Image_sizes__desktop__filesize_operator
+  sizes__desktop__filename: Post_Meta_Image_sizes__desktop__filename_operator
+  sizes__desktopHalf__url: Post_Meta_Image_sizes__desktopHalf__url_operator
+  sizes__desktopHalf__width: Post_Meta_Image_sizes__desktopHalf__width_operator
+  sizes__desktopHalf__height: Post_Meta_Image_sizes__desktopHalf__height_operator
+  sizes__desktopHalf__mimeType: Post_Meta_Image_sizes__desktopHalf__mimeType_operator
+  sizes__desktopHalf__filesize: Post_Meta_Image_sizes__desktopHalf__filesize_operator
+  sizes__desktopHalf__filename: Post_Meta_Image_sizes__desktopHalf__filename_operator
+  sizes__tablet__url: Post_Meta_Image_sizes__tablet__url_operator
+  sizes__tablet__width: Post_Meta_Image_sizes__tablet__width_operator
+  sizes__tablet__height: Post_Meta_Image_sizes__tablet__height_operator
+  sizes__tablet__mimeType: Post_Meta_Image_sizes__tablet__mimeType_operator
+  sizes__tablet__filesize: Post_Meta_Image_sizes__tablet__filesize_operator
+  sizes__tablet__filename: Post_Meta_Image_sizes__tablet__filename_operator
+  sizes__tabletHalf__url: Post_Meta_Image_sizes__tabletHalf__url_operator
+  sizes__tabletHalf__width: Post_Meta_Image_sizes__tabletHalf__width_operator
+  sizes__tabletHalf__height: Post_Meta_Image_sizes__tabletHalf__height_operator
+  sizes__tabletHalf__mimeType: Post_Meta_Image_sizes__tabletHalf__mimeType_operator
+  sizes__tabletHalf__filesize: Post_Meta_Image_sizes__tabletHalf__filesize_operator
+  sizes__tabletHalf__filename: Post_Meta_Image_sizes__tabletHalf__filename_operator
+  sizes__mobile__url: Post_Meta_Image_sizes__mobile__url_operator
+  sizes__mobile__width: Post_Meta_Image_sizes__mobile__width_operator
+  sizes__mobile__height: Post_Meta_Image_sizes__mobile__height_operator
+  sizes__mobile__mimeType: Post_Meta_Image_sizes__mobile__mimeType_operator
+  sizes__mobile__filesize: Post_Meta_Image_sizes__mobile__filesize_operator
+  sizes__mobile__filename: Post_Meta_Image_sizes__mobile__filename_operator
   id: Post_Meta_Image_id_operator
   AND: [Post_Meta_Image_where_and]
   OR: [Post_Meta_Image_where_or]
-}
-
-input Post_Meta_Image_alt_operator {
-  equals: String
-  not_equals: String
-  like: String
-  contains: String
-  in: [String]
-  not_in: [String]
-  all: [String]
-}
-
-input Post_Meta_Image_caption_operator {
-  equals: JSON
-  not_equals: JSON
-  like: JSON
-  contains: JSON
-  exists: Boolean
 }
 
 input Post_Meta_Image_blurhash_operator {
@@ -3548,6 +4844,384 @@ input Post_Meta_Image_height_operator {
   exists: Boolean
 }
 
+input Post_Meta_Image_sizes__card__url_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Post_Meta_Image_sizes__card__width_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Post_Meta_Image_sizes__card__height_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Post_Meta_Image_sizes__card__mimeType_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Post_Meta_Image_sizes__card__filesize_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Post_Meta_Image_sizes__card__filename_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Post_Meta_Image_sizes__desktop__url_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Post_Meta_Image_sizes__desktop__width_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Post_Meta_Image_sizes__desktop__height_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Post_Meta_Image_sizes__desktop__mimeType_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Post_Meta_Image_sizes__desktop__filesize_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Post_Meta_Image_sizes__desktop__filename_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Post_Meta_Image_sizes__desktopHalf__url_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Post_Meta_Image_sizes__desktopHalf__width_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Post_Meta_Image_sizes__desktopHalf__height_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Post_Meta_Image_sizes__desktopHalf__mimeType_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Post_Meta_Image_sizes__desktopHalf__filesize_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Post_Meta_Image_sizes__desktopHalf__filename_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Post_Meta_Image_sizes__tablet__url_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Post_Meta_Image_sizes__tablet__width_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Post_Meta_Image_sizes__tablet__height_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Post_Meta_Image_sizes__tablet__mimeType_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Post_Meta_Image_sizes__tablet__filesize_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Post_Meta_Image_sizes__tablet__filename_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Post_Meta_Image_sizes__tabletHalf__url_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Post_Meta_Image_sizes__tabletHalf__width_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Post_Meta_Image_sizes__tabletHalf__height_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Post_Meta_Image_sizes__tabletHalf__mimeType_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Post_Meta_Image_sizes__tabletHalf__filesize_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Post_Meta_Image_sizes__tabletHalf__filename_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Post_Meta_Image_sizes__mobile__url_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Post_Meta_Image_sizes__mobile__width_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Post_Meta_Image_sizes__mobile__height_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Post_Meta_Image_sizes__mobile__mimeType_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Post_Meta_Image_sizes__mobile__filesize_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Post_Meta_Image_sizes__mobile__filename_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
 input Post_Meta_Image_id_operator {
   equals: String
   not_equals: String
@@ -3560,8 +5234,6 @@ input Post_Meta_Image_id_operator {
 }
 
 input Post_Meta_Image_where_and {
-  alt: Post_Meta_Image_alt_operator
-  caption: Post_Meta_Image_caption_operator
   blurhash: Post_Meta_Image_blurhash_operator
   updatedAt: Post_Meta_Image_updatedAt_operator
   createdAt: Post_Meta_Image_createdAt_operator
@@ -3571,14 +5243,48 @@ input Post_Meta_Image_where_and {
   filesize: Post_Meta_Image_filesize_operator
   width: Post_Meta_Image_width_operator
   height: Post_Meta_Image_height_operator
+  sizes__card__url: Post_Meta_Image_sizes__card__url_operator
+  sizes__card__width: Post_Meta_Image_sizes__card__width_operator
+  sizes__card__height: Post_Meta_Image_sizes__card__height_operator
+  sizes__card__mimeType: Post_Meta_Image_sizes__card__mimeType_operator
+  sizes__card__filesize: Post_Meta_Image_sizes__card__filesize_operator
+  sizes__card__filename: Post_Meta_Image_sizes__card__filename_operator
+  sizes__desktop__url: Post_Meta_Image_sizes__desktop__url_operator
+  sizes__desktop__width: Post_Meta_Image_sizes__desktop__width_operator
+  sizes__desktop__height: Post_Meta_Image_sizes__desktop__height_operator
+  sizes__desktop__mimeType: Post_Meta_Image_sizes__desktop__mimeType_operator
+  sizes__desktop__filesize: Post_Meta_Image_sizes__desktop__filesize_operator
+  sizes__desktop__filename: Post_Meta_Image_sizes__desktop__filename_operator
+  sizes__desktopHalf__url: Post_Meta_Image_sizes__desktopHalf__url_operator
+  sizes__desktopHalf__width: Post_Meta_Image_sizes__desktopHalf__width_operator
+  sizes__desktopHalf__height: Post_Meta_Image_sizes__desktopHalf__height_operator
+  sizes__desktopHalf__mimeType: Post_Meta_Image_sizes__desktopHalf__mimeType_operator
+  sizes__desktopHalf__filesize: Post_Meta_Image_sizes__desktopHalf__filesize_operator
+  sizes__desktopHalf__filename: Post_Meta_Image_sizes__desktopHalf__filename_operator
+  sizes__tablet__url: Post_Meta_Image_sizes__tablet__url_operator
+  sizes__tablet__width: Post_Meta_Image_sizes__tablet__width_operator
+  sizes__tablet__height: Post_Meta_Image_sizes__tablet__height_operator
+  sizes__tablet__mimeType: Post_Meta_Image_sizes__tablet__mimeType_operator
+  sizes__tablet__filesize: Post_Meta_Image_sizes__tablet__filesize_operator
+  sizes__tablet__filename: Post_Meta_Image_sizes__tablet__filename_operator
+  sizes__tabletHalf__url: Post_Meta_Image_sizes__tabletHalf__url_operator
+  sizes__tabletHalf__width: Post_Meta_Image_sizes__tabletHalf__width_operator
+  sizes__tabletHalf__height: Post_Meta_Image_sizes__tabletHalf__height_operator
+  sizes__tabletHalf__mimeType: Post_Meta_Image_sizes__tabletHalf__mimeType_operator
+  sizes__tabletHalf__filesize: Post_Meta_Image_sizes__tabletHalf__filesize_operator
+  sizes__tabletHalf__filename: Post_Meta_Image_sizes__tabletHalf__filename_operator
+  sizes__mobile__url: Post_Meta_Image_sizes__mobile__url_operator
+  sizes__mobile__width: Post_Meta_Image_sizes__mobile__width_operator
+  sizes__mobile__height: Post_Meta_Image_sizes__mobile__height_operator
+  sizes__mobile__mimeType: Post_Meta_Image_sizes__mobile__mimeType_operator
+  sizes__mobile__filesize: Post_Meta_Image_sizes__mobile__filesize_operator
+  sizes__mobile__filename: Post_Meta_Image_sizes__mobile__filename_operator
   id: Post_Meta_Image_id_operator
   AND: [Post_Meta_Image_where_and]
   OR: [Post_Meta_Image_where_or]
 }
 
 input Post_Meta_Image_where_or {
-  alt: Post_Meta_Image_alt_operator
-  caption: Post_Meta_Image_caption_operator
   blurhash: Post_Meta_Image_blurhash_operator
   updatedAt: Post_Meta_Image_updatedAt_operator
   createdAt: Post_Meta_Image_createdAt_operator
@@ -3588,6 +5294,42 @@ input Post_Meta_Image_where_or {
   filesize: Post_Meta_Image_filesize_operator
   width: Post_Meta_Image_width_operator
   height: Post_Meta_Image_height_operator
+  sizes__card__url: Post_Meta_Image_sizes__card__url_operator
+  sizes__card__width: Post_Meta_Image_sizes__card__width_operator
+  sizes__card__height: Post_Meta_Image_sizes__card__height_operator
+  sizes__card__mimeType: Post_Meta_Image_sizes__card__mimeType_operator
+  sizes__card__filesize: Post_Meta_Image_sizes__card__filesize_operator
+  sizes__card__filename: Post_Meta_Image_sizes__card__filename_operator
+  sizes__desktop__url: Post_Meta_Image_sizes__desktop__url_operator
+  sizes__desktop__width: Post_Meta_Image_sizes__desktop__width_operator
+  sizes__desktop__height: Post_Meta_Image_sizes__desktop__height_operator
+  sizes__desktop__mimeType: Post_Meta_Image_sizes__desktop__mimeType_operator
+  sizes__desktop__filesize: Post_Meta_Image_sizes__desktop__filesize_operator
+  sizes__desktop__filename: Post_Meta_Image_sizes__desktop__filename_operator
+  sizes__desktopHalf__url: Post_Meta_Image_sizes__desktopHalf__url_operator
+  sizes__desktopHalf__width: Post_Meta_Image_sizes__desktopHalf__width_operator
+  sizes__desktopHalf__height: Post_Meta_Image_sizes__desktopHalf__height_operator
+  sizes__desktopHalf__mimeType: Post_Meta_Image_sizes__desktopHalf__mimeType_operator
+  sizes__desktopHalf__filesize: Post_Meta_Image_sizes__desktopHalf__filesize_operator
+  sizes__desktopHalf__filename: Post_Meta_Image_sizes__desktopHalf__filename_operator
+  sizes__tablet__url: Post_Meta_Image_sizes__tablet__url_operator
+  sizes__tablet__width: Post_Meta_Image_sizes__tablet__width_operator
+  sizes__tablet__height: Post_Meta_Image_sizes__tablet__height_operator
+  sizes__tablet__mimeType: Post_Meta_Image_sizes__tablet__mimeType_operator
+  sizes__tablet__filesize: Post_Meta_Image_sizes__tablet__filesize_operator
+  sizes__tablet__filename: Post_Meta_Image_sizes__tablet__filename_operator
+  sizes__tabletHalf__url: Post_Meta_Image_sizes__tabletHalf__url_operator
+  sizes__tabletHalf__width: Post_Meta_Image_sizes__tabletHalf__width_operator
+  sizes__tabletHalf__height: Post_Meta_Image_sizes__tabletHalf__height_operator
+  sizes__tabletHalf__mimeType: Post_Meta_Image_sizes__tabletHalf__mimeType_operator
+  sizes__tabletHalf__filesize: Post_Meta_Image_sizes__tabletHalf__filesize_operator
+  sizes__tabletHalf__filename: Post_Meta_Image_sizes__tabletHalf__filename_operator
+  sizes__mobile__url: Post_Meta_Image_sizes__mobile__url_operator
+  sizes__mobile__width: Post_Meta_Image_sizes__mobile__width_operator
+  sizes__mobile__height: Post_Meta_Image_sizes__mobile__height_operator
+  sizes__mobile__mimeType: Post_Meta_Image_sizes__mobile__mimeType_operator
+  sizes__mobile__filesize: Post_Meta_Image_sizes__mobile__filesize_operator
+  sizes__mobile__filename: Post_Meta_Image_sizes__mobile__filename_operator
   id: Post_Meta_Image_id_operator
   AND: [Post_Meta_Image_where_and]
   OR: [Post_Meta_Image_where_or]
@@ -3641,6 +5383,8 @@ input Post_where {
   layout__sideColumn__hero__links__id: Post_layout__sideColumn__hero__links__id_operator
   layout__sideColumn__projectHero__year: Post_layout__sideColumn__projectHero__year_operator
   layout__sideColumn__projectHero__client: Post_layout__sideColumn__projectHero__client_operator
+  layout__sideColumn__projectHero__usePostDescription: Post_layout__sideColumn__projectHero__usePostDescription_operator
+  layout__sideColumn__projectHero__customDescription: Post_layout__sideColumn__projectHero__customDescription_operator
   layout__sideColumn__projectHero__links__link__type: Post_layout__sideColumn__projectHero__links__link__type_operator
   layout__sideColumn__projectHero__links__link__newTab: Post_layout__sideColumn__projectHero__links__link__newTab_operator
   layout__sideColumn__projectHero__links__link__reference: Post_layout__sideColumn__projectHero__links__link__reference_Relation
@@ -3651,10 +5395,8 @@ input Post_where {
   layout__sideColumn__sideContent1: Post_layout__sideColumn__sideContent1_operator
   layout__sideColumn__sideContent2: Post_layout__sideColumn__sideContent2_operator
   layout__mainColumn__style: Post_layout__mainColumn__style_operator
-  layout__mainColumn__row1column1: Post_layout__mainColumn__row1column1_operator
-  layout__mainColumn__row1column2: Post_layout__mainColumn__row1column2_operator
-  layout__mainColumn__row2column1: Post_layout__mainColumn__row2column1_operator
-  layout__mainColumn__row2column2: Post_layout__mainColumn__row2column2_operator
+  layout__mainColumn__column1: Post_layout__mainColumn__column1_operator
+  layout__mainColumn__column2: Post_layout__mainColumn__column2_operator
   layout__id: Post_layout__id_operator
   relatedPosts: Post_relatedPosts_operator
   meta__title: Post_meta__title_operator
@@ -3759,8 +5501,11 @@ input Post_populatedAuthors__name_operator {
 }
 
 input Post_card__media_operator {
-  equals: String
-  not_equals: String
+  equals: JSON
+  not_equals: JSON
+  in: [JSON]
+  not_in: [JSON]
+  all: [JSON]
   exists: Boolean
 }
 
@@ -3831,8 +5576,11 @@ enum Post_layout__sideColumn__style_Input {
 }
 
 input Post_layout__sideColumn__hero__media_operator {
-  equals: String
-  not_equals: String
+  equals: JSON
+  not_equals: JSON
+  in: [JSON]
+  not_in: [JSON]
+  all: [JSON]
   exists: Boolean
 }
 
@@ -3937,6 +5685,20 @@ input Post_layout__sideColumn__projectHero__client_operator {
   exists: Boolean
 }
 
+input Post_layout__sideColumn__projectHero__usePostDescription_operator {
+  equals: Boolean
+  not_equals: Boolean
+  exists: Boolean
+}
+
+input Post_layout__sideColumn__projectHero__customDescription_operator {
+  equals: JSON
+  not_equals: JSON
+  like: JSON
+  contains: JSON
+  exists: Boolean
+}
+
 input Post_layout__sideColumn__projectHero__links__link__type_operator {
   equals: Post_layout__sideColumn__projectHero__links__link__type_Input
   not_equals: Post_layout__sideColumn__projectHero__links__link__type_Input
@@ -4037,12 +5799,10 @@ input Post_layout__mainColumn__style_operator {
 
 enum Post_layout__mainColumn__style_Input {
   singleLayout
-  twoRows
   twoColumns
-  threeSectionGrid
 }
 
-input Post_layout__mainColumn__row1column1_operator {
+input Post_layout__mainColumn__column1_operator {
   equals: JSON
   not_equals: JSON
   like: JSON
@@ -4050,23 +5810,7 @@ input Post_layout__mainColumn__row1column1_operator {
   exists: Boolean
 }
 
-input Post_layout__mainColumn__row1column2_operator {
-  equals: JSON
-  not_equals: JSON
-  like: JSON
-  contains: JSON
-  exists: Boolean
-}
-
-input Post_layout__mainColumn__row2column1_operator {
-  equals: JSON
-  not_equals: JSON
-  like: JSON
-  contains: JSON
-  exists: Boolean
-}
-
-input Post_layout__mainColumn__row2column2_operator {
+input Post_layout__mainColumn__column2_operator {
   equals: JSON
   not_equals: JSON
   like: JSON
@@ -4194,6 +5938,8 @@ input Post_where_and {
   layout__sideColumn__hero__links__id: Post_layout__sideColumn__hero__links__id_operator
   layout__sideColumn__projectHero__year: Post_layout__sideColumn__projectHero__year_operator
   layout__sideColumn__projectHero__client: Post_layout__sideColumn__projectHero__client_operator
+  layout__sideColumn__projectHero__usePostDescription: Post_layout__sideColumn__projectHero__usePostDescription_operator
+  layout__sideColumn__projectHero__customDescription: Post_layout__sideColumn__projectHero__customDescription_operator
   layout__sideColumn__projectHero__links__link__type: Post_layout__sideColumn__projectHero__links__link__type_operator
   layout__sideColumn__projectHero__links__link__newTab: Post_layout__sideColumn__projectHero__links__link__newTab_operator
   layout__sideColumn__projectHero__links__link__reference: Post_layout__sideColumn__projectHero__links__link__reference_Relation
@@ -4204,10 +5950,8 @@ input Post_where_and {
   layout__sideColumn__sideContent1: Post_layout__sideColumn__sideContent1_operator
   layout__sideColumn__sideContent2: Post_layout__sideColumn__sideContent2_operator
   layout__mainColumn__style: Post_layout__mainColumn__style_operator
-  layout__mainColumn__row1column1: Post_layout__mainColumn__row1column1_operator
-  layout__mainColumn__row1column2: Post_layout__mainColumn__row1column2_operator
-  layout__mainColumn__row2column1: Post_layout__mainColumn__row2column1_operator
-  layout__mainColumn__row2column2: Post_layout__mainColumn__row2column2_operator
+  layout__mainColumn__column1: Post_layout__mainColumn__column1_operator
+  layout__mainColumn__column2: Post_layout__mainColumn__column2_operator
   layout__id: Post_layout__id_operator
   relatedPosts: Post_relatedPosts_operator
   meta__title: Post_meta__title_operator
@@ -4250,6 +5994,8 @@ input Post_where_or {
   layout__sideColumn__hero__links__id: Post_layout__sideColumn__hero__links__id_operator
   layout__sideColumn__projectHero__year: Post_layout__sideColumn__projectHero__year_operator
   layout__sideColumn__projectHero__client: Post_layout__sideColumn__projectHero__client_operator
+  layout__sideColumn__projectHero__usePostDescription: Post_layout__sideColumn__projectHero__usePostDescription_operator
+  layout__sideColumn__projectHero__customDescription: Post_layout__sideColumn__projectHero__customDescription_operator
   layout__sideColumn__projectHero__links__link__type: Post_layout__sideColumn__projectHero__links__link__type_operator
   layout__sideColumn__projectHero__links__link__newTab: Post_layout__sideColumn__projectHero__links__link__newTab_operator
   layout__sideColumn__projectHero__links__link__reference: Post_layout__sideColumn__projectHero__links__link__reference_Relation
@@ -4260,10 +6006,8 @@ input Post_where_or {
   layout__sideColumn__sideContent1: Post_layout__sideColumn__sideContent1_operator
   layout__sideColumn__sideContent2: Post_layout__sideColumn__sideContent2_operator
   layout__mainColumn__style: Post_layout__mainColumn__style_operator
-  layout__mainColumn__row1column1: Post_layout__mainColumn__row1column1_operator
-  layout__mainColumn__row1column2: Post_layout__mainColumn__row1column2_operator
-  layout__mainColumn__row2column1: Post_layout__mainColumn__row2column1_operator
-  layout__mainColumn__row2column2: Post_layout__mainColumn__row2column2_operator
+  layout__mainColumn__column1: Post_layout__mainColumn__column1_operator
+  layout__mainColumn__column2: Post_layout__mainColumn__column2_operator
   layout__id: Post_layout__id_operator
   relatedPosts: Post_relatedPosts_operator
   meta__title: Post_meta__title_operator
@@ -5146,6 +6890,8 @@ type PostsDocAccessFields_layout_sideColumn_projectHero_Delete {
 type PostsDocAccessFields_layout_sideColumn_projectHero_Fields {
   year: PostsDocAccessFields_layout_sideColumn_projectHero_year
   client: PostsDocAccessFields_layout_sideColumn_projectHero_client
+  usePostDescription: PostsDocAccessFields_layout_sideColumn_projectHero_usePostDescription
+  customDescription: PostsDocAccessFields_layout_sideColumn_projectHero_customDescription
   links: PostsDocAccessFields_layout_sideColumn_projectHero_links
 }
 
@@ -5192,6 +6938,52 @@ type PostsDocAccessFields_layout_sideColumn_projectHero_client_Update {
 }
 
 type PostsDocAccessFields_layout_sideColumn_projectHero_client_Delete {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_projectHero_usePostDescription {
+  create: PostsDocAccessFields_layout_sideColumn_projectHero_usePostDescription_Create
+  read: PostsDocAccessFields_layout_sideColumn_projectHero_usePostDescription_Read
+  update: PostsDocAccessFields_layout_sideColumn_projectHero_usePostDescription_Update
+  delete: PostsDocAccessFields_layout_sideColumn_projectHero_usePostDescription_Delete
+}
+
+type PostsDocAccessFields_layout_sideColumn_projectHero_usePostDescription_Create {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_projectHero_usePostDescription_Read {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_projectHero_usePostDescription_Update {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_projectHero_usePostDescription_Delete {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_projectHero_customDescription {
+  create: PostsDocAccessFields_layout_sideColumn_projectHero_customDescription_Create
+  read: PostsDocAccessFields_layout_sideColumn_projectHero_customDescription_Read
+  update: PostsDocAccessFields_layout_sideColumn_projectHero_customDescription_Update
+  delete: PostsDocAccessFields_layout_sideColumn_projectHero_customDescription_Delete
+}
+
+type PostsDocAccessFields_layout_sideColumn_projectHero_customDescription_Create {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_projectHero_customDescription_Read {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_projectHero_customDescription_Update {
+  permission: Boolean!
+}
+
+type PostsDocAccessFields_layout_sideColumn_projectHero_customDescription_Delete {
   permission: Boolean!
 }
 
@@ -5490,10 +7282,8 @@ type PostsDocAccessFields_layout_mainColumn_Delete {
 
 type PostsDocAccessFields_layout_mainColumn_Fields {
   style: PostsDocAccessFields_layout_mainColumn_style
-  row1column1: PostsDocAccessFields_layout_mainColumn_row1column1
-  row1column2: PostsDocAccessFields_layout_mainColumn_row1column2
-  row2column1: PostsDocAccessFields_layout_mainColumn_row2column1
-  row2column2: PostsDocAccessFields_layout_mainColumn_row2column2
+  column1: PostsDocAccessFields_layout_mainColumn_column1
+  column2: PostsDocAccessFields_layout_mainColumn_column2
 }
 
 type PostsDocAccessFields_layout_mainColumn_style {
@@ -5519,95 +7309,49 @@ type PostsDocAccessFields_layout_mainColumn_style_Delete {
   permission: Boolean!
 }
 
-type PostsDocAccessFields_layout_mainColumn_row1column1 {
-  create: PostsDocAccessFields_layout_mainColumn_row1column1_Create
-  read: PostsDocAccessFields_layout_mainColumn_row1column1_Read
-  update: PostsDocAccessFields_layout_mainColumn_row1column1_Update
-  delete: PostsDocAccessFields_layout_mainColumn_row1column1_Delete
+type PostsDocAccessFields_layout_mainColumn_column1 {
+  create: PostsDocAccessFields_layout_mainColumn_column1_Create
+  read: PostsDocAccessFields_layout_mainColumn_column1_Read
+  update: PostsDocAccessFields_layout_mainColumn_column1_Update
+  delete: PostsDocAccessFields_layout_mainColumn_column1_Delete
 }
 
-type PostsDocAccessFields_layout_mainColumn_row1column1_Create {
+type PostsDocAccessFields_layout_mainColumn_column1_Create {
   permission: Boolean!
 }
 
-type PostsDocAccessFields_layout_mainColumn_row1column1_Read {
+type PostsDocAccessFields_layout_mainColumn_column1_Read {
   permission: Boolean!
 }
 
-type PostsDocAccessFields_layout_mainColumn_row1column1_Update {
+type PostsDocAccessFields_layout_mainColumn_column1_Update {
   permission: Boolean!
 }
 
-type PostsDocAccessFields_layout_mainColumn_row1column1_Delete {
+type PostsDocAccessFields_layout_mainColumn_column1_Delete {
   permission: Boolean!
 }
 
-type PostsDocAccessFields_layout_mainColumn_row1column2 {
-  create: PostsDocAccessFields_layout_mainColumn_row1column2_Create
-  read: PostsDocAccessFields_layout_mainColumn_row1column2_Read
-  update: PostsDocAccessFields_layout_mainColumn_row1column2_Update
-  delete: PostsDocAccessFields_layout_mainColumn_row1column2_Delete
+type PostsDocAccessFields_layout_mainColumn_column2 {
+  create: PostsDocAccessFields_layout_mainColumn_column2_Create
+  read: PostsDocAccessFields_layout_mainColumn_column2_Read
+  update: PostsDocAccessFields_layout_mainColumn_column2_Update
+  delete: PostsDocAccessFields_layout_mainColumn_column2_Delete
 }
 
-type PostsDocAccessFields_layout_mainColumn_row1column2_Create {
+type PostsDocAccessFields_layout_mainColumn_column2_Create {
   permission: Boolean!
 }
 
-type PostsDocAccessFields_layout_mainColumn_row1column2_Read {
+type PostsDocAccessFields_layout_mainColumn_column2_Read {
   permission: Boolean!
 }
 
-type PostsDocAccessFields_layout_mainColumn_row1column2_Update {
+type PostsDocAccessFields_layout_mainColumn_column2_Update {
   permission: Boolean!
 }
 
-type PostsDocAccessFields_layout_mainColumn_row1column2_Delete {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_layout_mainColumn_row2column1 {
-  create: PostsDocAccessFields_layout_mainColumn_row2column1_Create
-  read: PostsDocAccessFields_layout_mainColumn_row2column1_Read
-  update: PostsDocAccessFields_layout_mainColumn_row2column1_Update
-  delete: PostsDocAccessFields_layout_mainColumn_row2column1_Delete
-}
-
-type PostsDocAccessFields_layout_mainColumn_row2column1_Create {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_layout_mainColumn_row2column1_Read {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_layout_mainColumn_row2column1_Update {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_layout_mainColumn_row2column1_Delete {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_layout_mainColumn_row2column2 {
-  create: PostsDocAccessFields_layout_mainColumn_row2column2_Create
-  read: PostsDocAccessFields_layout_mainColumn_row2column2_Read
-  update: PostsDocAccessFields_layout_mainColumn_row2column2_Update
-  delete: PostsDocAccessFields_layout_mainColumn_row2column2_Delete
-}
-
-type PostsDocAccessFields_layout_mainColumn_row2column2_Create {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_layout_mainColumn_row2column2_Read {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_layout_mainColumn_row2column2_Update {
-  permission: Boolean!
-}
-
-type PostsDocAccessFields_layout_mainColumn_row2column2_Delete {
+type PostsDocAccessFields_layout_mainColumn_column2_Delete {
   permission: Boolean!
 }
 
@@ -5883,197 +7627,19 @@ type PostVersion_Version_PopulatedAuthors {
 }
 
 type PostVersion_Version_Card {
-  media(where: PostVersion_Version_Card_Media_where): Media
+  media: Media
   backgroundColour: String
   overlayImage: Boolean
   showDate: Boolean
 }
 
-input PostVersion_Version_Card_Media_where {
-  alt: PostVersion_Version_Card_Media_alt_operator
-  caption: PostVersion_Version_Card_Media_caption_operator
-  blurhash: PostVersion_Version_Card_Media_blurhash_operator
-  updatedAt: PostVersion_Version_Card_Media_updatedAt_operator
-  createdAt: PostVersion_Version_Card_Media_createdAt_operator
-  url: PostVersion_Version_Card_Media_url_operator
-  filename: PostVersion_Version_Card_Media_filename_operator
-  mimeType: PostVersion_Version_Card_Media_mimeType_operator
-  filesize: PostVersion_Version_Card_Media_filesize_operator
-  width: PostVersion_Version_Card_Media_width_operator
-  height: PostVersion_Version_Card_Media_height_operator
-  id: PostVersion_Version_Card_Media_id_operator
-  AND: [PostVersion_Version_Card_Media_where_and]
-  OR: [PostVersion_Version_Card_Media_where_or]
-}
-
-input PostVersion_Version_Card_Media_alt_operator {
-  equals: String
-  not_equals: String
-  like: String
-  contains: String
-  in: [String]
-  not_in: [String]
-  all: [String]
-}
-
-input PostVersion_Version_Card_Media_caption_operator {
-  equals: JSON
-  not_equals: JSON
-  like: JSON
-  contains: JSON
-  exists: Boolean
-}
-
-input PostVersion_Version_Card_Media_blurhash_operator {
-  equals: String
-  not_equals: String
-  like: String
-  contains: String
-  in: [String]
-  not_in: [String]
-  all: [String]
-  exists: Boolean
-}
-
-input PostVersion_Version_Card_Media_updatedAt_operator {
-  equals: DateTime
-  not_equals: DateTime
-  greater_than_equal: DateTime
-  greater_than: DateTime
-  less_than_equal: DateTime
-  less_than: DateTime
-  like: DateTime
-  exists: Boolean
-}
-
-input PostVersion_Version_Card_Media_createdAt_operator {
-  equals: DateTime
-  not_equals: DateTime
-  greater_than_equal: DateTime
-  greater_than: DateTime
-  less_than_equal: DateTime
-  less_than: DateTime
-  like: DateTime
-  exists: Boolean
-}
-
-input PostVersion_Version_Card_Media_url_operator {
-  equals: String
-  not_equals: String
-  like: String
-  contains: String
-  in: [String]
-  not_in: [String]
-  all: [String]
-  exists: Boolean
-}
-
-input PostVersion_Version_Card_Media_filename_operator {
-  equals: String
-  not_equals: String
-  like: String
-  contains: String
-  in: [String]
-  not_in: [String]
-  all: [String]
-  exists: Boolean
-}
-
-input PostVersion_Version_Card_Media_mimeType_operator {
-  equals: String
-  not_equals: String
-  like: String
-  contains: String
-  in: [String]
-  not_in: [String]
-  all: [String]
-  exists: Boolean
-}
-
-input PostVersion_Version_Card_Media_filesize_operator {
-  equals: Float
-  not_equals: Float
-  greater_than_equal: Float
-  greater_than: Float
-  less_than_equal: Float
-  less_than: Float
-  exists: Boolean
-}
-
-input PostVersion_Version_Card_Media_width_operator {
-  equals: Float
-  not_equals: Float
-  greater_than_equal: Float
-  greater_than: Float
-  less_than_equal: Float
-  less_than: Float
-  exists: Boolean
-}
-
-input PostVersion_Version_Card_Media_height_operator {
-  equals: Float
-  not_equals: Float
-  greater_than_equal: Float
-  greater_than: Float
-  less_than_equal: Float
-  less_than: Float
-  exists: Boolean
-}
-
-input PostVersion_Version_Card_Media_id_operator {
-  equals: String
-  not_equals: String
-  like: String
-  contains: String
-  in: [String]
-  not_in: [String]
-  all: [String]
-  exists: Boolean
-}
-
-input PostVersion_Version_Card_Media_where_and {
-  alt: PostVersion_Version_Card_Media_alt_operator
-  caption: PostVersion_Version_Card_Media_caption_operator
-  blurhash: PostVersion_Version_Card_Media_blurhash_operator
-  updatedAt: PostVersion_Version_Card_Media_updatedAt_operator
-  createdAt: PostVersion_Version_Card_Media_createdAt_operator
-  url: PostVersion_Version_Card_Media_url_operator
-  filename: PostVersion_Version_Card_Media_filename_operator
-  mimeType: PostVersion_Version_Card_Media_mimeType_operator
-  filesize: PostVersion_Version_Card_Media_filesize_operator
-  width: PostVersion_Version_Card_Media_width_operator
-  height: PostVersion_Version_Card_Media_height_operator
-  id: PostVersion_Version_Card_Media_id_operator
-  AND: [PostVersion_Version_Card_Media_where_and]
-  OR: [PostVersion_Version_Card_Media_where_or]
-}
-
-input PostVersion_Version_Card_Media_where_or {
-  alt: PostVersion_Version_Card_Media_alt_operator
-  caption: PostVersion_Version_Card_Media_caption_operator
-  blurhash: PostVersion_Version_Card_Media_blurhash_operator
-  updatedAt: PostVersion_Version_Card_Media_updatedAt_operator
-  createdAt: PostVersion_Version_Card_Media_createdAt_operator
-  url: PostVersion_Version_Card_Media_url_operator
-  filename: PostVersion_Version_Card_Media_filename_operator
-  mimeType: PostVersion_Version_Card_Media_mimeType_operator
-  filesize: PostVersion_Version_Card_Media_filesize_operator
-  width: PostVersion_Version_Card_Media_width_operator
-  height: PostVersion_Version_Card_Media_height_operator
-  id: PostVersion_Version_Card_Media_id_operator
-  AND: [PostVersion_Version_Card_Media_where_and]
-  OR: [PostVersion_Version_Card_Media_where_or]
-}
-
 type PostVersion_Version_Meta {
   title: String
   description: String
-  image(where: PostVersion_Version_Meta_Image_where): Media
+  image(where: PostVersion_Version_Meta_Image_where): Upload
 }
 
 input PostVersion_Version_Meta_Image_where {
-  alt: PostVersion_Version_Meta_Image_alt_operator
-  caption: PostVersion_Version_Meta_Image_caption_operator
   blurhash: PostVersion_Version_Meta_Image_blurhash_operator
   updatedAt: PostVersion_Version_Meta_Image_updatedAt_operator
   createdAt: PostVersion_Version_Meta_Image_createdAt_operator
@@ -6083,27 +7649,45 @@ input PostVersion_Version_Meta_Image_where {
   filesize: PostVersion_Version_Meta_Image_filesize_operator
   width: PostVersion_Version_Meta_Image_width_operator
   height: PostVersion_Version_Meta_Image_height_operator
+  sizes__card__url: PostVersion_Version_Meta_Image_sizes__card__url_operator
+  sizes__card__width: PostVersion_Version_Meta_Image_sizes__card__width_operator
+  sizes__card__height: PostVersion_Version_Meta_Image_sizes__card__height_operator
+  sizes__card__mimeType: PostVersion_Version_Meta_Image_sizes__card__mimeType_operator
+  sizes__card__filesize: PostVersion_Version_Meta_Image_sizes__card__filesize_operator
+  sizes__card__filename: PostVersion_Version_Meta_Image_sizes__card__filename_operator
+  sizes__desktop__url: PostVersion_Version_Meta_Image_sizes__desktop__url_operator
+  sizes__desktop__width: PostVersion_Version_Meta_Image_sizes__desktop__width_operator
+  sizes__desktop__height: PostVersion_Version_Meta_Image_sizes__desktop__height_operator
+  sizes__desktop__mimeType: PostVersion_Version_Meta_Image_sizes__desktop__mimeType_operator
+  sizes__desktop__filesize: PostVersion_Version_Meta_Image_sizes__desktop__filesize_operator
+  sizes__desktop__filename: PostVersion_Version_Meta_Image_sizes__desktop__filename_operator
+  sizes__desktopHalf__url: PostVersion_Version_Meta_Image_sizes__desktopHalf__url_operator
+  sizes__desktopHalf__width: PostVersion_Version_Meta_Image_sizes__desktopHalf__width_operator
+  sizes__desktopHalf__height: PostVersion_Version_Meta_Image_sizes__desktopHalf__height_operator
+  sizes__desktopHalf__mimeType: PostVersion_Version_Meta_Image_sizes__desktopHalf__mimeType_operator
+  sizes__desktopHalf__filesize: PostVersion_Version_Meta_Image_sizes__desktopHalf__filesize_operator
+  sizes__desktopHalf__filename: PostVersion_Version_Meta_Image_sizes__desktopHalf__filename_operator
+  sizes__tablet__url: PostVersion_Version_Meta_Image_sizes__tablet__url_operator
+  sizes__tablet__width: PostVersion_Version_Meta_Image_sizes__tablet__width_operator
+  sizes__tablet__height: PostVersion_Version_Meta_Image_sizes__tablet__height_operator
+  sizes__tablet__mimeType: PostVersion_Version_Meta_Image_sizes__tablet__mimeType_operator
+  sizes__tablet__filesize: PostVersion_Version_Meta_Image_sizes__tablet__filesize_operator
+  sizes__tablet__filename: PostVersion_Version_Meta_Image_sizes__tablet__filename_operator
+  sizes__tabletHalf__url: PostVersion_Version_Meta_Image_sizes__tabletHalf__url_operator
+  sizes__tabletHalf__width: PostVersion_Version_Meta_Image_sizes__tabletHalf__width_operator
+  sizes__tabletHalf__height: PostVersion_Version_Meta_Image_sizes__tabletHalf__height_operator
+  sizes__tabletHalf__mimeType: PostVersion_Version_Meta_Image_sizes__tabletHalf__mimeType_operator
+  sizes__tabletHalf__filesize: PostVersion_Version_Meta_Image_sizes__tabletHalf__filesize_operator
+  sizes__tabletHalf__filename: PostVersion_Version_Meta_Image_sizes__tabletHalf__filename_operator
+  sizes__mobile__url: PostVersion_Version_Meta_Image_sizes__mobile__url_operator
+  sizes__mobile__width: PostVersion_Version_Meta_Image_sizes__mobile__width_operator
+  sizes__mobile__height: PostVersion_Version_Meta_Image_sizes__mobile__height_operator
+  sizes__mobile__mimeType: PostVersion_Version_Meta_Image_sizes__mobile__mimeType_operator
+  sizes__mobile__filesize: PostVersion_Version_Meta_Image_sizes__mobile__filesize_operator
+  sizes__mobile__filename: PostVersion_Version_Meta_Image_sizes__mobile__filename_operator
   id: PostVersion_Version_Meta_Image_id_operator
   AND: [PostVersion_Version_Meta_Image_where_and]
   OR: [PostVersion_Version_Meta_Image_where_or]
-}
-
-input PostVersion_Version_Meta_Image_alt_operator {
-  equals: String
-  not_equals: String
-  like: String
-  contains: String
-  in: [String]
-  not_in: [String]
-  all: [String]
-}
-
-input PostVersion_Version_Meta_Image_caption_operator {
-  equals: JSON
-  not_equals: JSON
-  like: JSON
-  contains: JSON
-  exists: Boolean
 }
 
 input PostVersion_Version_Meta_Image_blurhash_operator {
@@ -6202,6 +7786,384 @@ input PostVersion_Version_Meta_Image_height_operator {
   exists: Boolean
 }
 
+input PostVersion_Version_Meta_Image_sizes__card__url_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input PostVersion_Version_Meta_Image_sizes__card__width_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input PostVersion_Version_Meta_Image_sizes__card__height_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input PostVersion_Version_Meta_Image_sizes__card__mimeType_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input PostVersion_Version_Meta_Image_sizes__card__filesize_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input PostVersion_Version_Meta_Image_sizes__card__filename_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input PostVersion_Version_Meta_Image_sizes__desktop__url_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input PostVersion_Version_Meta_Image_sizes__desktop__width_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input PostVersion_Version_Meta_Image_sizes__desktop__height_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input PostVersion_Version_Meta_Image_sizes__desktop__mimeType_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input PostVersion_Version_Meta_Image_sizes__desktop__filesize_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input PostVersion_Version_Meta_Image_sizes__desktop__filename_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input PostVersion_Version_Meta_Image_sizes__desktopHalf__url_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input PostVersion_Version_Meta_Image_sizes__desktopHalf__width_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input PostVersion_Version_Meta_Image_sizes__desktopHalf__height_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input PostVersion_Version_Meta_Image_sizes__desktopHalf__mimeType_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input PostVersion_Version_Meta_Image_sizes__desktopHalf__filesize_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input PostVersion_Version_Meta_Image_sizes__desktopHalf__filename_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input PostVersion_Version_Meta_Image_sizes__tablet__url_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input PostVersion_Version_Meta_Image_sizes__tablet__width_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input PostVersion_Version_Meta_Image_sizes__tablet__height_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input PostVersion_Version_Meta_Image_sizes__tablet__mimeType_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input PostVersion_Version_Meta_Image_sizes__tablet__filesize_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input PostVersion_Version_Meta_Image_sizes__tablet__filename_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input PostVersion_Version_Meta_Image_sizes__tabletHalf__url_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input PostVersion_Version_Meta_Image_sizes__tabletHalf__width_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input PostVersion_Version_Meta_Image_sizes__tabletHalf__height_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input PostVersion_Version_Meta_Image_sizes__tabletHalf__mimeType_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input PostVersion_Version_Meta_Image_sizes__tabletHalf__filesize_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input PostVersion_Version_Meta_Image_sizes__tabletHalf__filename_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input PostVersion_Version_Meta_Image_sizes__mobile__url_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input PostVersion_Version_Meta_Image_sizes__mobile__width_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input PostVersion_Version_Meta_Image_sizes__mobile__height_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input PostVersion_Version_Meta_Image_sizes__mobile__mimeType_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input PostVersion_Version_Meta_Image_sizes__mobile__filesize_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input PostVersion_Version_Meta_Image_sizes__mobile__filename_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
 input PostVersion_Version_Meta_Image_id_operator {
   equals: String
   not_equals: String
@@ -6214,8 +8176,6 @@ input PostVersion_Version_Meta_Image_id_operator {
 }
 
 input PostVersion_Version_Meta_Image_where_and {
-  alt: PostVersion_Version_Meta_Image_alt_operator
-  caption: PostVersion_Version_Meta_Image_caption_operator
   blurhash: PostVersion_Version_Meta_Image_blurhash_operator
   updatedAt: PostVersion_Version_Meta_Image_updatedAt_operator
   createdAt: PostVersion_Version_Meta_Image_createdAt_operator
@@ -6225,14 +8185,48 @@ input PostVersion_Version_Meta_Image_where_and {
   filesize: PostVersion_Version_Meta_Image_filesize_operator
   width: PostVersion_Version_Meta_Image_width_operator
   height: PostVersion_Version_Meta_Image_height_operator
+  sizes__card__url: PostVersion_Version_Meta_Image_sizes__card__url_operator
+  sizes__card__width: PostVersion_Version_Meta_Image_sizes__card__width_operator
+  sizes__card__height: PostVersion_Version_Meta_Image_sizes__card__height_operator
+  sizes__card__mimeType: PostVersion_Version_Meta_Image_sizes__card__mimeType_operator
+  sizes__card__filesize: PostVersion_Version_Meta_Image_sizes__card__filesize_operator
+  sizes__card__filename: PostVersion_Version_Meta_Image_sizes__card__filename_operator
+  sizes__desktop__url: PostVersion_Version_Meta_Image_sizes__desktop__url_operator
+  sizes__desktop__width: PostVersion_Version_Meta_Image_sizes__desktop__width_operator
+  sizes__desktop__height: PostVersion_Version_Meta_Image_sizes__desktop__height_operator
+  sizes__desktop__mimeType: PostVersion_Version_Meta_Image_sizes__desktop__mimeType_operator
+  sizes__desktop__filesize: PostVersion_Version_Meta_Image_sizes__desktop__filesize_operator
+  sizes__desktop__filename: PostVersion_Version_Meta_Image_sizes__desktop__filename_operator
+  sizes__desktopHalf__url: PostVersion_Version_Meta_Image_sizes__desktopHalf__url_operator
+  sizes__desktopHalf__width: PostVersion_Version_Meta_Image_sizes__desktopHalf__width_operator
+  sizes__desktopHalf__height: PostVersion_Version_Meta_Image_sizes__desktopHalf__height_operator
+  sizes__desktopHalf__mimeType: PostVersion_Version_Meta_Image_sizes__desktopHalf__mimeType_operator
+  sizes__desktopHalf__filesize: PostVersion_Version_Meta_Image_sizes__desktopHalf__filesize_operator
+  sizes__desktopHalf__filename: PostVersion_Version_Meta_Image_sizes__desktopHalf__filename_operator
+  sizes__tablet__url: PostVersion_Version_Meta_Image_sizes__tablet__url_operator
+  sizes__tablet__width: PostVersion_Version_Meta_Image_sizes__tablet__width_operator
+  sizes__tablet__height: PostVersion_Version_Meta_Image_sizes__tablet__height_operator
+  sizes__tablet__mimeType: PostVersion_Version_Meta_Image_sizes__tablet__mimeType_operator
+  sizes__tablet__filesize: PostVersion_Version_Meta_Image_sizes__tablet__filesize_operator
+  sizes__tablet__filename: PostVersion_Version_Meta_Image_sizes__tablet__filename_operator
+  sizes__tabletHalf__url: PostVersion_Version_Meta_Image_sizes__tabletHalf__url_operator
+  sizes__tabletHalf__width: PostVersion_Version_Meta_Image_sizes__tabletHalf__width_operator
+  sizes__tabletHalf__height: PostVersion_Version_Meta_Image_sizes__tabletHalf__height_operator
+  sizes__tabletHalf__mimeType: PostVersion_Version_Meta_Image_sizes__tabletHalf__mimeType_operator
+  sizes__tabletHalf__filesize: PostVersion_Version_Meta_Image_sizes__tabletHalf__filesize_operator
+  sizes__tabletHalf__filename: PostVersion_Version_Meta_Image_sizes__tabletHalf__filename_operator
+  sizes__mobile__url: PostVersion_Version_Meta_Image_sizes__mobile__url_operator
+  sizes__mobile__width: PostVersion_Version_Meta_Image_sizes__mobile__width_operator
+  sizes__mobile__height: PostVersion_Version_Meta_Image_sizes__mobile__height_operator
+  sizes__mobile__mimeType: PostVersion_Version_Meta_Image_sizes__mobile__mimeType_operator
+  sizes__mobile__filesize: PostVersion_Version_Meta_Image_sizes__mobile__filesize_operator
+  sizes__mobile__filename: PostVersion_Version_Meta_Image_sizes__mobile__filename_operator
   id: PostVersion_Version_Meta_Image_id_operator
   AND: [PostVersion_Version_Meta_Image_where_and]
   OR: [PostVersion_Version_Meta_Image_where_or]
 }
 
 input PostVersion_Version_Meta_Image_where_or {
-  alt: PostVersion_Version_Meta_Image_alt_operator
-  caption: PostVersion_Version_Meta_Image_caption_operator
   blurhash: PostVersion_Version_Meta_Image_blurhash_operator
   updatedAt: PostVersion_Version_Meta_Image_updatedAt_operator
   createdAt: PostVersion_Version_Meta_Image_createdAt_operator
@@ -6242,6 +8236,42 @@ input PostVersion_Version_Meta_Image_where_or {
   filesize: PostVersion_Version_Meta_Image_filesize_operator
   width: PostVersion_Version_Meta_Image_width_operator
   height: PostVersion_Version_Meta_Image_height_operator
+  sizes__card__url: PostVersion_Version_Meta_Image_sizes__card__url_operator
+  sizes__card__width: PostVersion_Version_Meta_Image_sizes__card__width_operator
+  sizes__card__height: PostVersion_Version_Meta_Image_sizes__card__height_operator
+  sizes__card__mimeType: PostVersion_Version_Meta_Image_sizes__card__mimeType_operator
+  sizes__card__filesize: PostVersion_Version_Meta_Image_sizes__card__filesize_operator
+  sizes__card__filename: PostVersion_Version_Meta_Image_sizes__card__filename_operator
+  sizes__desktop__url: PostVersion_Version_Meta_Image_sizes__desktop__url_operator
+  sizes__desktop__width: PostVersion_Version_Meta_Image_sizes__desktop__width_operator
+  sizes__desktop__height: PostVersion_Version_Meta_Image_sizes__desktop__height_operator
+  sizes__desktop__mimeType: PostVersion_Version_Meta_Image_sizes__desktop__mimeType_operator
+  sizes__desktop__filesize: PostVersion_Version_Meta_Image_sizes__desktop__filesize_operator
+  sizes__desktop__filename: PostVersion_Version_Meta_Image_sizes__desktop__filename_operator
+  sizes__desktopHalf__url: PostVersion_Version_Meta_Image_sizes__desktopHalf__url_operator
+  sizes__desktopHalf__width: PostVersion_Version_Meta_Image_sizes__desktopHalf__width_operator
+  sizes__desktopHalf__height: PostVersion_Version_Meta_Image_sizes__desktopHalf__height_operator
+  sizes__desktopHalf__mimeType: PostVersion_Version_Meta_Image_sizes__desktopHalf__mimeType_operator
+  sizes__desktopHalf__filesize: PostVersion_Version_Meta_Image_sizes__desktopHalf__filesize_operator
+  sizes__desktopHalf__filename: PostVersion_Version_Meta_Image_sizes__desktopHalf__filename_operator
+  sizes__tablet__url: PostVersion_Version_Meta_Image_sizes__tablet__url_operator
+  sizes__tablet__width: PostVersion_Version_Meta_Image_sizes__tablet__width_operator
+  sizes__tablet__height: PostVersion_Version_Meta_Image_sizes__tablet__height_operator
+  sizes__tablet__mimeType: PostVersion_Version_Meta_Image_sizes__tablet__mimeType_operator
+  sizes__tablet__filesize: PostVersion_Version_Meta_Image_sizes__tablet__filesize_operator
+  sizes__tablet__filename: PostVersion_Version_Meta_Image_sizes__tablet__filename_operator
+  sizes__tabletHalf__url: PostVersion_Version_Meta_Image_sizes__tabletHalf__url_operator
+  sizes__tabletHalf__width: PostVersion_Version_Meta_Image_sizes__tabletHalf__width_operator
+  sizes__tabletHalf__height: PostVersion_Version_Meta_Image_sizes__tabletHalf__height_operator
+  sizes__tabletHalf__mimeType: PostVersion_Version_Meta_Image_sizes__tabletHalf__mimeType_operator
+  sizes__tabletHalf__filesize: PostVersion_Version_Meta_Image_sizes__tabletHalf__filesize_operator
+  sizes__tabletHalf__filename: PostVersion_Version_Meta_Image_sizes__tabletHalf__filename_operator
+  sizes__mobile__url: PostVersion_Version_Meta_Image_sizes__mobile__url_operator
+  sizes__mobile__width: PostVersion_Version_Meta_Image_sizes__mobile__width_operator
+  sizes__mobile__height: PostVersion_Version_Meta_Image_sizes__mobile__height_operator
+  sizes__mobile__mimeType: PostVersion_Version_Meta_Image_sizes__mobile__mimeType_operator
+  sizes__mobile__filesize: PostVersion_Version_Meta_Image_sizes__mobile__filesize_operator
+  sizes__mobile__filename: PostVersion_Version_Meta_Image_sizes__mobile__filename_operator
   id: PostVersion_Version_Meta_Image_id_operator
   AND: [PostVersion_Version_Meta_Image_where_and]
   OR: [PostVersion_Version_Meta_Image_where_or]
@@ -6296,6 +8326,8 @@ input versionsPost_where {
   version__layout__sideColumn__hero__links__id: versionsPost_version__layout__sideColumn__hero__links__id_operator
   version__layout__sideColumn__projectHero__year: versionsPost_version__layout__sideColumn__projectHero__year_operator
   version__layout__sideColumn__projectHero__client: versionsPost_version__layout__sideColumn__projectHero__client_operator
+  version__layout__sideColumn__projectHero__usePostDescription: versionsPost_version__layout__sideColumn__projectHero__usePostDescription_operator
+  version__layout__sideColumn__projectHero__customDescription: versionsPost_version__layout__sideColumn__projectHero__customDescription_operator
   version__layout__sideColumn__projectHero__links__link__type: versionsPost_version__layout__sideColumn__projectHero__links__link__type_operator
   version__layout__sideColumn__projectHero__links__link__newTab: versionsPost_version__layout__sideColumn__projectHero__links__link__newTab_operator
   version__layout__sideColumn__projectHero__links__link__reference: versionsPost_version__layout__sideColumn__projectHero__links__link__reference_Relation
@@ -6306,10 +8338,8 @@ input versionsPost_where {
   version__layout__sideColumn__sideContent1: versionsPost_version__layout__sideColumn__sideContent1_operator
   version__layout__sideColumn__sideContent2: versionsPost_version__layout__sideColumn__sideContent2_operator
   version__layout__mainColumn__style: versionsPost_version__layout__mainColumn__style_operator
-  version__layout__mainColumn__row1column1: versionsPost_version__layout__mainColumn__row1column1_operator
-  version__layout__mainColumn__row1column2: versionsPost_version__layout__mainColumn__row1column2_operator
-  version__layout__mainColumn__row2column1: versionsPost_version__layout__mainColumn__row2column1_operator
-  version__layout__mainColumn__row2column2: versionsPost_version__layout__mainColumn__row2column2_operator
+  version__layout__mainColumn__column1: versionsPost_version__layout__mainColumn__column1_operator
+  version__layout__mainColumn__column2: versionsPost_version__layout__mainColumn__column2_operator
   version__layout__id: versionsPost_version__layout__id_operator
   version__relatedPosts: versionsPost_version__relatedPosts_operator
   version__meta__title: versionsPost_version__meta__title_operator
@@ -6426,8 +8456,11 @@ input versionsPost_version__populatedAuthors__name_operator {
 }
 
 input versionsPost_version__card__media_operator {
-  equals: String
-  not_equals: String
+  equals: JSON
+  not_equals: JSON
+  in: [JSON]
+  not_in: [JSON]
+  all: [JSON]
   exists: Boolean
 }
 
@@ -6498,8 +8531,11 @@ enum versionsPost_version__layout__sideColumn__style_Input {
 }
 
 input versionsPost_version__layout__sideColumn__hero__media_operator {
-  equals: String
-  not_equals: String
+  equals: JSON
+  not_equals: JSON
+  in: [JSON]
+  not_in: [JSON]
+  all: [JSON]
   exists: Boolean
 }
 
@@ -6604,6 +8640,20 @@ input versionsPost_version__layout__sideColumn__projectHero__client_operator {
   exists: Boolean
 }
 
+input versionsPost_version__layout__sideColumn__projectHero__usePostDescription_operator {
+  equals: Boolean
+  not_equals: Boolean
+  exists: Boolean
+}
+
+input versionsPost_version__layout__sideColumn__projectHero__customDescription_operator {
+  equals: JSON
+  not_equals: JSON
+  like: JSON
+  contains: JSON
+  exists: Boolean
+}
+
 input versionsPost_version__layout__sideColumn__projectHero__links__link__type_operator {
   equals: versionsPost_version__layout__sideColumn__projectHero__links__link__type_Input
   not_equals: versionsPost_version__layout__sideColumn__projectHero__links__link__type_Input
@@ -6704,12 +8754,10 @@ input versionsPost_version__layout__mainColumn__style_operator {
 
 enum versionsPost_version__layout__mainColumn__style_Input {
   singleLayout
-  twoRows
   twoColumns
-  threeSectionGrid
 }
 
-input versionsPost_version__layout__mainColumn__row1column1_operator {
+input versionsPost_version__layout__mainColumn__column1_operator {
   equals: JSON
   not_equals: JSON
   like: JSON
@@ -6717,23 +8765,7 @@ input versionsPost_version__layout__mainColumn__row1column1_operator {
   exists: Boolean
 }
 
-input versionsPost_version__layout__mainColumn__row1column2_operator {
-  equals: JSON
-  not_equals: JSON
-  like: JSON
-  contains: JSON
-  exists: Boolean
-}
-
-input versionsPost_version__layout__mainColumn__row2column1_operator {
-  equals: JSON
-  not_equals: JSON
-  like: JSON
-  contains: JSON
-  exists: Boolean
-}
-
-input versionsPost_version__layout__mainColumn__row2column2_operator {
+input versionsPost_version__layout__mainColumn__column2_operator {
   equals: JSON
   not_equals: JSON
   like: JSON
@@ -6890,6 +8922,8 @@ input versionsPost_where_and {
   version__layout__sideColumn__hero__links__id: versionsPost_version__layout__sideColumn__hero__links__id_operator
   version__layout__sideColumn__projectHero__year: versionsPost_version__layout__sideColumn__projectHero__year_operator
   version__layout__sideColumn__projectHero__client: versionsPost_version__layout__sideColumn__projectHero__client_operator
+  version__layout__sideColumn__projectHero__usePostDescription: versionsPost_version__layout__sideColumn__projectHero__usePostDescription_operator
+  version__layout__sideColumn__projectHero__customDescription: versionsPost_version__layout__sideColumn__projectHero__customDescription_operator
   version__layout__sideColumn__projectHero__links__link__type: versionsPost_version__layout__sideColumn__projectHero__links__link__type_operator
   version__layout__sideColumn__projectHero__links__link__newTab: versionsPost_version__layout__sideColumn__projectHero__links__link__newTab_operator
   version__layout__sideColumn__projectHero__links__link__reference: versionsPost_version__layout__sideColumn__projectHero__links__link__reference_Relation
@@ -6900,10 +8934,8 @@ input versionsPost_where_and {
   version__layout__sideColumn__sideContent1: versionsPost_version__layout__sideColumn__sideContent1_operator
   version__layout__sideColumn__sideContent2: versionsPost_version__layout__sideColumn__sideContent2_operator
   version__layout__mainColumn__style: versionsPost_version__layout__mainColumn__style_operator
-  version__layout__mainColumn__row1column1: versionsPost_version__layout__mainColumn__row1column1_operator
-  version__layout__mainColumn__row1column2: versionsPost_version__layout__mainColumn__row1column2_operator
-  version__layout__mainColumn__row2column1: versionsPost_version__layout__mainColumn__row2column1_operator
-  version__layout__mainColumn__row2column2: versionsPost_version__layout__mainColumn__row2column2_operator
+  version__layout__mainColumn__column1: versionsPost_version__layout__mainColumn__column1_operator
+  version__layout__mainColumn__column2: versionsPost_version__layout__mainColumn__column2_operator
   version__layout__id: versionsPost_version__layout__id_operator
   version__relatedPosts: versionsPost_version__relatedPosts_operator
   version__meta__title: versionsPost_version__meta__title_operator
@@ -6950,6 +8982,8 @@ input versionsPost_where_or {
   version__layout__sideColumn__hero__links__id: versionsPost_version__layout__sideColumn__hero__links__id_operator
   version__layout__sideColumn__projectHero__year: versionsPost_version__layout__sideColumn__projectHero__year_operator
   version__layout__sideColumn__projectHero__client: versionsPost_version__layout__sideColumn__projectHero__client_operator
+  version__layout__sideColumn__projectHero__usePostDescription: versionsPost_version__layout__sideColumn__projectHero__usePostDescription_operator
+  version__layout__sideColumn__projectHero__customDescription: versionsPost_version__layout__sideColumn__projectHero__customDescription_operator
   version__layout__sideColumn__projectHero__links__link__type: versionsPost_version__layout__sideColumn__projectHero__links__link__type_operator
   version__layout__sideColumn__projectHero__links__link__newTab: versionsPost_version__layout__sideColumn__projectHero__links__link__newTab_operator
   version__layout__sideColumn__projectHero__links__link__reference: versionsPost_version__layout__sideColumn__projectHero__links__link__reference_Relation
@@ -6960,10 +8994,8 @@ input versionsPost_where_or {
   version__layout__sideColumn__sideContent1: versionsPost_version__layout__sideColumn__sideContent1_operator
   version__layout__sideColumn__sideContent2: versionsPost_version__layout__sideColumn__sideContent2_operator
   version__layout__mainColumn__style: versionsPost_version__layout__mainColumn__style_operator
-  version__layout__mainColumn__row1column1: versionsPost_version__layout__mainColumn__row1column1_operator
-  version__layout__mainColumn__row1column2: versionsPost_version__layout__mainColumn__row1column2_operator
-  version__layout__mainColumn__row2column1: versionsPost_version__layout__mainColumn__row2column1_operator
-  version__layout__mainColumn__row2column2: versionsPost_version__layout__mainColumn__row2column2_operator
+  version__layout__mainColumn__column1: versionsPost_version__layout__mainColumn__column1_operator
+  version__layout__mainColumn__column2: versionsPost_version__layout__mainColumn__column2_operator
   version__layout__id: versionsPost_version__layout__id_operator
   version__relatedPosts: versionsPost_version__relatedPosts_operator
   version__meta__title: versionsPost_version__meta__title_operator
@@ -6995,20 +9027,19 @@ type allMedia {
 }
 
 input Media_where {
+  media: Media_media_operator
   alt: Media_alt_operator
   caption: Media_caption_operator
-  blurhash: Media_blurhash_operator
   updatedAt: Media_updatedAt_operator
   createdAt: Media_createdAt_operator
-  url: Media_url_operator
-  filename: Media_filename_operator
-  mimeType: Media_mimeType_operator
-  filesize: Media_filesize_operator
-  width: Media_width_operator
-  height: Media_height_operator
   id: Media_id_operator
   AND: [Media_where_and]
   OR: [Media_where_or]
+}
+
+input Media_media_operator {
+  equals: String
+  not_equals: String
 }
 
 input Media_alt_operator {
@@ -7026,17 +9057,6 @@ input Media_caption_operator {
   not_equals: JSON
   like: JSON
   contains: JSON
-  exists: Boolean
-}
-
-input Media_blurhash_operator {
-  equals: String
-  not_equals: String
-  like: String
-  contains: String
-  in: [String]
-  not_in: [String]
-  all: [String]
   exists: Boolean
 }
 
@@ -7062,69 +9082,6 @@ input Media_createdAt_operator {
   exists: Boolean
 }
 
-input Media_url_operator {
-  equals: String
-  not_equals: String
-  like: String
-  contains: String
-  in: [String]
-  not_in: [String]
-  all: [String]
-  exists: Boolean
-}
-
-input Media_filename_operator {
-  equals: String
-  not_equals: String
-  like: String
-  contains: String
-  in: [String]
-  not_in: [String]
-  all: [String]
-  exists: Boolean
-}
-
-input Media_mimeType_operator {
-  equals: String
-  not_equals: String
-  like: String
-  contains: String
-  in: [String]
-  not_in: [String]
-  all: [String]
-  exists: Boolean
-}
-
-input Media_filesize_operator {
-  equals: Float
-  not_equals: Float
-  greater_than_equal: Float
-  greater_than: Float
-  less_than_equal: Float
-  less_than: Float
-  exists: Boolean
-}
-
-input Media_width_operator {
-  equals: Float
-  not_equals: Float
-  greater_than_equal: Float
-  greater_than: Float
-  less_than_equal: Float
-  less_than: Float
-  exists: Boolean
-}
-
-input Media_height_operator {
-  equals: Float
-  not_equals: Float
-  greater_than_equal: Float
-  greater_than: Float
-  less_than_equal: Float
-  less_than: Float
-  exists: Boolean
-}
-
 input Media_id_operator {
   equals: Int
   not_equals: Int
@@ -7136,34 +9093,22 @@ input Media_id_operator {
 }
 
 input Media_where_and {
+  media: Media_media_operator
   alt: Media_alt_operator
   caption: Media_caption_operator
-  blurhash: Media_blurhash_operator
   updatedAt: Media_updatedAt_operator
   createdAt: Media_createdAt_operator
-  url: Media_url_operator
-  filename: Media_filename_operator
-  mimeType: Media_mimeType_operator
-  filesize: Media_filesize_operator
-  width: Media_width_operator
-  height: Media_height_operator
   id: Media_id_operator
   AND: [Media_where_and]
   OR: [Media_where_or]
 }
 
 input Media_where_or {
+  media: Media_media_operator
   alt: Media_alt_operator
   caption: Media_caption_operator
-  blurhash: Media_blurhash_operator
   updatedAt: Media_updatedAt_operator
   createdAt: Media_createdAt_operator
-  url: Media_url_operator
-  filename: Media_filename_operator
-  mimeType: Media_mimeType_operator
-  filesize: Media_filesize_operator
-  width: Media_width_operator
-  height: Media_height_operator
   id: Media_id_operator
   AND: [Media_where_and]
   OR: [Media_where_or]
@@ -7178,17 +9123,34 @@ type mediaDocAccess {
 }
 
 type MediaDocAccessFields {
+  media: MediaDocAccessFields_media
   alt: MediaDocAccessFields_alt
   caption: MediaDocAccessFields_caption
-  blurhash: MediaDocAccessFields_blurhash
   updatedAt: MediaDocAccessFields_updatedAt
   createdAt: MediaDocAccessFields_createdAt
-  url: MediaDocAccessFields_url
-  filename: MediaDocAccessFields_filename
-  mimeType: MediaDocAccessFields_mimeType
-  filesize: MediaDocAccessFields_filesize
-  width: MediaDocAccessFields_width
-  height: MediaDocAccessFields_height
+}
+
+type MediaDocAccessFields_media {
+  create: MediaDocAccessFields_media_Create
+  read: MediaDocAccessFields_media_Read
+  update: MediaDocAccessFields_media_Update
+  delete: MediaDocAccessFields_media_Delete
+}
+
+type MediaDocAccessFields_media_Create {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_media_Read {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_media_Update {
+  permission: Boolean!
+}
+
+type MediaDocAccessFields_media_Delete {
+  permission: Boolean!
 }
 
 type MediaDocAccessFields_alt {
@@ -7237,29 +9199,6 @@ type MediaDocAccessFields_caption_Delete {
   permission: Boolean!
 }
 
-type MediaDocAccessFields_blurhash {
-  create: MediaDocAccessFields_blurhash_Create
-  read: MediaDocAccessFields_blurhash_Read
-  update: MediaDocAccessFields_blurhash_Update
-  delete: MediaDocAccessFields_blurhash_Delete
-}
-
-type MediaDocAccessFields_blurhash_Create {
-  permission: Boolean!
-}
-
-type MediaDocAccessFields_blurhash_Read {
-  permission: Boolean!
-}
-
-type MediaDocAccessFields_blurhash_Update {
-  permission: Boolean!
-}
-
-type MediaDocAccessFields_blurhash_Delete {
-  permission: Boolean!
-}
-
 type MediaDocAccessFields_updatedAt {
   create: MediaDocAccessFields_updatedAt_Create
   read: MediaDocAccessFields_updatedAt_Read
@@ -7303,144 +9242,6 @@ type MediaDocAccessFields_createdAt_Update {
 }
 
 type MediaDocAccessFields_createdAt_Delete {
-  permission: Boolean!
-}
-
-type MediaDocAccessFields_url {
-  create: MediaDocAccessFields_url_Create
-  read: MediaDocAccessFields_url_Read
-  update: MediaDocAccessFields_url_Update
-  delete: MediaDocAccessFields_url_Delete
-}
-
-type MediaDocAccessFields_url_Create {
-  permission: Boolean!
-}
-
-type MediaDocAccessFields_url_Read {
-  permission: Boolean!
-}
-
-type MediaDocAccessFields_url_Update {
-  permission: Boolean!
-}
-
-type MediaDocAccessFields_url_Delete {
-  permission: Boolean!
-}
-
-type MediaDocAccessFields_filename {
-  create: MediaDocAccessFields_filename_Create
-  read: MediaDocAccessFields_filename_Read
-  update: MediaDocAccessFields_filename_Update
-  delete: MediaDocAccessFields_filename_Delete
-}
-
-type MediaDocAccessFields_filename_Create {
-  permission: Boolean!
-}
-
-type MediaDocAccessFields_filename_Read {
-  permission: Boolean!
-}
-
-type MediaDocAccessFields_filename_Update {
-  permission: Boolean!
-}
-
-type MediaDocAccessFields_filename_Delete {
-  permission: Boolean!
-}
-
-type MediaDocAccessFields_mimeType {
-  create: MediaDocAccessFields_mimeType_Create
-  read: MediaDocAccessFields_mimeType_Read
-  update: MediaDocAccessFields_mimeType_Update
-  delete: MediaDocAccessFields_mimeType_Delete
-}
-
-type MediaDocAccessFields_mimeType_Create {
-  permission: Boolean!
-}
-
-type MediaDocAccessFields_mimeType_Read {
-  permission: Boolean!
-}
-
-type MediaDocAccessFields_mimeType_Update {
-  permission: Boolean!
-}
-
-type MediaDocAccessFields_mimeType_Delete {
-  permission: Boolean!
-}
-
-type MediaDocAccessFields_filesize {
-  create: MediaDocAccessFields_filesize_Create
-  read: MediaDocAccessFields_filesize_Read
-  update: MediaDocAccessFields_filesize_Update
-  delete: MediaDocAccessFields_filesize_Delete
-}
-
-type MediaDocAccessFields_filesize_Create {
-  permission: Boolean!
-}
-
-type MediaDocAccessFields_filesize_Read {
-  permission: Boolean!
-}
-
-type MediaDocAccessFields_filesize_Update {
-  permission: Boolean!
-}
-
-type MediaDocAccessFields_filesize_Delete {
-  permission: Boolean!
-}
-
-type MediaDocAccessFields_width {
-  create: MediaDocAccessFields_width_Create
-  read: MediaDocAccessFields_width_Read
-  update: MediaDocAccessFields_width_Update
-  delete: MediaDocAccessFields_width_Delete
-}
-
-type MediaDocAccessFields_width_Create {
-  permission: Boolean!
-}
-
-type MediaDocAccessFields_width_Read {
-  permission: Boolean!
-}
-
-type MediaDocAccessFields_width_Update {
-  permission: Boolean!
-}
-
-type MediaDocAccessFields_width_Delete {
-  permission: Boolean!
-}
-
-type MediaDocAccessFields_height {
-  create: MediaDocAccessFields_height_Create
-  read: MediaDocAccessFields_height_Read
-  update: MediaDocAccessFields_height_Update
-  delete: MediaDocAccessFields_height_Delete
-}
-
-type MediaDocAccessFields_height_Create {
-  permission: Boolean!
-}
-
-type MediaDocAccessFields_height_Read {
-  permission: Boolean!
-}
-
-type MediaDocAccessFields_height_Update {
-  permission: Boolean!
-}
-
-type MediaDocAccessFields_height_Delete {
   permission: Boolean!
 }
 
@@ -8541,6 +10342,1964 @@ type usersMe {
   user: User
 }
 
+type Uploads {
+  docs: [Upload]
+  hasNextPage: Boolean
+  hasPrevPage: Boolean
+  limit: Int
+  nextPage: Int
+  offset: Int
+  page: Int
+  pagingCounter: Int
+  prevPage: Int
+  totalDocs: Int
+  totalPages: Int
+}
+
+input Upload_where {
+  blurhash: Upload_blurhash_operator
+  updatedAt: Upload_updatedAt_operator
+  createdAt: Upload_createdAt_operator
+  url: Upload_url_operator
+  filename: Upload_filename_operator
+  mimeType: Upload_mimeType_operator
+  filesize: Upload_filesize_operator
+  width: Upload_width_operator
+  height: Upload_height_operator
+  sizes__card__url: Upload_sizes__card__url_operator
+  sizes__card__width: Upload_sizes__card__width_operator
+  sizes__card__height: Upload_sizes__card__height_operator
+  sizes__card__mimeType: Upload_sizes__card__mimeType_operator
+  sizes__card__filesize: Upload_sizes__card__filesize_operator
+  sizes__card__filename: Upload_sizes__card__filename_operator
+  sizes__desktop__url: Upload_sizes__desktop__url_operator
+  sizes__desktop__width: Upload_sizes__desktop__width_operator
+  sizes__desktop__height: Upload_sizes__desktop__height_operator
+  sizes__desktop__mimeType: Upload_sizes__desktop__mimeType_operator
+  sizes__desktop__filesize: Upload_sizes__desktop__filesize_operator
+  sizes__desktop__filename: Upload_sizes__desktop__filename_operator
+  sizes__desktopHalf__url: Upload_sizes__desktopHalf__url_operator
+  sizes__desktopHalf__width: Upload_sizes__desktopHalf__width_operator
+  sizes__desktopHalf__height: Upload_sizes__desktopHalf__height_operator
+  sizes__desktopHalf__mimeType: Upload_sizes__desktopHalf__mimeType_operator
+  sizes__desktopHalf__filesize: Upload_sizes__desktopHalf__filesize_operator
+  sizes__desktopHalf__filename: Upload_sizes__desktopHalf__filename_operator
+  sizes__tablet__url: Upload_sizes__tablet__url_operator
+  sizes__tablet__width: Upload_sizes__tablet__width_operator
+  sizes__tablet__height: Upload_sizes__tablet__height_operator
+  sizes__tablet__mimeType: Upload_sizes__tablet__mimeType_operator
+  sizes__tablet__filesize: Upload_sizes__tablet__filesize_operator
+  sizes__tablet__filename: Upload_sizes__tablet__filename_operator
+  sizes__tabletHalf__url: Upload_sizes__tabletHalf__url_operator
+  sizes__tabletHalf__width: Upload_sizes__tabletHalf__width_operator
+  sizes__tabletHalf__height: Upload_sizes__tabletHalf__height_operator
+  sizes__tabletHalf__mimeType: Upload_sizes__tabletHalf__mimeType_operator
+  sizes__tabletHalf__filesize: Upload_sizes__tabletHalf__filesize_operator
+  sizes__tabletHalf__filename: Upload_sizes__tabletHalf__filename_operator
+  sizes__mobile__url: Upload_sizes__mobile__url_operator
+  sizes__mobile__width: Upload_sizes__mobile__width_operator
+  sizes__mobile__height: Upload_sizes__mobile__height_operator
+  sizes__mobile__mimeType: Upload_sizes__mobile__mimeType_operator
+  sizes__mobile__filesize: Upload_sizes__mobile__filesize_operator
+  sizes__mobile__filename: Upload_sizes__mobile__filename_operator
+  id: Upload_id_operator
+  AND: [Upload_where_and]
+  OR: [Upload_where_or]
+}
+
+input Upload_blurhash_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Upload_updatedAt_operator {
+  equals: DateTime
+  not_equals: DateTime
+  greater_than_equal: DateTime
+  greater_than: DateTime
+  less_than_equal: DateTime
+  less_than: DateTime
+  like: DateTime
+  exists: Boolean
+}
+
+input Upload_createdAt_operator {
+  equals: DateTime
+  not_equals: DateTime
+  greater_than_equal: DateTime
+  greater_than: DateTime
+  less_than_equal: DateTime
+  less_than: DateTime
+  like: DateTime
+  exists: Boolean
+}
+
+input Upload_url_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Upload_filename_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Upload_mimeType_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Upload_filesize_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Upload_width_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Upload_height_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Upload_sizes__card__url_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Upload_sizes__card__width_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Upload_sizes__card__height_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Upload_sizes__card__mimeType_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Upload_sizes__card__filesize_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Upload_sizes__card__filename_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Upload_sizes__desktop__url_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Upload_sizes__desktop__width_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Upload_sizes__desktop__height_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Upload_sizes__desktop__mimeType_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Upload_sizes__desktop__filesize_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Upload_sizes__desktop__filename_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Upload_sizes__desktopHalf__url_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Upload_sizes__desktopHalf__width_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Upload_sizes__desktopHalf__height_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Upload_sizes__desktopHalf__mimeType_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Upload_sizes__desktopHalf__filesize_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Upload_sizes__desktopHalf__filename_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Upload_sizes__tablet__url_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Upload_sizes__tablet__width_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Upload_sizes__tablet__height_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Upload_sizes__tablet__mimeType_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Upload_sizes__tablet__filesize_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Upload_sizes__tablet__filename_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Upload_sizes__tabletHalf__url_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Upload_sizes__tabletHalf__width_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Upload_sizes__tabletHalf__height_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Upload_sizes__tabletHalf__mimeType_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Upload_sizes__tabletHalf__filesize_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Upload_sizes__tabletHalf__filename_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Upload_sizes__mobile__url_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Upload_sizes__mobile__width_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Upload_sizes__mobile__height_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Upload_sizes__mobile__mimeType_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Upload_sizes__mobile__filesize_operator {
+  equals: Float
+  not_equals: Float
+  greater_than_equal: Float
+  greater_than: Float
+  less_than_equal: Float
+  less_than: Float
+  exists: Boolean
+}
+
+input Upload_sizes__mobile__filename_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input Upload_id_operator {
+  equals: Int
+  not_equals: Int
+  greater_than_equal: Int
+  greater_than: Int
+  less_than_equal: Int
+  less_than: Int
+  exists: Boolean
+}
+
+input Upload_where_and {
+  blurhash: Upload_blurhash_operator
+  updatedAt: Upload_updatedAt_operator
+  createdAt: Upload_createdAt_operator
+  url: Upload_url_operator
+  filename: Upload_filename_operator
+  mimeType: Upload_mimeType_operator
+  filesize: Upload_filesize_operator
+  width: Upload_width_operator
+  height: Upload_height_operator
+  sizes__card__url: Upload_sizes__card__url_operator
+  sizes__card__width: Upload_sizes__card__width_operator
+  sizes__card__height: Upload_sizes__card__height_operator
+  sizes__card__mimeType: Upload_sizes__card__mimeType_operator
+  sizes__card__filesize: Upload_sizes__card__filesize_operator
+  sizes__card__filename: Upload_sizes__card__filename_operator
+  sizes__desktop__url: Upload_sizes__desktop__url_operator
+  sizes__desktop__width: Upload_sizes__desktop__width_operator
+  sizes__desktop__height: Upload_sizes__desktop__height_operator
+  sizes__desktop__mimeType: Upload_sizes__desktop__mimeType_operator
+  sizes__desktop__filesize: Upload_sizes__desktop__filesize_operator
+  sizes__desktop__filename: Upload_sizes__desktop__filename_operator
+  sizes__desktopHalf__url: Upload_sizes__desktopHalf__url_operator
+  sizes__desktopHalf__width: Upload_sizes__desktopHalf__width_operator
+  sizes__desktopHalf__height: Upload_sizes__desktopHalf__height_operator
+  sizes__desktopHalf__mimeType: Upload_sizes__desktopHalf__mimeType_operator
+  sizes__desktopHalf__filesize: Upload_sizes__desktopHalf__filesize_operator
+  sizes__desktopHalf__filename: Upload_sizes__desktopHalf__filename_operator
+  sizes__tablet__url: Upload_sizes__tablet__url_operator
+  sizes__tablet__width: Upload_sizes__tablet__width_operator
+  sizes__tablet__height: Upload_sizes__tablet__height_operator
+  sizes__tablet__mimeType: Upload_sizes__tablet__mimeType_operator
+  sizes__tablet__filesize: Upload_sizes__tablet__filesize_operator
+  sizes__tablet__filename: Upload_sizes__tablet__filename_operator
+  sizes__tabletHalf__url: Upload_sizes__tabletHalf__url_operator
+  sizes__tabletHalf__width: Upload_sizes__tabletHalf__width_operator
+  sizes__tabletHalf__height: Upload_sizes__tabletHalf__height_operator
+  sizes__tabletHalf__mimeType: Upload_sizes__tabletHalf__mimeType_operator
+  sizes__tabletHalf__filesize: Upload_sizes__tabletHalf__filesize_operator
+  sizes__tabletHalf__filename: Upload_sizes__tabletHalf__filename_operator
+  sizes__mobile__url: Upload_sizes__mobile__url_operator
+  sizes__mobile__width: Upload_sizes__mobile__width_operator
+  sizes__mobile__height: Upload_sizes__mobile__height_operator
+  sizes__mobile__mimeType: Upload_sizes__mobile__mimeType_operator
+  sizes__mobile__filesize: Upload_sizes__mobile__filesize_operator
+  sizes__mobile__filename: Upload_sizes__mobile__filename_operator
+  id: Upload_id_operator
+  AND: [Upload_where_and]
+  OR: [Upload_where_or]
+}
+
+input Upload_where_or {
+  blurhash: Upload_blurhash_operator
+  updatedAt: Upload_updatedAt_operator
+  createdAt: Upload_createdAt_operator
+  url: Upload_url_operator
+  filename: Upload_filename_operator
+  mimeType: Upload_mimeType_operator
+  filesize: Upload_filesize_operator
+  width: Upload_width_operator
+  height: Upload_height_operator
+  sizes__card__url: Upload_sizes__card__url_operator
+  sizes__card__width: Upload_sizes__card__width_operator
+  sizes__card__height: Upload_sizes__card__height_operator
+  sizes__card__mimeType: Upload_sizes__card__mimeType_operator
+  sizes__card__filesize: Upload_sizes__card__filesize_operator
+  sizes__card__filename: Upload_sizes__card__filename_operator
+  sizes__desktop__url: Upload_sizes__desktop__url_operator
+  sizes__desktop__width: Upload_sizes__desktop__width_operator
+  sizes__desktop__height: Upload_sizes__desktop__height_operator
+  sizes__desktop__mimeType: Upload_sizes__desktop__mimeType_operator
+  sizes__desktop__filesize: Upload_sizes__desktop__filesize_operator
+  sizes__desktop__filename: Upload_sizes__desktop__filename_operator
+  sizes__desktopHalf__url: Upload_sizes__desktopHalf__url_operator
+  sizes__desktopHalf__width: Upload_sizes__desktopHalf__width_operator
+  sizes__desktopHalf__height: Upload_sizes__desktopHalf__height_operator
+  sizes__desktopHalf__mimeType: Upload_sizes__desktopHalf__mimeType_operator
+  sizes__desktopHalf__filesize: Upload_sizes__desktopHalf__filesize_operator
+  sizes__desktopHalf__filename: Upload_sizes__desktopHalf__filename_operator
+  sizes__tablet__url: Upload_sizes__tablet__url_operator
+  sizes__tablet__width: Upload_sizes__tablet__width_operator
+  sizes__tablet__height: Upload_sizes__tablet__height_operator
+  sizes__tablet__mimeType: Upload_sizes__tablet__mimeType_operator
+  sizes__tablet__filesize: Upload_sizes__tablet__filesize_operator
+  sizes__tablet__filename: Upload_sizes__tablet__filename_operator
+  sizes__tabletHalf__url: Upload_sizes__tabletHalf__url_operator
+  sizes__tabletHalf__width: Upload_sizes__tabletHalf__width_operator
+  sizes__tabletHalf__height: Upload_sizes__tabletHalf__height_operator
+  sizes__tabletHalf__mimeType: Upload_sizes__tabletHalf__mimeType_operator
+  sizes__tabletHalf__filesize: Upload_sizes__tabletHalf__filesize_operator
+  sizes__tabletHalf__filename: Upload_sizes__tabletHalf__filename_operator
+  sizes__mobile__url: Upload_sizes__mobile__url_operator
+  sizes__mobile__width: Upload_sizes__mobile__width_operator
+  sizes__mobile__height: Upload_sizes__mobile__height_operator
+  sizes__mobile__mimeType: Upload_sizes__mobile__mimeType_operator
+  sizes__mobile__filesize: Upload_sizes__mobile__filesize_operator
+  sizes__mobile__filename: Upload_sizes__mobile__filename_operator
+  id: Upload_id_operator
+  AND: [Upload_where_and]
+  OR: [Upload_where_or]
+}
+
+type uploadsDocAccess {
+  fields: UploadsDocAccessFields
+  create: UploadsCreateDocAccess
+  read: UploadsReadDocAccess
+  update: UploadsUpdateDocAccess
+  delete: UploadsDeleteDocAccess
+}
+
+type UploadsDocAccessFields {
+  blurhash: UploadsDocAccessFields_blurhash
+  updatedAt: UploadsDocAccessFields_updatedAt
+  createdAt: UploadsDocAccessFields_createdAt
+  url: UploadsDocAccessFields_url
+  filename: UploadsDocAccessFields_filename
+  mimeType: UploadsDocAccessFields_mimeType
+  filesize: UploadsDocAccessFields_filesize
+  width: UploadsDocAccessFields_width
+  height: UploadsDocAccessFields_height
+  sizes: UploadsDocAccessFields_sizes
+}
+
+type UploadsDocAccessFields_blurhash {
+  create: UploadsDocAccessFields_blurhash_Create
+  read: UploadsDocAccessFields_blurhash_Read
+  update: UploadsDocAccessFields_blurhash_Update
+  delete: UploadsDocAccessFields_blurhash_Delete
+}
+
+type UploadsDocAccessFields_blurhash_Create {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_blurhash_Read {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_blurhash_Update {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_blurhash_Delete {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_updatedAt {
+  create: UploadsDocAccessFields_updatedAt_Create
+  read: UploadsDocAccessFields_updatedAt_Read
+  update: UploadsDocAccessFields_updatedAt_Update
+  delete: UploadsDocAccessFields_updatedAt_Delete
+}
+
+type UploadsDocAccessFields_updatedAt_Create {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_updatedAt_Read {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_updatedAt_Update {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_updatedAt_Delete {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_createdAt {
+  create: UploadsDocAccessFields_createdAt_Create
+  read: UploadsDocAccessFields_createdAt_Read
+  update: UploadsDocAccessFields_createdAt_Update
+  delete: UploadsDocAccessFields_createdAt_Delete
+}
+
+type UploadsDocAccessFields_createdAt_Create {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_createdAt_Read {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_createdAt_Update {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_createdAt_Delete {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_url {
+  create: UploadsDocAccessFields_url_Create
+  read: UploadsDocAccessFields_url_Read
+  update: UploadsDocAccessFields_url_Update
+  delete: UploadsDocAccessFields_url_Delete
+}
+
+type UploadsDocAccessFields_url_Create {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_url_Read {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_url_Update {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_url_Delete {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_filename {
+  create: UploadsDocAccessFields_filename_Create
+  read: UploadsDocAccessFields_filename_Read
+  update: UploadsDocAccessFields_filename_Update
+  delete: UploadsDocAccessFields_filename_Delete
+}
+
+type UploadsDocAccessFields_filename_Create {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_filename_Read {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_filename_Update {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_filename_Delete {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_mimeType {
+  create: UploadsDocAccessFields_mimeType_Create
+  read: UploadsDocAccessFields_mimeType_Read
+  update: UploadsDocAccessFields_mimeType_Update
+  delete: UploadsDocAccessFields_mimeType_Delete
+}
+
+type UploadsDocAccessFields_mimeType_Create {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_mimeType_Read {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_mimeType_Update {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_mimeType_Delete {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_filesize {
+  create: UploadsDocAccessFields_filesize_Create
+  read: UploadsDocAccessFields_filesize_Read
+  update: UploadsDocAccessFields_filesize_Update
+  delete: UploadsDocAccessFields_filesize_Delete
+}
+
+type UploadsDocAccessFields_filesize_Create {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_filesize_Read {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_filesize_Update {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_filesize_Delete {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_width {
+  create: UploadsDocAccessFields_width_Create
+  read: UploadsDocAccessFields_width_Read
+  update: UploadsDocAccessFields_width_Update
+  delete: UploadsDocAccessFields_width_Delete
+}
+
+type UploadsDocAccessFields_width_Create {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_width_Read {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_width_Update {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_width_Delete {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_height {
+  create: UploadsDocAccessFields_height_Create
+  read: UploadsDocAccessFields_height_Read
+  update: UploadsDocAccessFields_height_Update
+  delete: UploadsDocAccessFields_height_Delete
+}
+
+type UploadsDocAccessFields_height_Create {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_height_Read {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_height_Update {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_height_Delete {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes {
+  create: UploadsDocAccessFields_sizes_Create
+  read: UploadsDocAccessFields_sizes_Read
+  update: UploadsDocAccessFields_sizes_Update
+  delete: UploadsDocAccessFields_sizes_Delete
+  fields: UploadsDocAccessFields_sizes_Fields
+}
+
+type UploadsDocAccessFields_sizes_Create {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_Read {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_Update {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_Delete {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_Fields {
+  card: UploadsDocAccessFields_sizes_card
+  desktop: UploadsDocAccessFields_sizes_desktop
+  desktopHalf: UploadsDocAccessFields_sizes_desktopHalf
+  tablet: UploadsDocAccessFields_sizes_tablet
+  tabletHalf: UploadsDocAccessFields_sizes_tabletHalf
+  mobile: UploadsDocAccessFields_sizes_mobile
+}
+
+type UploadsDocAccessFields_sizes_card {
+  create: UploadsDocAccessFields_sizes_card_Create
+  read: UploadsDocAccessFields_sizes_card_Read
+  update: UploadsDocAccessFields_sizes_card_Update
+  delete: UploadsDocAccessFields_sizes_card_Delete
+  fields: UploadsDocAccessFields_sizes_card_Fields
+}
+
+type UploadsDocAccessFields_sizes_card_Create {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_card_Read {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_card_Update {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_card_Delete {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_card_Fields {
+  url: UploadsDocAccessFields_sizes_card_url
+  width: UploadsDocAccessFields_sizes_card_width
+  height: UploadsDocAccessFields_sizes_card_height
+  mimeType: UploadsDocAccessFields_sizes_card_mimeType
+  filesize: UploadsDocAccessFields_sizes_card_filesize
+  filename: UploadsDocAccessFields_sizes_card_filename
+}
+
+type UploadsDocAccessFields_sizes_card_url {
+  create: UploadsDocAccessFields_sizes_card_url_Create
+  read: UploadsDocAccessFields_sizes_card_url_Read
+  update: UploadsDocAccessFields_sizes_card_url_Update
+  delete: UploadsDocAccessFields_sizes_card_url_Delete
+}
+
+type UploadsDocAccessFields_sizes_card_url_Create {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_card_url_Read {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_card_url_Update {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_card_url_Delete {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_card_width {
+  create: UploadsDocAccessFields_sizes_card_width_Create
+  read: UploadsDocAccessFields_sizes_card_width_Read
+  update: UploadsDocAccessFields_sizes_card_width_Update
+  delete: UploadsDocAccessFields_sizes_card_width_Delete
+}
+
+type UploadsDocAccessFields_sizes_card_width_Create {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_card_width_Read {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_card_width_Update {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_card_width_Delete {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_card_height {
+  create: UploadsDocAccessFields_sizes_card_height_Create
+  read: UploadsDocAccessFields_sizes_card_height_Read
+  update: UploadsDocAccessFields_sizes_card_height_Update
+  delete: UploadsDocAccessFields_sizes_card_height_Delete
+}
+
+type UploadsDocAccessFields_sizes_card_height_Create {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_card_height_Read {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_card_height_Update {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_card_height_Delete {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_card_mimeType {
+  create: UploadsDocAccessFields_sizes_card_mimeType_Create
+  read: UploadsDocAccessFields_sizes_card_mimeType_Read
+  update: UploadsDocAccessFields_sizes_card_mimeType_Update
+  delete: UploadsDocAccessFields_sizes_card_mimeType_Delete
+}
+
+type UploadsDocAccessFields_sizes_card_mimeType_Create {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_card_mimeType_Read {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_card_mimeType_Update {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_card_mimeType_Delete {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_card_filesize {
+  create: UploadsDocAccessFields_sizes_card_filesize_Create
+  read: UploadsDocAccessFields_sizes_card_filesize_Read
+  update: UploadsDocAccessFields_sizes_card_filesize_Update
+  delete: UploadsDocAccessFields_sizes_card_filesize_Delete
+}
+
+type UploadsDocAccessFields_sizes_card_filesize_Create {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_card_filesize_Read {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_card_filesize_Update {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_card_filesize_Delete {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_card_filename {
+  create: UploadsDocAccessFields_sizes_card_filename_Create
+  read: UploadsDocAccessFields_sizes_card_filename_Read
+  update: UploadsDocAccessFields_sizes_card_filename_Update
+  delete: UploadsDocAccessFields_sizes_card_filename_Delete
+}
+
+type UploadsDocAccessFields_sizes_card_filename_Create {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_card_filename_Read {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_card_filename_Update {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_card_filename_Delete {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_desktop {
+  create: UploadsDocAccessFields_sizes_desktop_Create
+  read: UploadsDocAccessFields_sizes_desktop_Read
+  update: UploadsDocAccessFields_sizes_desktop_Update
+  delete: UploadsDocAccessFields_sizes_desktop_Delete
+  fields: UploadsDocAccessFields_sizes_desktop_Fields
+}
+
+type UploadsDocAccessFields_sizes_desktop_Create {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_desktop_Read {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_desktop_Update {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_desktop_Delete {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_desktop_Fields {
+  url: UploadsDocAccessFields_sizes_desktop_url
+  width: UploadsDocAccessFields_sizes_desktop_width
+  height: UploadsDocAccessFields_sizes_desktop_height
+  mimeType: UploadsDocAccessFields_sizes_desktop_mimeType
+  filesize: UploadsDocAccessFields_sizes_desktop_filesize
+  filename: UploadsDocAccessFields_sizes_desktop_filename
+}
+
+type UploadsDocAccessFields_sizes_desktop_url {
+  create: UploadsDocAccessFields_sizes_desktop_url_Create
+  read: UploadsDocAccessFields_sizes_desktop_url_Read
+  update: UploadsDocAccessFields_sizes_desktop_url_Update
+  delete: UploadsDocAccessFields_sizes_desktop_url_Delete
+}
+
+type UploadsDocAccessFields_sizes_desktop_url_Create {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_desktop_url_Read {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_desktop_url_Update {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_desktop_url_Delete {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_desktop_width {
+  create: UploadsDocAccessFields_sizes_desktop_width_Create
+  read: UploadsDocAccessFields_sizes_desktop_width_Read
+  update: UploadsDocAccessFields_sizes_desktop_width_Update
+  delete: UploadsDocAccessFields_sizes_desktop_width_Delete
+}
+
+type UploadsDocAccessFields_sizes_desktop_width_Create {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_desktop_width_Read {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_desktop_width_Update {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_desktop_width_Delete {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_desktop_height {
+  create: UploadsDocAccessFields_sizes_desktop_height_Create
+  read: UploadsDocAccessFields_sizes_desktop_height_Read
+  update: UploadsDocAccessFields_sizes_desktop_height_Update
+  delete: UploadsDocAccessFields_sizes_desktop_height_Delete
+}
+
+type UploadsDocAccessFields_sizes_desktop_height_Create {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_desktop_height_Read {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_desktop_height_Update {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_desktop_height_Delete {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_desktop_mimeType {
+  create: UploadsDocAccessFields_sizes_desktop_mimeType_Create
+  read: UploadsDocAccessFields_sizes_desktop_mimeType_Read
+  update: UploadsDocAccessFields_sizes_desktop_mimeType_Update
+  delete: UploadsDocAccessFields_sizes_desktop_mimeType_Delete
+}
+
+type UploadsDocAccessFields_sizes_desktop_mimeType_Create {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_desktop_mimeType_Read {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_desktop_mimeType_Update {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_desktop_mimeType_Delete {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_desktop_filesize {
+  create: UploadsDocAccessFields_sizes_desktop_filesize_Create
+  read: UploadsDocAccessFields_sizes_desktop_filesize_Read
+  update: UploadsDocAccessFields_sizes_desktop_filesize_Update
+  delete: UploadsDocAccessFields_sizes_desktop_filesize_Delete
+}
+
+type UploadsDocAccessFields_sizes_desktop_filesize_Create {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_desktop_filesize_Read {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_desktop_filesize_Update {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_desktop_filesize_Delete {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_desktop_filename {
+  create: UploadsDocAccessFields_sizes_desktop_filename_Create
+  read: UploadsDocAccessFields_sizes_desktop_filename_Read
+  update: UploadsDocAccessFields_sizes_desktop_filename_Update
+  delete: UploadsDocAccessFields_sizes_desktop_filename_Delete
+}
+
+type UploadsDocAccessFields_sizes_desktop_filename_Create {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_desktop_filename_Read {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_desktop_filename_Update {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_desktop_filename_Delete {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_desktopHalf {
+  create: UploadsDocAccessFields_sizes_desktopHalf_Create
+  read: UploadsDocAccessFields_sizes_desktopHalf_Read
+  update: UploadsDocAccessFields_sizes_desktopHalf_Update
+  delete: UploadsDocAccessFields_sizes_desktopHalf_Delete
+  fields: UploadsDocAccessFields_sizes_desktopHalf_Fields
+}
+
+type UploadsDocAccessFields_sizes_desktopHalf_Create {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_desktopHalf_Read {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_desktopHalf_Update {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_desktopHalf_Delete {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_desktopHalf_Fields {
+  url: UploadsDocAccessFields_sizes_desktopHalf_url
+  width: UploadsDocAccessFields_sizes_desktopHalf_width
+  height: UploadsDocAccessFields_sizes_desktopHalf_height
+  mimeType: UploadsDocAccessFields_sizes_desktopHalf_mimeType
+  filesize: UploadsDocAccessFields_sizes_desktopHalf_filesize
+  filename: UploadsDocAccessFields_sizes_desktopHalf_filename
+}
+
+type UploadsDocAccessFields_sizes_desktopHalf_url {
+  create: UploadsDocAccessFields_sizes_desktopHalf_url_Create
+  read: UploadsDocAccessFields_sizes_desktopHalf_url_Read
+  update: UploadsDocAccessFields_sizes_desktopHalf_url_Update
+  delete: UploadsDocAccessFields_sizes_desktopHalf_url_Delete
+}
+
+type UploadsDocAccessFields_sizes_desktopHalf_url_Create {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_desktopHalf_url_Read {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_desktopHalf_url_Update {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_desktopHalf_url_Delete {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_desktopHalf_width {
+  create: UploadsDocAccessFields_sizes_desktopHalf_width_Create
+  read: UploadsDocAccessFields_sizes_desktopHalf_width_Read
+  update: UploadsDocAccessFields_sizes_desktopHalf_width_Update
+  delete: UploadsDocAccessFields_sizes_desktopHalf_width_Delete
+}
+
+type UploadsDocAccessFields_sizes_desktopHalf_width_Create {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_desktopHalf_width_Read {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_desktopHalf_width_Update {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_desktopHalf_width_Delete {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_desktopHalf_height {
+  create: UploadsDocAccessFields_sizes_desktopHalf_height_Create
+  read: UploadsDocAccessFields_sizes_desktopHalf_height_Read
+  update: UploadsDocAccessFields_sizes_desktopHalf_height_Update
+  delete: UploadsDocAccessFields_sizes_desktopHalf_height_Delete
+}
+
+type UploadsDocAccessFields_sizes_desktopHalf_height_Create {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_desktopHalf_height_Read {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_desktopHalf_height_Update {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_desktopHalf_height_Delete {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_desktopHalf_mimeType {
+  create: UploadsDocAccessFields_sizes_desktopHalf_mimeType_Create
+  read: UploadsDocAccessFields_sizes_desktopHalf_mimeType_Read
+  update: UploadsDocAccessFields_sizes_desktopHalf_mimeType_Update
+  delete: UploadsDocAccessFields_sizes_desktopHalf_mimeType_Delete
+}
+
+type UploadsDocAccessFields_sizes_desktopHalf_mimeType_Create {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_desktopHalf_mimeType_Read {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_desktopHalf_mimeType_Update {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_desktopHalf_mimeType_Delete {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_desktopHalf_filesize {
+  create: UploadsDocAccessFields_sizes_desktopHalf_filesize_Create
+  read: UploadsDocAccessFields_sizes_desktopHalf_filesize_Read
+  update: UploadsDocAccessFields_sizes_desktopHalf_filesize_Update
+  delete: UploadsDocAccessFields_sizes_desktopHalf_filesize_Delete
+}
+
+type UploadsDocAccessFields_sizes_desktopHalf_filesize_Create {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_desktopHalf_filesize_Read {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_desktopHalf_filesize_Update {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_desktopHalf_filesize_Delete {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_desktopHalf_filename {
+  create: UploadsDocAccessFields_sizes_desktopHalf_filename_Create
+  read: UploadsDocAccessFields_sizes_desktopHalf_filename_Read
+  update: UploadsDocAccessFields_sizes_desktopHalf_filename_Update
+  delete: UploadsDocAccessFields_sizes_desktopHalf_filename_Delete
+}
+
+type UploadsDocAccessFields_sizes_desktopHalf_filename_Create {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_desktopHalf_filename_Read {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_desktopHalf_filename_Update {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_desktopHalf_filename_Delete {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_tablet {
+  create: UploadsDocAccessFields_sizes_tablet_Create
+  read: UploadsDocAccessFields_sizes_tablet_Read
+  update: UploadsDocAccessFields_sizes_tablet_Update
+  delete: UploadsDocAccessFields_sizes_tablet_Delete
+  fields: UploadsDocAccessFields_sizes_tablet_Fields
+}
+
+type UploadsDocAccessFields_sizes_tablet_Create {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_tablet_Read {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_tablet_Update {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_tablet_Delete {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_tablet_Fields {
+  url: UploadsDocAccessFields_sizes_tablet_url
+  width: UploadsDocAccessFields_sizes_tablet_width
+  height: UploadsDocAccessFields_sizes_tablet_height
+  mimeType: UploadsDocAccessFields_sizes_tablet_mimeType
+  filesize: UploadsDocAccessFields_sizes_tablet_filesize
+  filename: UploadsDocAccessFields_sizes_tablet_filename
+}
+
+type UploadsDocAccessFields_sizes_tablet_url {
+  create: UploadsDocAccessFields_sizes_tablet_url_Create
+  read: UploadsDocAccessFields_sizes_tablet_url_Read
+  update: UploadsDocAccessFields_sizes_tablet_url_Update
+  delete: UploadsDocAccessFields_sizes_tablet_url_Delete
+}
+
+type UploadsDocAccessFields_sizes_tablet_url_Create {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_tablet_url_Read {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_tablet_url_Update {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_tablet_url_Delete {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_tablet_width {
+  create: UploadsDocAccessFields_sizes_tablet_width_Create
+  read: UploadsDocAccessFields_sizes_tablet_width_Read
+  update: UploadsDocAccessFields_sizes_tablet_width_Update
+  delete: UploadsDocAccessFields_sizes_tablet_width_Delete
+}
+
+type UploadsDocAccessFields_sizes_tablet_width_Create {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_tablet_width_Read {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_tablet_width_Update {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_tablet_width_Delete {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_tablet_height {
+  create: UploadsDocAccessFields_sizes_tablet_height_Create
+  read: UploadsDocAccessFields_sizes_tablet_height_Read
+  update: UploadsDocAccessFields_sizes_tablet_height_Update
+  delete: UploadsDocAccessFields_sizes_tablet_height_Delete
+}
+
+type UploadsDocAccessFields_sizes_tablet_height_Create {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_tablet_height_Read {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_tablet_height_Update {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_tablet_height_Delete {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_tablet_mimeType {
+  create: UploadsDocAccessFields_sizes_tablet_mimeType_Create
+  read: UploadsDocAccessFields_sizes_tablet_mimeType_Read
+  update: UploadsDocAccessFields_sizes_tablet_mimeType_Update
+  delete: UploadsDocAccessFields_sizes_tablet_mimeType_Delete
+}
+
+type UploadsDocAccessFields_sizes_tablet_mimeType_Create {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_tablet_mimeType_Read {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_tablet_mimeType_Update {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_tablet_mimeType_Delete {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_tablet_filesize {
+  create: UploadsDocAccessFields_sizes_tablet_filesize_Create
+  read: UploadsDocAccessFields_sizes_tablet_filesize_Read
+  update: UploadsDocAccessFields_sizes_tablet_filesize_Update
+  delete: UploadsDocAccessFields_sizes_tablet_filesize_Delete
+}
+
+type UploadsDocAccessFields_sizes_tablet_filesize_Create {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_tablet_filesize_Read {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_tablet_filesize_Update {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_tablet_filesize_Delete {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_tablet_filename {
+  create: UploadsDocAccessFields_sizes_tablet_filename_Create
+  read: UploadsDocAccessFields_sizes_tablet_filename_Read
+  update: UploadsDocAccessFields_sizes_tablet_filename_Update
+  delete: UploadsDocAccessFields_sizes_tablet_filename_Delete
+}
+
+type UploadsDocAccessFields_sizes_tablet_filename_Create {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_tablet_filename_Read {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_tablet_filename_Update {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_tablet_filename_Delete {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_tabletHalf {
+  create: UploadsDocAccessFields_sizes_tabletHalf_Create
+  read: UploadsDocAccessFields_sizes_tabletHalf_Read
+  update: UploadsDocAccessFields_sizes_tabletHalf_Update
+  delete: UploadsDocAccessFields_sizes_tabletHalf_Delete
+  fields: UploadsDocAccessFields_sizes_tabletHalf_Fields
+}
+
+type UploadsDocAccessFields_sizes_tabletHalf_Create {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_tabletHalf_Read {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_tabletHalf_Update {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_tabletHalf_Delete {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_tabletHalf_Fields {
+  url: UploadsDocAccessFields_sizes_tabletHalf_url
+  width: UploadsDocAccessFields_sizes_tabletHalf_width
+  height: UploadsDocAccessFields_sizes_tabletHalf_height
+  mimeType: UploadsDocAccessFields_sizes_tabletHalf_mimeType
+  filesize: UploadsDocAccessFields_sizes_tabletHalf_filesize
+  filename: UploadsDocAccessFields_sizes_tabletHalf_filename
+}
+
+type UploadsDocAccessFields_sizes_tabletHalf_url {
+  create: UploadsDocAccessFields_sizes_tabletHalf_url_Create
+  read: UploadsDocAccessFields_sizes_tabletHalf_url_Read
+  update: UploadsDocAccessFields_sizes_tabletHalf_url_Update
+  delete: UploadsDocAccessFields_sizes_tabletHalf_url_Delete
+}
+
+type UploadsDocAccessFields_sizes_tabletHalf_url_Create {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_tabletHalf_url_Read {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_tabletHalf_url_Update {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_tabletHalf_url_Delete {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_tabletHalf_width {
+  create: UploadsDocAccessFields_sizes_tabletHalf_width_Create
+  read: UploadsDocAccessFields_sizes_tabletHalf_width_Read
+  update: UploadsDocAccessFields_sizes_tabletHalf_width_Update
+  delete: UploadsDocAccessFields_sizes_tabletHalf_width_Delete
+}
+
+type UploadsDocAccessFields_sizes_tabletHalf_width_Create {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_tabletHalf_width_Read {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_tabletHalf_width_Update {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_tabletHalf_width_Delete {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_tabletHalf_height {
+  create: UploadsDocAccessFields_sizes_tabletHalf_height_Create
+  read: UploadsDocAccessFields_sizes_tabletHalf_height_Read
+  update: UploadsDocAccessFields_sizes_tabletHalf_height_Update
+  delete: UploadsDocAccessFields_sizes_tabletHalf_height_Delete
+}
+
+type UploadsDocAccessFields_sizes_tabletHalf_height_Create {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_tabletHalf_height_Read {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_tabletHalf_height_Update {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_tabletHalf_height_Delete {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_tabletHalf_mimeType {
+  create: UploadsDocAccessFields_sizes_tabletHalf_mimeType_Create
+  read: UploadsDocAccessFields_sizes_tabletHalf_mimeType_Read
+  update: UploadsDocAccessFields_sizes_tabletHalf_mimeType_Update
+  delete: UploadsDocAccessFields_sizes_tabletHalf_mimeType_Delete
+}
+
+type UploadsDocAccessFields_sizes_tabletHalf_mimeType_Create {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_tabletHalf_mimeType_Read {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_tabletHalf_mimeType_Update {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_tabletHalf_mimeType_Delete {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_tabletHalf_filesize {
+  create: UploadsDocAccessFields_sizes_tabletHalf_filesize_Create
+  read: UploadsDocAccessFields_sizes_tabletHalf_filesize_Read
+  update: UploadsDocAccessFields_sizes_tabletHalf_filesize_Update
+  delete: UploadsDocAccessFields_sizes_tabletHalf_filesize_Delete
+}
+
+type UploadsDocAccessFields_sizes_tabletHalf_filesize_Create {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_tabletHalf_filesize_Read {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_tabletHalf_filesize_Update {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_tabletHalf_filesize_Delete {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_tabletHalf_filename {
+  create: UploadsDocAccessFields_sizes_tabletHalf_filename_Create
+  read: UploadsDocAccessFields_sizes_tabletHalf_filename_Read
+  update: UploadsDocAccessFields_sizes_tabletHalf_filename_Update
+  delete: UploadsDocAccessFields_sizes_tabletHalf_filename_Delete
+}
+
+type UploadsDocAccessFields_sizes_tabletHalf_filename_Create {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_tabletHalf_filename_Read {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_tabletHalf_filename_Update {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_tabletHalf_filename_Delete {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_mobile {
+  create: UploadsDocAccessFields_sizes_mobile_Create
+  read: UploadsDocAccessFields_sizes_mobile_Read
+  update: UploadsDocAccessFields_sizes_mobile_Update
+  delete: UploadsDocAccessFields_sizes_mobile_Delete
+  fields: UploadsDocAccessFields_sizes_mobile_Fields
+}
+
+type UploadsDocAccessFields_sizes_mobile_Create {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_mobile_Read {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_mobile_Update {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_mobile_Delete {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_mobile_Fields {
+  url: UploadsDocAccessFields_sizes_mobile_url
+  width: UploadsDocAccessFields_sizes_mobile_width
+  height: UploadsDocAccessFields_sizes_mobile_height
+  mimeType: UploadsDocAccessFields_sizes_mobile_mimeType
+  filesize: UploadsDocAccessFields_sizes_mobile_filesize
+  filename: UploadsDocAccessFields_sizes_mobile_filename
+}
+
+type UploadsDocAccessFields_sizes_mobile_url {
+  create: UploadsDocAccessFields_sizes_mobile_url_Create
+  read: UploadsDocAccessFields_sizes_mobile_url_Read
+  update: UploadsDocAccessFields_sizes_mobile_url_Update
+  delete: UploadsDocAccessFields_sizes_mobile_url_Delete
+}
+
+type UploadsDocAccessFields_sizes_mobile_url_Create {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_mobile_url_Read {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_mobile_url_Update {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_mobile_url_Delete {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_mobile_width {
+  create: UploadsDocAccessFields_sizes_mobile_width_Create
+  read: UploadsDocAccessFields_sizes_mobile_width_Read
+  update: UploadsDocAccessFields_sizes_mobile_width_Update
+  delete: UploadsDocAccessFields_sizes_mobile_width_Delete
+}
+
+type UploadsDocAccessFields_sizes_mobile_width_Create {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_mobile_width_Read {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_mobile_width_Update {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_mobile_width_Delete {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_mobile_height {
+  create: UploadsDocAccessFields_sizes_mobile_height_Create
+  read: UploadsDocAccessFields_sizes_mobile_height_Read
+  update: UploadsDocAccessFields_sizes_mobile_height_Update
+  delete: UploadsDocAccessFields_sizes_mobile_height_Delete
+}
+
+type UploadsDocAccessFields_sizes_mobile_height_Create {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_mobile_height_Read {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_mobile_height_Update {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_mobile_height_Delete {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_mobile_mimeType {
+  create: UploadsDocAccessFields_sizes_mobile_mimeType_Create
+  read: UploadsDocAccessFields_sizes_mobile_mimeType_Read
+  update: UploadsDocAccessFields_sizes_mobile_mimeType_Update
+  delete: UploadsDocAccessFields_sizes_mobile_mimeType_Delete
+}
+
+type UploadsDocAccessFields_sizes_mobile_mimeType_Create {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_mobile_mimeType_Read {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_mobile_mimeType_Update {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_mobile_mimeType_Delete {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_mobile_filesize {
+  create: UploadsDocAccessFields_sizes_mobile_filesize_Create
+  read: UploadsDocAccessFields_sizes_mobile_filesize_Read
+  update: UploadsDocAccessFields_sizes_mobile_filesize_Update
+  delete: UploadsDocAccessFields_sizes_mobile_filesize_Delete
+}
+
+type UploadsDocAccessFields_sizes_mobile_filesize_Create {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_mobile_filesize_Read {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_mobile_filesize_Update {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_mobile_filesize_Delete {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_mobile_filename {
+  create: UploadsDocAccessFields_sizes_mobile_filename_Create
+  read: UploadsDocAccessFields_sizes_mobile_filename_Read
+  update: UploadsDocAccessFields_sizes_mobile_filename_Update
+  delete: UploadsDocAccessFields_sizes_mobile_filename_Delete
+}
+
+type UploadsDocAccessFields_sizes_mobile_filename_Create {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_mobile_filename_Read {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_mobile_filename_Update {
+  permission: Boolean!
+}
+
+type UploadsDocAccessFields_sizes_mobile_filename_Delete {
+  permission: Boolean!
+}
+
+type UploadsCreateDocAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type UploadsReadDocAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type UploadsUpdateDocAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type UploadsDeleteDocAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
 type Redirect {
   id: Int
   from: String!
@@ -9192,20 +12951,19 @@ type Site {
 }
 
 input Site_FaviconSVG_where {
+  media: Site_FaviconSVG_media_operator
   alt: Site_FaviconSVG_alt_operator
   caption: Site_FaviconSVG_caption_operator
-  blurhash: Site_FaviconSVG_blurhash_operator
   updatedAt: Site_FaviconSVG_updatedAt_operator
   createdAt: Site_FaviconSVG_createdAt_operator
-  url: Site_FaviconSVG_url_operator
-  filename: Site_FaviconSVG_filename_operator
-  mimeType: Site_FaviconSVG_mimeType_operator
-  filesize: Site_FaviconSVG_filesize_operator
-  width: Site_FaviconSVG_width_operator
-  height: Site_FaviconSVG_height_operator
   id: Site_FaviconSVG_id_operator
   AND: [Site_FaviconSVG_where_and]
   OR: [Site_FaviconSVG_where_or]
+}
+
+input Site_FaviconSVG_media_operator {
+  equals: String
+  not_equals: String
 }
 
 input Site_FaviconSVG_alt_operator {
@@ -9223,17 +12981,6 @@ input Site_FaviconSVG_caption_operator {
   not_equals: JSON
   like: JSON
   contains: JSON
-  exists: Boolean
-}
-
-input Site_FaviconSVG_blurhash_operator {
-  equals: String
-  not_equals: String
-  like: String
-  contains: String
-  in: [String]
-  not_in: [String]
-  all: [String]
   exists: Boolean
 }
 
@@ -9259,69 +13006,6 @@ input Site_FaviconSVG_createdAt_operator {
   exists: Boolean
 }
 
-input Site_FaviconSVG_url_operator {
-  equals: String
-  not_equals: String
-  like: String
-  contains: String
-  in: [String]
-  not_in: [String]
-  all: [String]
-  exists: Boolean
-}
-
-input Site_FaviconSVG_filename_operator {
-  equals: String
-  not_equals: String
-  like: String
-  contains: String
-  in: [String]
-  not_in: [String]
-  all: [String]
-  exists: Boolean
-}
-
-input Site_FaviconSVG_mimeType_operator {
-  equals: String
-  not_equals: String
-  like: String
-  contains: String
-  in: [String]
-  not_in: [String]
-  all: [String]
-  exists: Boolean
-}
-
-input Site_FaviconSVG_filesize_operator {
-  equals: Float
-  not_equals: Float
-  greater_than_equal: Float
-  greater_than: Float
-  less_than_equal: Float
-  less_than: Float
-  exists: Boolean
-}
-
-input Site_FaviconSVG_width_operator {
-  equals: Float
-  not_equals: Float
-  greater_than_equal: Float
-  greater_than: Float
-  less_than_equal: Float
-  less_than: Float
-  exists: Boolean
-}
-
-input Site_FaviconSVG_height_operator {
-  equals: Float
-  not_equals: Float
-  greater_than_equal: Float
-  greater_than: Float
-  less_than_equal: Float
-  less_than: Float
-  exists: Boolean
-}
-
 input Site_FaviconSVG_id_operator {
   equals: String
   not_equals: String
@@ -9334,54 +13018,41 @@ input Site_FaviconSVG_id_operator {
 }
 
 input Site_FaviconSVG_where_and {
+  media: Site_FaviconSVG_media_operator
   alt: Site_FaviconSVG_alt_operator
   caption: Site_FaviconSVG_caption_operator
-  blurhash: Site_FaviconSVG_blurhash_operator
   updatedAt: Site_FaviconSVG_updatedAt_operator
   createdAt: Site_FaviconSVG_createdAt_operator
-  url: Site_FaviconSVG_url_operator
-  filename: Site_FaviconSVG_filename_operator
-  mimeType: Site_FaviconSVG_mimeType_operator
-  filesize: Site_FaviconSVG_filesize_operator
-  width: Site_FaviconSVG_width_operator
-  height: Site_FaviconSVG_height_operator
   id: Site_FaviconSVG_id_operator
   AND: [Site_FaviconSVG_where_and]
   OR: [Site_FaviconSVG_where_or]
 }
 
 input Site_FaviconSVG_where_or {
+  media: Site_FaviconSVG_media_operator
   alt: Site_FaviconSVG_alt_operator
   caption: Site_FaviconSVG_caption_operator
-  blurhash: Site_FaviconSVG_blurhash_operator
   updatedAt: Site_FaviconSVG_updatedAt_operator
   createdAt: Site_FaviconSVG_createdAt_operator
-  url: Site_FaviconSVG_url_operator
-  filename: Site_FaviconSVG_filename_operator
-  mimeType: Site_FaviconSVG_mimeType_operator
-  filesize: Site_FaviconSVG_filesize_operator
-  width: Site_FaviconSVG_width_operator
-  height: Site_FaviconSVG_height_operator
   id: Site_FaviconSVG_id_operator
   AND: [Site_FaviconSVG_where_and]
   OR: [Site_FaviconSVG_where_or]
 }
 
 input Site_FaviconICO_where {
+  media: Site_FaviconICO_media_operator
   alt: Site_FaviconICO_alt_operator
   caption: Site_FaviconICO_caption_operator
-  blurhash: Site_FaviconICO_blurhash_operator
   updatedAt: Site_FaviconICO_updatedAt_operator
   createdAt: Site_FaviconICO_createdAt_operator
-  url: Site_FaviconICO_url_operator
-  filename: Site_FaviconICO_filename_operator
-  mimeType: Site_FaviconICO_mimeType_operator
-  filesize: Site_FaviconICO_filesize_operator
-  width: Site_FaviconICO_width_operator
-  height: Site_FaviconICO_height_operator
   id: Site_FaviconICO_id_operator
   AND: [Site_FaviconICO_where_and]
   OR: [Site_FaviconICO_where_or]
+}
+
+input Site_FaviconICO_media_operator {
+  equals: String
+  not_equals: String
 }
 
 input Site_FaviconICO_alt_operator {
@@ -9399,17 +13070,6 @@ input Site_FaviconICO_caption_operator {
   not_equals: JSON
   like: JSON
   contains: JSON
-  exists: Boolean
-}
-
-input Site_FaviconICO_blurhash_operator {
-  equals: String
-  not_equals: String
-  like: String
-  contains: String
-  in: [String]
-  not_in: [String]
-  all: [String]
   exists: Boolean
 }
 
@@ -9435,69 +13095,6 @@ input Site_FaviconICO_createdAt_operator {
   exists: Boolean
 }
 
-input Site_FaviconICO_url_operator {
-  equals: String
-  not_equals: String
-  like: String
-  contains: String
-  in: [String]
-  not_in: [String]
-  all: [String]
-  exists: Boolean
-}
-
-input Site_FaviconICO_filename_operator {
-  equals: String
-  not_equals: String
-  like: String
-  contains: String
-  in: [String]
-  not_in: [String]
-  all: [String]
-  exists: Boolean
-}
-
-input Site_FaviconICO_mimeType_operator {
-  equals: String
-  not_equals: String
-  like: String
-  contains: String
-  in: [String]
-  not_in: [String]
-  all: [String]
-  exists: Boolean
-}
-
-input Site_FaviconICO_filesize_operator {
-  equals: Float
-  not_equals: Float
-  greater_than_equal: Float
-  greater_than: Float
-  less_than_equal: Float
-  less_than: Float
-  exists: Boolean
-}
-
-input Site_FaviconICO_width_operator {
-  equals: Float
-  not_equals: Float
-  greater_than_equal: Float
-  greater_than: Float
-  less_than_equal: Float
-  less_than: Float
-  exists: Boolean
-}
-
-input Site_FaviconICO_height_operator {
-  equals: Float
-  not_equals: Float
-  greater_than_equal: Float
-  greater_than: Float
-  less_than_equal: Float
-  less_than: Float
-  exists: Boolean
-}
-
 input Site_FaviconICO_id_operator {
   equals: String
   not_equals: String
@@ -9510,34 +13107,22 @@ input Site_FaviconICO_id_operator {
 }
 
 input Site_FaviconICO_where_and {
+  media: Site_FaviconICO_media_operator
   alt: Site_FaviconICO_alt_operator
   caption: Site_FaviconICO_caption_operator
-  blurhash: Site_FaviconICO_blurhash_operator
   updatedAt: Site_FaviconICO_updatedAt_operator
   createdAt: Site_FaviconICO_createdAt_operator
-  url: Site_FaviconICO_url_operator
-  filename: Site_FaviconICO_filename_operator
-  mimeType: Site_FaviconICO_mimeType_operator
-  filesize: Site_FaviconICO_filesize_operator
-  width: Site_FaviconICO_width_operator
-  height: Site_FaviconICO_height_operator
   id: Site_FaviconICO_id_operator
   AND: [Site_FaviconICO_where_and]
   OR: [Site_FaviconICO_where_or]
 }
 
 input Site_FaviconICO_where_or {
+  media: Site_FaviconICO_media_operator
   alt: Site_FaviconICO_alt_operator
   caption: Site_FaviconICO_caption_operator
-  blurhash: Site_FaviconICO_blurhash_operator
   updatedAt: Site_FaviconICO_updatedAt_operator
   createdAt: Site_FaviconICO_createdAt_operator
-  url: Site_FaviconICO_url_operator
-  filename: Site_FaviconICO_filename_operator
-  mimeType: Site_FaviconICO_mimeType_operator
-  filesize: Site_FaviconICO_filesize_operator
-  width: Site_FaviconICO_width_operator
-  height: Site_FaviconICO_height_operator
   id: Site_FaviconICO_id_operator
   AND: [Site_FaviconICO_where_and]
   OR: [Site_FaviconICO_where_or]
@@ -9941,7 +13526,7 @@ type HiddenLayout {
   createdAt: DateTime
 }
 
-union HiddenLayout_Layout = CallToActionBlock | MediaBlock | ArchiveBlock | CodeBlock
+union HiddenLayout_Layout = CallToActionBlock | MediaBlock | ArchiveBlock | CodeBlock | VimeoBlock
 
 type CallToActionBlock {
   invertBackground: Boolean
@@ -9953,9 +13538,12 @@ type CallToActionBlock {
 }
 
 type MediaBlock {
-  invertBackground: Boolean
   aspectRatio: MediaBlock_aspectRatio
-  media(where: MediaBlock_Media_where): Media!
+  sideCaption: Boolean
+  layout: MediaBlock_layout
+  media1: Media!
+  media2: Media
+  media3: Media
   id: String
   blockName: String
   blockType: String
@@ -9967,180 +13555,10 @@ enum MediaBlock_aspectRatio {
   video
 }
 
-input MediaBlock_Media_where {
-  alt: MediaBlock_Media_alt_operator
-  caption: MediaBlock_Media_caption_operator
-  blurhash: MediaBlock_Media_blurhash_operator
-  updatedAt: MediaBlock_Media_updatedAt_operator
-  createdAt: MediaBlock_Media_createdAt_operator
-  url: MediaBlock_Media_url_operator
-  filename: MediaBlock_Media_filename_operator
-  mimeType: MediaBlock_Media_mimeType_operator
-  filesize: MediaBlock_Media_filesize_operator
-  width: MediaBlock_Media_width_operator
-  height: MediaBlock_Media_height_operator
-  id: MediaBlock_Media_id_operator
-  AND: [MediaBlock_Media_where_and]
-  OR: [MediaBlock_Media_where_or]
-}
-
-input MediaBlock_Media_alt_operator {
-  equals: String
-  not_equals: String
-  like: String
-  contains: String
-  in: [String]
-  not_in: [String]
-  all: [String]
-}
-
-input MediaBlock_Media_caption_operator {
-  equals: JSON
-  not_equals: JSON
-  like: JSON
-  contains: JSON
-  exists: Boolean
-}
-
-input MediaBlock_Media_blurhash_operator {
-  equals: String
-  not_equals: String
-  like: String
-  contains: String
-  in: [String]
-  not_in: [String]
-  all: [String]
-  exists: Boolean
-}
-
-input MediaBlock_Media_updatedAt_operator {
-  equals: DateTime
-  not_equals: DateTime
-  greater_than_equal: DateTime
-  greater_than: DateTime
-  less_than_equal: DateTime
-  less_than: DateTime
-  like: DateTime
-  exists: Boolean
-}
-
-input MediaBlock_Media_createdAt_operator {
-  equals: DateTime
-  not_equals: DateTime
-  greater_than_equal: DateTime
-  greater_than: DateTime
-  less_than_equal: DateTime
-  less_than: DateTime
-  like: DateTime
-  exists: Boolean
-}
-
-input MediaBlock_Media_url_operator {
-  equals: String
-  not_equals: String
-  like: String
-  contains: String
-  in: [String]
-  not_in: [String]
-  all: [String]
-  exists: Boolean
-}
-
-input MediaBlock_Media_filename_operator {
-  equals: String
-  not_equals: String
-  like: String
-  contains: String
-  in: [String]
-  not_in: [String]
-  all: [String]
-  exists: Boolean
-}
-
-input MediaBlock_Media_mimeType_operator {
-  equals: String
-  not_equals: String
-  like: String
-  contains: String
-  in: [String]
-  not_in: [String]
-  all: [String]
-  exists: Boolean
-}
-
-input MediaBlock_Media_filesize_operator {
-  equals: Float
-  not_equals: Float
-  greater_than_equal: Float
-  greater_than: Float
-  less_than_equal: Float
-  less_than: Float
-  exists: Boolean
-}
-
-input MediaBlock_Media_width_operator {
-  equals: Float
-  not_equals: Float
-  greater_than_equal: Float
-  greater_than: Float
-  less_than_equal: Float
-  less_than: Float
-  exists: Boolean
-}
-
-input MediaBlock_Media_height_operator {
-  equals: Float
-  not_equals: Float
-  greater_than_equal: Float
-  greater_than: Float
-  less_than_equal: Float
-  less_than: Float
-  exists: Boolean
-}
-
-input MediaBlock_Media_id_operator {
-  equals: String
-  not_equals: String
-  like: String
-  contains: String
-  in: [String]
-  not_in: [String]
-  all: [String]
-  exists: Boolean
-}
-
-input MediaBlock_Media_where_and {
-  alt: MediaBlock_Media_alt_operator
-  caption: MediaBlock_Media_caption_operator
-  blurhash: MediaBlock_Media_blurhash_operator
-  updatedAt: MediaBlock_Media_updatedAt_operator
-  createdAt: MediaBlock_Media_createdAt_operator
-  url: MediaBlock_Media_url_operator
-  filename: MediaBlock_Media_filename_operator
-  mimeType: MediaBlock_Media_mimeType_operator
-  filesize: MediaBlock_Media_filesize_operator
-  width: MediaBlock_Media_width_operator
-  height: MediaBlock_Media_height_operator
-  id: MediaBlock_Media_id_operator
-  AND: [MediaBlock_Media_where_and]
-  OR: [MediaBlock_Media_where_or]
-}
-
-input MediaBlock_Media_where_or {
-  alt: MediaBlock_Media_alt_operator
-  caption: MediaBlock_Media_caption_operator
-  blurhash: MediaBlock_Media_blurhash_operator
-  updatedAt: MediaBlock_Media_updatedAt_operator
-  createdAt: MediaBlock_Media_createdAt_operator
-  url: MediaBlock_Media_url_operator
-  filename: MediaBlock_Media_filename_operator
-  mimeType: MediaBlock_Media_mimeType_operator
-  filesize: MediaBlock_Media_filesize_operator
-  width: MediaBlock_Media_width_operator
-  height: MediaBlock_Media_height_operator
-  id: MediaBlock_Media_id_operator
-  AND: [MediaBlock_Media_where_and]
-  OR: [MediaBlock_Media_where_or]
+enum MediaBlock_layout {
+  default
+  twoColumn
+  heroGrid
 }
 
 type ArchiveBlock {
@@ -10198,9 +13616,121 @@ type CodeBlock {
 }
 
 enum CodeBlock_language {
+  css
+  dockerfile
   go
+  graphql
+  handlebars
+  html
+  java
   javascript
+  kotlin
+  markdown
+  pgsql
+  python
+  rust
+  scss
+  swift
   typescript
+  xml
+  yaml
+}
+
+type VimeoBlock {
+  videoId: String
+  previewImage(where: VimeoBlock_PreviewImage_where): Media
+  id: String
+  blockName: String
+  blockType: String
+}
+
+input VimeoBlock_PreviewImage_where {
+  media: VimeoBlock_PreviewImage_media_operator
+  alt: VimeoBlock_PreviewImage_alt_operator
+  caption: VimeoBlock_PreviewImage_caption_operator
+  updatedAt: VimeoBlock_PreviewImage_updatedAt_operator
+  createdAt: VimeoBlock_PreviewImage_createdAt_operator
+  id: VimeoBlock_PreviewImage_id_operator
+  AND: [VimeoBlock_PreviewImage_where_and]
+  OR: [VimeoBlock_PreviewImage_where_or]
+}
+
+input VimeoBlock_PreviewImage_media_operator {
+  equals: String
+  not_equals: String
+}
+
+input VimeoBlock_PreviewImage_alt_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+}
+
+input VimeoBlock_PreviewImage_caption_operator {
+  equals: JSON
+  not_equals: JSON
+  like: JSON
+  contains: JSON
+  exists: Boolean
+}
+
+input VimeoBlock_PreviewImage_updatedAt_operator {
+  equals: DateTime
+  not_equals: DateTime
+  greater_than_equal: DateTime
+  greater_than: DateTime
+  less_than_equal: DateTime
+  less_than: DateTime
+  like: DateTime
+  exists: Boolean
+}
+
+input VimeoBlock_PreviewImage_createdAt_operator {
+  equals: DateTime
+  not_equals: DateTime
+  greater_than_equal: DateTime
+  greater_than: DateTime
+  less_than_equal: DateTime
+  less_than: DateTime
+  like: DateTime
+  exists: Boolean
+}
+
+input VimeoBlock_PreviewImage_id_operator {
+  equals: String
+  not_equals: String
+  like: String
+  contains: String
+  in: [String]
+  not_in: [String]
+  all: [String]
+  exists: Boolean
+}
+
+input VimeoBlock_PreviewImage_where_and {
+  media: VimeoBlock_PreviewImage_media_operator
+  alt: VimeoBlock_PreviewImage_alt_operator
+  caption: VimeoBlock_PreviewImage_caption_operator
+  updatedAt: VimeoBlock_PreviewImage_updatedAt_operator
+  createdAt: VimeoBlock_PreviewImage_createdAt_operator
+  id: VimeoBlock_PreviewImage_id_operator
+  AND: [VimeoBlock_PreviewImage_where_and]
+  OR: [VimeoBlock_PreviewImage_where_or]
+}
+
+input VimeoBlock_PreviewImage_where_or {
+  media: VimeoBlock_PreviewImage_media_operator
+  alt: VimeoBlock_PreviewImage_alt_operator
+  caption: VimeoBlock_PreviewImage_caption_operator
+  updatedAt: VimeoBlock_PreviewImage_updatedAt_operator
+  createdAt: VimeoBlock_PreviewImage_createdAt_operator
+  id: VimeoBlock_PreviewImage_id_operator
+  AND: [VimeoBlock_PreviewImage_where_and]
+  OR: [VimeoBlock_PreviewImage_where_or]
 }
 
 type hidden_layoutDocAccess {
@@ -10303,6 +13833,7 @@ type Access {
   keywords: keywordsAccess
   clients: clientsAccess
   users: usersAccess
+  uploads: uploadsAccess
   redirects: redirectsAccess
   payload_preferences: payload_preferencesAccess
   site: siteAccess
@@ -10881,6 +14412,8 @@ type PagesFields_layout_sideColumn_projectHero_Delete {
 type PagesFields_layout_sideColumn_projectHero_Fields {
   year: PagesFields_layout_sideColumn_projectHero_year
   client: PagesFields_layout_sideColumn_projectHero_client
+  usePostDescription: PagesFields_layout_sideColumn_projectHero_usePostDescription
+  customDescription: PagesFields_layout_sideColumn_projectHero_customDescription
   links: PagesFields_layout_sideColumn_projectHero_links
 }
 
@@ -10927,6 +14460,52 @@ type PagesFields_layout_sideColumn_projectHero_client_Update {
 }
 
 type PagesFields_layout_sideColumn_projectHero_client_Delete {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_projectHero_usePostDescription {
+  create: PagesFields_layout_sideColumn_projectHero_usePostDescription_Create
+  read: PagesFields_layout_sideColumn_projectHero_usePostDescription_Read
+  update: PagesFields_layout_sideColumn_projectHero_usePostDescription_Update
+  delete: PagesFields_layout_sideColumn_projectHero_usePostDescription_Delete
+}
+
+type PagesFields_layout_sideColumn_projectHero_usePostDescription_Create {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_projectHero_usePostDescription_Read {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_projectHero_usePostDescription_Update {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_projectHero_usePostDescription_Delete {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_projectHero_customDescription {
+  create: PagesFields_layout_sideColumn_projectHero_customDescription_Create
+  read: PagesFields_layout_sideColumn_projectHero_customDescription_Read
+  update: PagesFields_layout_sideColumn_projectHero_customDescription_Update
+  delete: PagesFields_layout_sideColumn_projectHero_customDescription_Delete
+}
+
+type PagesFields_layout_sideColumn_projectHero_customDescription_Create {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_projectHero_customDescription_Read {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_projectHero_customDescription_Update {
+  permission: Boolean!
+}
+
+type PagesFields_layout_sideColumn_projectHero_customDescription_Delete {
   permission: Boolean!
 }
 
@@ -11225,10 +14804,8 @@ type PagesFields_layout_mainColumn_Delete {
 
 type PagesFields_layout_mainColumn_Fields {
   style: PagesFields_layout_mainColumn_style
-  row1column1: PagesFields_layout_mainColumn_row1column1
-  row1column2: PagesFields_layout_mainColumn_row1column2
-  row2column1: PagesFields_layout_mainColumn_row2column1
-  row2column2: PagesFields_layout_mainColumn_row2column2
+  column1: PagesFields_layout_mainColumn_column1
+  column2: PagesFields_layout_mainColumn_column2
 }
 
 type PagesFields_layout_mainColumn_style {
@@ -11254,95 +14831,49 @@ type PagesFields_layout_mainColumn_style_Delete {
   permission: Boolean!
 }
 
-type PagesFields_layout_mainColumn_row1column1 {
-  create: PagesFields_layout_mainColumn_row1column1_Create
-  read: PagesFields_layout_mainColumn_row1column1_Read
-  update: PagesFields_layout_mainColumn_row1column1_Update
-  delete: PagesFields_layout_mainColumn_row1column1_Delete
+type PagesFields_layout_mainColumn_column1 {
+  create: PagesFields_layout_mainColumn_column1_Create
+  read: PagesFields_layout_mainColumn_column1_Read
+  update: PagesFields_layout_mainColumn_column1_Update
+  delete: PagesFields_layout_mainColumn_column1_Delete
 }
 
-type PagesFields_layout_mainColumn_row1column1_Create {
+type PagesFields_layout_mainColumn_column1_Create {
   permission: Boolean!
 }
 
-type PagesFields_layout_mainColumn_row1column1_Read {
+type PagesFields_layout_mainColumn_column1_Read {
   permission: Boolean!
 }
 
-type PagesFields_layout_mainColumn_row1column1_Update {
+type PagesFields_layout_mainColumn_column1_Update {
   permission: Boolean!
 }
 
-type PagesFields_layout_mainColumn_row1column1_Delete {
+type PagesFields_layout_mainColumn_column1_Delete {
   permission: Boolean!
 }
 
-type PagesFields_layout_mainColumn_row1column2 {
-  create: PagesFields_layout_mainColumn_row1column2_Create
-  read: PagesFields_layout_mainColumn_row1column2_Read
-  update: PagesFields_layout_mainColumn_row1column2_Update
-  delete: PagesFields_layout_mainColumn_row1column2_Delete
+type PagesFields_layout_mainColumn_column2 {
+  create: PagesFields_layout_mainColumn_column2_Create
+  read: PagesFields_layout_mainColumn_column2_Read
+  update: PagesFields_layout_mainColumn_column2_Update
+  delete: PagesFields_layout_mainColumn_column2_Delete
 }
 
-type PagesFields_layout_mainColumn_row1column2_Create {
+type PagesFields_layout_mainColumn_column2_Create {
   permission: Boolean!
 }
 
-type PagesFields_layout_mainColumn_row1column2_Read {
+type PagesFields_layout_mainColumn_column2_Read {
   permission: Boolean!
 }
 
-type PagesFields_layout_mainColumn_row1column2_Update {
+type PagesFields_layout_mainColumn_column2_Update {
   permission: Boolean!
 }
 
-type PagesFields_layout_mainColumn_row1column2_Delete {
-  permission: Boolean!
-}
-
-type PagesFields_layout_mainColumn_row2column1 {
-  create: PagesFields_layout_mainColumn_row2column1_Create
-  read: PagesFields_layout_mainColumn_row2column1_Read
-  update: PagesFields_layout_mainColumn_row2column1_Update
-  delete: PagesFields_layout_mainColumn_row2column1_Delete
-}
-
-type PagesFields_layout_mainColumn_row2column1_Create {
-  permission: Boolean!
-}
-
-type PagesFields_layout_mainColumn_row2column1_Read {
-  permission: Boolean!
-}
-
-type PagesFields_layout_mainColumn_row2column1_Update {
-  permission: Boolean!
-}
-
-type PagesFields_layout_mainColumn_row2column1_Delete {
-  permission: Boolean!
-}
-
-type PagesFields_layout_mainColumn_row2column2 {
-  create: PagesFields_layout_mainColumn_row2column2_Create
-  read: PagesFields_layout_mainColumn_row2column2_Read
-  update: PagesFields_layout_mainColumn_row2column2_Update
-  delete: PagesFields_layout_mainColumn_row2column2_Delete
-}
-
-type PagesFields_layout_mainColumn_row2column2_Create {
-  permission: Boolean!
-}
-
-type PagesFields_layout_mainColumn_row2column2_Read {
-  permission: Boolean!
-}
-
-type PagesFields_layout_mainColumn_row2column2_Update {
-  permission: Boolean!
-}
-
-type PagesFields_layout_mainColumn_row2column2_Delete {
+type PagesFields_layout_mainColumn_column2_Delete {
   permission: Boolean!
 }
 
@@ -12431,6 +15962,8 @@ type PostsFields_layout_sideColumn_projectHero_Delete {
 type PostsFields_layout_sideColumn_projectHero_Fields {
   year: PostsFields_layout_sideColumn_projectHero_year
   client: PostsFields_layout_sideColumn_projectHero_client
+  usePostDescription: PostsFields_layout_sideColumn_projectHero_usePostDescription
+  customDescription: PostsFields_layout_sideColumn_projectHero_customDescription
   links: PostsFields_layout_sideColumn_projectHero_links
 }
 
@@ -12477,6 +16010,52 @@ type PostsFields_layout_sideColumn_projectHero_client_Update {
 }
 
 type PostsFields_layout_sideColumn_projectHero_client_Delete {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_projectHero_usePostDescription {
+  create: PostsFields_layout_sideColumn_projectHero_usePostDescription_Create
+  read: PostsFields_layout_sideColumn_projectHero_usePostDescription_Read
+  update: PostsFields_layout_sideColumn_projectHero_usePostDescription_Update
+  delete: PostsFields_layout_sideColumn_projectHero_usePostDescription_Delete
+}
+
+type PostsFields_layout_sideColumn_projectHero_usePostDescription_Create {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_projectHero_usePostDescription_Read {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_projectHero_usePostDescription_Update {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_projectHero_usePostDescription_Delete {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_projectHero_customDescription {
+  create: PostsFields_layout_sideColumn_projectHero_customDescription_Create
+  read: PostsFields_layout_sideColumn_projectHero_customDescription_Read
+  update: PostsFields_layout_sideColumn_projectHero_customDescription_Update
+  delete: PostsFields_layout_sideColumn_projectHero_customDescription_Delete
+}
+
+type PostsFields_layout_sideColumn_projectHero_customDescription_Create {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_projectHero_customDescription_Read {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_projectHero_customDescription_Update {
+  permission: Boolean!
+}
+
+type PostsFields_layout_sideColumn_projectHero_customDescription_Delete {
   permission: Boolean!
 }
 
@@ -12775,10 +16354,8 @@ type PostsFields_layout_mainColumn_Delete {
 
 type PostsFields_layout_mainColumn_Fields {
   style: PostsFields_layout_mainColumn_style
-  row1column1: PostsFields_layout_mainColumn_row1column1
-  row1column2: PostsFields_layout_mainColumn_row1column2
-  row2column1: PostsFields_layout_mainColumn_row2column1
-  row2column2: PostsFields_layout_mainColumn_row2column2
+  column1: PostsFields_layout_mainColumn_column1
+  column2: PostsFields_layout_mainColumn_column2
 }
 
 type PostsFields_layout_mainColumn_style {
@@ -12804,95 +16381,49 @@ type PostsFields_layout_mainColumn_style_Delete {
   permission: Boolean!
 }
 
-type PostsFields_layout_mainColumn_row1column1 {
-  create: PostsFields_layout_mainColumn_row1column1_Create
-  read: PostsFields_layout_mainColumn_row1column1_Read
-  update: PostsFields_layout_mainColumn_row1column1_Update
-  delete: PostsFields_layout_mainColumn_row1column1_Delete
+type PostsFields_layout_mainColumn_column1 {
+  create: PostsFields_layout_mainColumn_column1_Create
+  read: PostsFields_layout_mainColumn_column1_Read
+  update: PostsFields_layout_mainColumn_column1_Update
+  delete: PostsFields_layout_mainColumn_column1_Delete
 }
 
-type PostsFields_layout_mainColumn_row1column1_Create {
+type PostsFields_layout_mainColumn_column1_Create {
   permission: Boolean!
 }
 
-type PostsFields_layout_mainColumn_row1column1_Read {
+type PostsFields_layout_mainColumn_column1_Read {
   permission: Boolean!
 }
 
-type PostsFields_layout_mainColumn_row1column1_Update {
+type PostsFields_layout_mainColumn_column1_Update {
   permission: Boolean!
 }
 
-type PostsFields_layout_mainColumn_row1column1_Delete {
+type PostsFields_layout_mainColumn_column1_Delete {
   permission: Boolean!
 }
 
-type PostsFields_layout_mainColumn_row1column2 {
-  create: PostsFields_layout_mainColumn_row1column2_Create
-  read: PostsFields_layout_mainColumn_row1column2_Read
-  update: PostsFields_layout_mainColumn_row1column2_Update
-  delete: PostsFields_layout_mainColumn_row1column2_Delete
+type PostsFields_layout_mainColumn_column2 {
+  create: PostsFields_layout_mainColumn_column2_Create
+  read: PostsFields_layout_mainColumn_column2_Read
+  update: PostsFields_layout_mainColumn_column2_Update
+  delete: PostsFields_layout_mainColumn_column2_Delete
 }
 
-type PostsFields_layout_mainColumn_row1column2_Create {
+type PostsFields_layout_mainColumn_column2_Create {
   permission: Boolean!
 }
 
-type PostsFields_layout_mainColumn_row1column2_Read {
+type PostsFields_layout_mainColumn_column2_Read {
   permission: Boolean!
 }
 
-type PostsFields_layout_mainColumn_row1column2_Update {
+type PostsFields_layout_mainColumn_column2_Update {
   permission: Boolean!
 }
 
-type PostsFields_layout_mainColumn_row1column2_Delete {
-  permission: Boolean!
-}
-
-type PostsFields_layout_mainColumn_row2column1 {
-  create: PostsFields_layout_mainColumn_row2column1_Create
-  read: PostsFields_layout_mainColumn_row2column1_Read
-  update: PostsFields_layout_mainColumn_row2column1_Update
-  delete: PostsFields_layout_mainColumn_row2column1_Delete
-}
-
-type PostsFields_layout_mainColumn_row2column1_Create {
-  permission: Boolean!
-}
-
-type PostsFields_layout_mainColumn_row2column1_Read {
-  permission: Boolean!
-}
-
-type PostsFields_layout_mainColumn_row2column1_Update {
-  permission: Boolean!
-}
-
-type PostsFields_layout_mainColumn_row2column1_Delete {
-  permission: Boolean!
-}
-
-type PostsFields_layout_mainColumn_row2column2 {
-  create: PostsFields_layout_mainColumn_row2column2_Create
-  read: PostsFields_layout_mainColumn_row2column2_Read
-  update: PostsFields_layout_mainColumn_row2column2_Update
-  delete: PostsFields_layout_mainColumn_row2column2_Delete
-}
-
-type PostsFields_layout_mainColumn_row2column2_Create {
-  permission: Boolean!
-}
-
-type PostsFields_layout_mainColumn_row2column2_Read {
-  permission: Boolean!
-}
-
-type PostsFields_layout_mainColumn_row2column2_Update {
-  permission: Boolean!
-}
-
-type PostsFields_layout_mainColumn_row2column2_Delete {
+type PostsFields_layout_mainColumn_column2_Delete {
   permission: Boolean!
 }
 
@@ -13144,17 +16675,34 @@ type mediaAccess {
 }
 
 type MediaFields {
+  media: MediaFields_media
   alt: MediaFields_alt
   caption: MediaFields_caption
-  blurhash: MediaFields_blurhash
   updatedAt: MediaFields_updatedAt
   createdAt: MediaFields_createdAt
-  url: MediaFields_url
-  filename: MediaFields_filename
-  mimeType: MediaFields_mimeType
-  filesize: MediaFields_filesize
-  width: MediaFields_width
-  height: MediaFields_height
+}
+
+type MediaFields_media {
+  create: MediaFields_media_Create
+  read: MediaFields_media_Read
+  update: MediaFields_media_Update
+  delete: MediaFields_media_Delete
+}
+
+type MediaFields_media_Create {
+  permission: Boolean!
+}
+
+type MediaFields_media_Read {
+  permission: Boolean!
+}
+
+type MediaFields_media_Update {
+  permission: Boolean!
+}
+
+type MediaFields_media_Delete {
+  permission: Boolean!
 }
 
 type MediaFields_alt {
@@ -13203,29 +16751,6 @@ type MediaFields_caption_Delete {
   permission: Boolean!
 }
 
-type MediaFields_blurhash {
-  create: MediaFields_blurhash_Create
-  read: MediaFields_blurhash_Read
-  update: MediaFields_blurhash_Update
-  delete: MediaFields_blurhash_Delete
-}
-
-type MediaFields_blurhash_Create {
-  permission: Boolean!
-}
-
-type MediaFields_blurhash_Read {
-  permission: Boolean!
-}
-
-type MediaFields_blurhash_Update {
-  permission: Boolean!
-}
-
-type MediaFields_blurhash_Delete {
-  permission: Boolean!
-}
-
 type MediaFields_updatedAt {
   create: MediaFields_updatedAt_Create
   read: MediaFields_updatedAt_Read
@@ -13269,144 +16794,6 @@ type MediaFields_createdAt_Update {
 }
 
 type MediaFields_createdAt_Delete {
-  permission: Boolean!
-}
-
-type MediaFields_url {
-  create: MediaFields_url_Create
-  read: MediaFields_url_Read
-  update: MediaFields_url_Update
-  delete: MediaFields_url_Delete
-}
-
-type MediaFields_url_Create {
-  permission: Boolean!
-}
-
-type MediaFields_url_Read {
-  permission: Boolean!
-}
-
-type MediaFields_url_Update {
-  permission: Boolean!
-}
-
-type MediaFields_url_Delete {
-  permission: Boolean!
-}
-
-type MediaFields_filename {
-  create: MediaFields_filename_Create
-  read: MediaFields_filename_Read
-  update: MediaFields_filename_Update
-  delete: MediaFields_filename_Delete
-}
-
-type MediaFields_filename_Create {
-  permission: Boolean!
-}
-
-type MediaFields_filename_Read {
-  permission: Boolean!
-}
-
-type MediaFields_filename_Update {
-  permission: Boolean!
-}
-
-type MediaFields_filename_Delete {
-  permission: Boolean!
-}
-
-type MediaFields_mimeType {
-  create: MediaFields_mimeType_Create
-  read: MediaFields_mimeType_Read
-  update: MediaFields_mimeType_Update
-  delete: MediaFields_mimeType_Delete
-}
-
-type MediaFields_mimeType_Create {
-  permission: Boolean!
-}
-
-type MediaFields_mimeType_Read {
-  permission: Boolean!
-}
-
-type MediaFields_mimeType_Update {
-  permission: Boolean!
-}
-
-type MediaFields_mimeType_Delete {
-  permission: Boolean!
-}
-
-type MediaFields_filesize {
-  create: MediaFields_filesize_Create
-  read: MediaFields_filesize_Read
-  update: MediaFields_filesize_Update
-  delete: MediaFields_filesize_Delete
-}
-
-type MediaFields_filesize_Create {
-  permission: Boolean!
-}
-
-type MediaFields_filesize_Read {
-  permission: Boolean!
-}
-
-type MediaFields_filesize_Update {
-  permission: Boolean!
-}
-
-type MediaFields_filesize_Delete {
-  permission: Boolean!
-}
-
-type MediaFields_width {
-  create: MediaFields_width_Create
-  read: MediaFields_width_Read
-  update: MediaFields_width_Update
-  delete: MediaFields_width_Delete
-}
-
-type MediaFields_width_Create {
-  permission: Boolean!
-}
-
-type MediaFields_width_Read {
-  permission: Boolean!
-}
-
-type MediaFields_width_Update {
-  permission: Boolean!
-}
-
-type MediaFields_width_Delete {
-  permission: Boolean!
-}
-
-type MediaFields_height {
-  create: MediaFields_height_Create
-  read: MediaFields_height_Read
-  update: MediaFields_height_Update
-  delete: MediaFields_height_Delete
-}
-
-type MediaFields_height_Create {
-  permission: Boolean!
-}
-
-type MediaFields_height_Read {
-  permission: Boolean!
-}
-
-type MediaFields_height_Update {
-  permission: Boolean!
-}
-
-type MediaFields_height_Delete {
   permission: Boolean!
 }
 
@@ -14064,6 +17451,1313 @@ type UsersDeleteAccess {
 }
 
 type UsersUnlockAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type uploadsAccess {
+  fields: UploadsFields
+  create: UploadsCreateAccess
+  read: UploadsReadAccess
+  update: UploadsUpdateAccess
+  delete: UploadsDeleteAccess
+}
+
+type UploadsFields {
+  blurhash: UploadsFields_blurhash
+  updatedAt: UploadsFields_updatedAt
+  createdAt: UploadsFields_createdAt
+  url: UploadsFields_url
+  filename: UploadsFields_filename
+  mimeType: UploadsFields_mimeType
+  filesize: UploadsFields_filesize
+  width: UploadsFields_width
+  height: UploadsFields_height
+  sizes: UploadsFields_sizes
+}
+
+type UploadsFields_blurhash {
+  create: UploadsFields_blurhash_Create
+  read: UploadsFields_blurhash_Read
+  update: UploadsFields_blurhash_Update
+  delete: UploadsFields_blurhash_Delete
+}
+
+type UploadsFields_blurhash_Create {
+  permission: Boolean!
+}
+
+type UploadsFields_blurhash_Read {
+  permission: Boolean!
+}
+
+type UploadsFields_blurhash_Update {
+  permission: Boolean!
+}
+
+type UploadsFields_blurhash_Delete {
+  permission: Boolean!
+}
+
+type UploadsFields_updatedAt {
+  create: UploadsFields_updatedAt_Create
+  read: UploadsFields_updatedAt_Read
+  update: UploadsFields_updatedAt_Update
+  delete: UploadsFields_updatedAt_Delete
+}
+
+type UploadsFields_updatedAt_Create {
+  permission: Boolean!
+}
+
+type UploadsFields_updatedAt_Read {
+  permission: Boolean!
+}
+
+type UploadsFields_updatedAt_Update {
+  permission: Boolean!
+}
+
+type UploadsFields_updatedAt_Delete {
+  permission: Boolean!
+}
+
+type UploadsFields_createdAt {
+  create: UploadsFields_createdAt_Create
+  read: UploadsFields_createdAt_Read
+  update: UploadsFields_createdAt_Update
+  delete: UploadsFields_createdAt_Delete
+}
+
+type UploadsFields_createdAt_Create {
+  permission: Boolean!
+}
+
+type UploadsFields_createdAt_Read {
+  permission: Boolean!
+}
+
+type UploadsFields_createdAt_Update {
+  permission: Boolean!
+}
+
+type UploadsFields_createdAt_Delete {
+  permission: Boolean!
+}
+
+type UploadsFields_url {
+  create: UploadsFields_url_Create
+  read: UploadsFields_url_Read
+  update: UploadsFields_url_Update
+  delete: UploadsFields_url_Delete
+}
+
+type UploadsFields_url_Create {
+  permission: Boolean!
+}
+
+type UploadsFields_url_Read {
+  permission: Boolean!
+}
+
+type UploadsFields_url_Update {
+  permission: Boolean!
+}
+
+type UploadsFields_url_Delete {
+  permission: Boolean!
+}
+
+type UploadsFields_filename {
+  create: UploadsFields_filename_Create
+  read: UploadsFields_filename_Read
+  update: UploadsFields_filename_Update
+  delete: UploadsFields_filename_Delete
+}
+
+type UploadsFields_filename_Create {
+  permission: Boolean!
+}
+
+type UploadsFields_filename_Read {
+  permission: Boolean!
+}
+
+type UploadsFields_filename_Update {
+  permission: Boolean!
+}
+
+type UploadsFields_filename_Delete {
+  permission: Boolean!
+}
+
+type UploadsFields_mimeType {
+  create: UploadsFields_mimeType_Create
+  read: UploadsFields_mimeType_Read
+  update: UploadsFields_mimeType_Update
+  delete: UploadsFields_mimeType_Delete
+}
+
+type UploadsFields_mimeType_Create {
+  permission: Boolean!
+}
+
+type UploadsFields_mimeType_Read {
+  permission: Boolean!
+}
+
+type UploadsFields_mimeType_Update {
+  permission: Boolean!
+}
+
+type UploadsFields_mimeType_Delete {
+  permission: Boolean!
+}
+
+type UploadsFields_filesize {
+  create: UploadsFields_filesize_Create
+  read: UploadsFields_filesize_Read
+  update: UploadsFields_filesize_Update
+  delete: UploadsFields_filesize_Delete
+}
+
+type UploadsFields_filesize_Create {
+  permission: Boolean!
+}
+
+type UploadsFields_filesize_Read {
+  permission: Boolean!
+}
+
+type UploadsFields_filesize_Update {
+  permission: Boolean!
+}
+
+type UploadsFields_filesize_Delete {
+  permission: Boolean!
+}
+
+type UploadsFields_width {
+  create: UploadsFields_width_Create
+  read: UploadsFields_width_Read
+  update: UploadsFields_width_Update
+  delete: UploadsFields_width_Delete
+}
+
+type UploadsFields_width_Create {
+  permission: Boolean!
+}
+
+type UploadsFields_width_Read {
+  permission: Boolean!
+}
+
+type UploadsFields_width_Update {
+  permission: Boolean!
+}
+
+type UploadsFields_width_Delete {
+  permission: Boolean!
+}
+
+type UploadsFields_height {
+  create: UploadsFields_height_Create
+  read: UploadsFields_height_Read
+  update: UploadsFields_height_Update
+  delete: UploadsFields_height_Delete
+}
+
+type UploadsFields_height_Create {
+  permission: Boolean!
+}
+
+type UploadsFields_height_Read {
+  permission: Boolean!
+}
+
+type UploadsFields_height_Update {
+  permission: Boolean!
+}
+
+type UploadsFields_height_Delete {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes {
+  create: UploadsFields_sizes_Create
+  read: UploadsFields_sizes_Read
+  update: UploadsFields_sizes_Update
+  delete: UploadsFields_sizes_Delete
+  fields: UploadsFields_sizes_Fields
+}
+
+type UploadsFields_sizes_Create {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_Read {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_Update {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_Delete {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_Fields {
+  card: UploadsFields_sizes_card
+  desktop: UploadsFields_sizes_desktop
+  desktopHalf: UploadsFields_sizes_desktopHalf
+  tablet: UploadsFields_sizes_tablet
+  tabletHalf: UploadsFields_sizes_tabletHalf
+  mobile: UploadsFields_sizes_mobile
+}
+
+type UploadsFields_sizes_card {
+  create: UploadsFields_sizes_card_Create
+  read: UploadsFields_sizes_card_Read
+  update: UploadsFields_sizes_card_Update
+  delete: UploadsFields_sizes_card_Delete
+  fields: UploadsFields_sizes_card_Fields
+}
+
+type UploadsFields_sizes_card_Create {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_card_Read {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_card_Update {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_card_Delete {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_card_Fields {
+  url: UploadsFields_sizes_card_url
+  width: UploadsFields_sizes_card_width
+  height: UploadsFields_sizes_card_height
+  mimeType: UploadsFields_sizes_card_mimeType
+  filesize: UploadsFields_sizes_card_filesize
+  filename: UploadsFields_sizes_card_filename
+}
+
+type UploadsFields_sizes_card_url {
+  create: UploadsFields_sizes_card_url_Create
+  read: UploadsFields_sizes_card_url_Read
+  update: UploadsFields_sizes_card_url_Update
+  delete: UploadsFields_sizes_card_url_Delete
+}
+
+type UploadsFields_sizes_card_url_Create {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_card_url_Read {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_card_url_Update {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_card_url_Delete {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_card_width {
+  create: UploadsFields_sizes_card_width_Create
+  read: UploadsFields_sizes_card_width_Read
+  update: UploadsFields_sizes_card_width_Update
+  delete: UploadsFields_sizes_card_width_Delete
+}
+
+type UploadsFields_sizes_card_width_Create {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_card_width_Read {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_card_width_Update {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_card_width_Delete {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_card_height {
+  create: UploadsFields_sizes_card_height_Create
+  read: UploadsFields_sizes_card_height_Read
+  update: UploadsFields_sizes_card_height_Update
+  delete: UploadsFields_sizes_card_height_Delete
+}
+
+type UploadsFields_sizes_card_height_Create {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_card_height_Read {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_card_height_Update {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_card_height_Delete {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_card_mimeType {
+  create: UploadsFields_sizes_card_mimeType_Create
+  read: UploadsFields_sizes_card_mimeType_Read
+  update: UploadsFields_sizes_card_mimeType_Update
+  delete: UploadsFields_sizes_card_mimeType_Delete
+}
+
+type UploadsFields_sizes_card_mimeType_Create {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_card_mimeType_Read {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_card_mimeType_Update {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_card_mimeType_Delete {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_card_filesize {
+  create: UploadsFields_sizes_card_filesize_Create
+  read: UploadsFields_sizes_card_filesize_Read
+  update: UploadsFields_sizes_card_filesize_Update
+  delete: UploadsFields_sizes_card_filesize_Delete
+}
+
+type UploadsFields_sizes_card_filesize_Create {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_card_filesize_Read {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_card_filesize_Update {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_card_filesize_Delete {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_card_filename {
+  create: UploadsFields_sizes_card_filename_Create
+  read: UploadsFields_sizes_card_filename_Read
+  update: UploadsFields_sizes_card_filename_Update
+  delete: UploadsFields_sizes_card_filename_Delete
+}
+
+type UploadsFields_sizes_card_filename_Create {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_card_filename_Read {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_card_filename_Update {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_card_filename_Delete {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_desktop {
+  create: UploadsFields_sizes_desktop_Create
+  read: UploadsFields_sizes_desktop_Read
+  update: UploadsFields_sizes_desktop_Update
+  delete: UploadsFields_sizes_desktop_Delete
+  fields: UploadsFields_sizes_desktop_Fields
+}
+
+type UploadsFields_sizes_desktop_Create {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_desktop_Read {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_desktop_Update {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_desktop_Delete {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_desktop_Fields {
+  url: UploadsFields_sizes_desktop_url
+  width: UploadsFields_sizes_desktop_width
+  height: UploadsFields_sizes_desktop_height
+  mimeType: UploadsFields_sizes_desktop_mimeType
+  filesize: UploadsFields_sizes_desktop_filesize
+  filename: UploadsFields_sizes_desktop_filename
+}
+
+type UploadsFields_sizes_desktop_url {
+  create: UploadsFields_sizes_desktop_url_Create
+  read: UploadsFields_sizes_desktop_url_Read
+  update: UploadsFields_sizes_desktop_url_Update
+  delete: UploadsFields_sizes_desktop_url_Delete
+}
+
+type UploadsFields_sizes_desktop_url_Create {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_desktop_url_Read {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_desktop_url_Update {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_desktop_url_Delete {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_desktop_width {
+  create: UploadsFields_sizes_desktop_width_Create
+  read: UploadsFields_sizes_desktop_width_Read
+  update: UploadsFields_sizes_desktop_width_Update
+  delete: UploadsFields_sizes_desktop_width_Delete
+}
+
+type UploadsFields_sizes_desktop_width_Create {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_desktop_width_Read {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_desktop_width_Update {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_desktop_width_Delete {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_desktop_height {
+  create: UploadsFields_sizes_desktop_height_Create
+  read: UploadsFields_sizes_desktop_height_Read
+  update: UploadsFields_sizes_desktop_height_Update
+  delete: UploadsFields_sizes_desktop_height_Delete
+}
+
+type UploadsFields_sizes_desktop_height_Create {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_desktop_height_Read {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_desktop_height_Update {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_desktop_height_Delete {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_desktop_mimeType {
+  create: UploadsFields_sizes_desktop_mimeType_Create
+  read: UploadsFields_sizes_desktop_mimeType_Read
+  update: UploadsFields_sizes_desktop_mimeType_Update
+  delete: UploadsFields_sizes_desktop_mimeType_Delete
+}
+
+type UploadsFields_sizes_desktop_mimeType_Create {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_desktop_mimeType_Read {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_desktop_mimeType_Update {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_desktop_mimeType_Delete {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_desktop_filesize {
+  create: UploadsFields_sizes_desktop_filesize_Create
+  read: UploadsFields_sizes_desktop_filesize_Read
+  update: UploadsFields_sizes_desktop_filesize_Update
+  delete: UploadsFields_sizes_desktop_filesize_Delete
+}
+
+type UploadsFields_sizes_desktop_filesize_Create {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_desktop_filesize_Read {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_desktop_filesize_Update {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_desktop_filesize_Delete {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_desktop_filename {
+  create: UploadsFields_sizes_desktop_filename_Create
+  read: UploadsFields_sizes_desktop_filename_Read
+  update: UploadsFields_sizes_desktop_filename_Update
+  delete: UploadsFields_sizes_desktop_filename_Delete
+}
+
+type UploadsFields_sizes_desktop_filename_Create {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_desktop_filename_Read {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_desktop_filename_Update {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_desktop_filename_Delete {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_desktopHalf {
+  create: UploadsFields_sizes_desktopHalf_Create
+  read: UploadsFields_sizes_desktopHalf_Read
+  update: UploadsFields_sizes_desktopHalf_Update
+  delete: UploadsFields_sizes_desktopHalf_Delete
+  fields: UploadsFields_sizes_desktopHalf_Fields
+}
+
+type UploadsFields_sizes_desktopHalf_Create {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_desktopHalf_Read {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_desktopHalf_Update {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_desktopHalf_Delete {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_desktopHalf_Fields {
+  url: UploadsFields_sizes_desktopHalf_url
+  width: UploadsFields_sizes_desktopHalf_width
+  height: UploadsFields_sizes_desktopHalf_height
+  mimeType: UploadsFields_sizes_desktopHalf_mimeType
+  filesize: UploadsFields_sizes_desktopHalf_filesize
+  filename: UploadsFields_sizes_desktopHalf_filename
+}
+
+type UploadsFields_sizes_desktopHalf_url {
+  create: UploadsFields_sizes_desktopHalf_url_Create
+  read: UploadsFields_sizes_desktopHalf_url_Read
+  update: UploadsFields_sizes_desktopHalf_url_Update
+  delete: UploadsFields_sizes_desktopHalf_url_Delete
+}
+
+type UploadsFields_sizes_desktopHalf_url_Create {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_desktopHalf_url_Read {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_desktopHalf_url_Update {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_desktopHalf_url_Delete {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_desktopHalf_width {
+  create: UploadsFields_sizes_desktopHalf_width_Create
+  read: UploadsFields_sizes_desktopHalf_width_Read
+  update: UploadsFields_sizes_desktopHalf_width_Update
+  delete: UploadsFields_sizes_desktopHalf_width_Delete
+}
+
+type UploadsFields_sizes_desktopHalf_width_Create {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_desktopHalf_width_Read {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_desktopHalf_width_Update {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_desktopHalf_width_Delete {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_desktopHalf_height {
+  create: UploadsFields_sizes_desktopHalf_height_Create
+  read: UploadsFields_sizes_desktopHalf_height_Read
+  update: UploadsFields_sizes_desktopHalf_height_Update
+  delete: UploadsFields_sizes_desktopHalf_height_Delete
+}
+
+type UploadsFields_sizes_desktopHalf_height_Create {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_desktopHalf_height_Read {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_desktopHalf_height_Update {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_desktopHalf_height_Delete {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_desktopHalf_mimeType {
+  create: UploadsFields_sizes_desktopHalf_mimeType_Create
+  read: UploadsFields_sizes_desktopHalf_mimeType_Read
+  update: UploadsFields_sizes_desktopHalf_mimeType_Update
+  delete: UploadsFields_sizes_desktopHalf_mimeType_Delete
+}
+
+type UploadsFields_sizes_desktopHalf_mimeType_Create {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_desktopHalf_mimeType_Read {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_desktopHalf_mimeType_Update {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_desktopHalf_mimeType_Delete {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_desktopHalf_filesize {
+  create: UploadsFields_sizes_desktopHalf_filesize_Create
+  read: UploadsFields_sizes_desktopHalf_filesize_Read
+  update: UploadsFields_sizes_desktopHalf_filesize_Update
+  delete: UploadsFields_sizes_desktopHalf_filesize_Delete
+}
+
+type UploadsFields_sizes_desktopHalf_filesize_Create {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_desktopHalf_filesize_Read {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_desktopHalf_filesize_Update {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_desktopHalf_filesize_Delete {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_desktopHalf_filename {
+  create: UploadsFields_sizes_desktopHalf_filename_Create
+  read: UploadsFields_sizes_desktopHalf_filename_Read
+  update: UploadsFields_sizes_desktopHalf_filename_Update
+  delete: UploadsFields_sizes_desktopHalf_filename_Delete
+}
+
+type UploadsFields_sizes_desktopHalf_filename_Create {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_desktopHalf_filename_Read {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_desktopHalf_filename_Update {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_desktopHalf_filename_Delete {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_tablet {
+  create: UploadsFields_sizes_tablet_Create
+  read: UploadsFields_sizes_tablet_Read
+  update: UploadsFields_sizes_tablet_Update
+  delete: UploadsFields_sizes_tablet_Delete
+  fields: UploadsFields_sizes_tablet_Fields
+}
+
+type UploadsFields_sizes_tablet_Create {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_tablet_Read {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_tablet_Update {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_tablet_Delete {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_tablet_Fields {
+  url: UploadsFields_sizes_tablet_url
+  width: UploadsFields_sizes_tablet_width
+  height: UploadsFields_sizes_tablet_height
+  mimeType: UploadsFields_sizes_tablet_mimeType
+  filesize: UploadsFields_sizes_tablet_filesize
+  filename: UploadsFields_sizes_tablet_filename
+}
+
+type UploadsFields_sizes_tablet_url {
+  create: UploadsFields_sizes_tablet_url_Create
+  read: UploadsFields_sizes_tablet_url_Read
+  update: UploadsFields_sizes_tablet_url_Update
+  delete: UploadsFields_sizes_tablet_url_Delete
+}
+
+type UploadsFields_sizes_tablet_url_Create {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_tablet_url_Read {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_tablet_url_Update {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_tablet_url_Delete {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_tablet_width {
+  create: UploadsFields_sizes_tablet_width_Create
+  read: UploadsFields_sizes_tablet_width_Read
+  update: UploadsFields_sizes_tablet_width_Update
+  delete: UploadsFields_sizes_tablet_width_Delete
+}
+
+type UploadsFields_sizes_tablet_width_Create {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_tablet_width_Read {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_tablet_width_Update {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_tablet_width_Delete {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_tablet_height {
+  create: UploadsFields_sizes_tablet_height_Create
+  read: UploadsFields_sizes_tablet_height_Read
+  update: UploadsFields_sizes_tablet_height_Update
+  delete: UploadsFields_sizes_tablet_height_Delete
+}
+
+type UploadsFields_sizes_tablet_height_Create {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_tablet_height_Read {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_tablet_height_Update {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_tablet_height_Delete {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_tablet_mimeType {
+  create: UploadsFields_sizes_tablet_mimeType_Create
+  read: UploadsFields_sizes_tablet_mimeType_Read
+  update: UploadsFields_sizes_tablet_mimeType_Update
+  delete: UploadsFields_sizes_tablet_mimeType_Delete
+}
+
+type UploadsFields_sizes_tablet_mimeType_Create {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_tablet_mimeType_Read {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_tablet_mimeType_Update {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_tablet_mimeType_Delete {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_tablet_filesize {
+  create: UploadsFields_sizes_tablet_filesize_Create
+  read: UploadsFields_sizes_tablet_filesize_Read
+  update: UploadsFields_sizes_tablet_filesize_Update
+  delete: UploadsFields_sizes_tablet_filesize_Delete
+}
+
+type UploadsFields_sizes_tablet_filesize_Create {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_tablet_filesize_Read {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_tablet_filesize_Update {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_tablet_filesize_Delete {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_tablet_filename {
+  create: UploadsFields_sizes_tablet_filename_Create
+  read: UploadsFields_sizes_tablet_filename_Read
+  update: UploadsFields_sizes_tablet_filename_Update
+  delete: UploadsFields_sizes_tablet_filename_Delete
+}
+
+type UploadsFields_sizes_tablet_filename_Create {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_tablet_filename_Read {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_tablet_filename_Update {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_tablet_filename_Delete {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_tabletHalf {
+  create: UploadsFields_sizes_tabletHalf_Create
+  read: UploadsFields_sizes_tabletHalf_Read
+  update: UploadsFields_sizes_tabletHalf_Update
+  delete: UploadsFields_sizes_tabletHalf_Delete
+  fields: UploadsFields_sizes_tabletHalf_Fields
+}
+
+type UploadsFields_sizes_tabletHalf_Create {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_tabletHalf_Read {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_tabletHalf_Update {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_tabletHalf_Delete {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_tabletHalf_Fields {
+  url: UploadsFields_sizes_tabletHalf_url
+  width: UploadsFields_sizes_tabletHalf_width
+  height: UploadsFields_sizes_tabletHalf_height
+  mimeType: UploadsFields_sizes_tabletHalf_mimeType
+  filesize: UploadsFields_sizes_tabletHalf_filesize
+  filename: UploadsFields_sizes_tabletHalf_filename
+}
+
+type UploadsFields_sizes_tabletHalf_url {
+  create: UploadsFields_sizes_tabletHalf_url_Create
+  read: UploadsFields_sizes_tabletHalf_url_Read
+  update: UploadsFields_sizes_tabletHalf_url_Update
+  delete: UploadsFields_sizes_tabletHalf_url_Delete
+}
+
+type UploadsFields_sizes_tabletHalf_url_Create {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_tabletHalf_url_Read {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_tabletHalf_url_Update {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_tabletHalf_url_Delete {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_tabletHalf_width {
+  create: UploadsFields_sizes_tabletHalf_width_Create
+  read: UploadsFields_sizes_tabletHalf_width_Read
+  update: UploadsFields_sizes_tabletHalf_width_Update
+  delete: UploadsFields_sizes_tabletHalf_width_Delete
+}
+
+type UploadsFields_sizes_tabletHalf_width_Create {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_tabletHalf_width_Read {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_tabletHalf_width_Update {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_tabletHalf_width_Delete {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_tabletHalf_height {
+  create: UploadsFields_sizes_tabletHalf_height_Create
+  read: UploadsFields_sizes_tabletHalf_height_Read
+  update: UploadsFields_sizes_tabletHalf_height_Update
+  delete: UploadsFields_sizes_tabletHalf_height_Delete
+}
+
+type UploadsFields_sizes_tabletHalf_height_Create {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_tabletHalf_height_Read {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_tabletHalf_height_Update {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_tabletHalf_height_Delete {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_tabletHalf_mimeType {
+  create: UploadsFields_sizes_tabletHalf_mimeType_Create
+  read: UploadsFields_sizes_tabletHalf_mimeType_Read
+  update: UploadsFields_sizes_tabletHalf_mimeType_Update
+  delete: UploadsFields_sizes_tabletHalf_mimeType_Delete
+}
+
+type UploadsFields_sizes_tabletHalf_mimeType_Create {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_tabletHalf_mimeType_Read {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_tabletHalf_mimeType_Update {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_tabletHalf_mimeType_Delete {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_tabletHalf_filesize {
+  create: UploadsFields_sizes_tabletHalf_filesize_Create
+  read: UploadsFields_sizes_tabletHalf_filesize_Read
+  update: UploadsFields_sizes_tabletHalf_filesize_Update
+  delete: UploadsFields_sizes_tabletHalf_filesize_Delete
+}
+
+type UploadsFields_sizes_tabletHalf_filesize_Create {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_tabletHalf_filesize_Read {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_tabletHalf_filesize_Update {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_tabletHalf_filesize_Delete {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_tabletHalf_filename {
+  create: UploadsFields_sizes_tabletHalf_filename_Create
+  read: UploadsFields_sizes_tabletHalf_filename_Read
+  update: UploadsFields_sizes_tabletHalf_filename_Update
+  delete: UploadsFields_sizes_tabletHalf_filename_Delete
+}
+
+type UploadsFields_sizes_tabletHalf_filename_Create {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_tabletHalf_filename_Read {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_tabletHalf_filename_Update {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_tabletHalf_filename_Delete {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_mobile {
+  create: UploadsFields_sizes_mobile_Create
+  read: UploadsFields_sizes_mobile_Read
+  update: UploadsFields_sizes_mobile_Update
+  delete: UploadsFields_sizes_mobile_Delete
+  fields: UploadsFields_sizes_mobile_Fields
+}
+
+type UploadsFields_sizes_mobile_Create {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_mobile_Read {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_mobile_Update {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_mobile_Delete {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_mobile_Fields {
+  url: UploadsFields_sizes_mobile_url
+  width: UploadsFields_sizes_mobile_width
+  height: UploadsFields_sizes_mobile_height
+  mimeType: UploadsFields_sizes_mobile_mimeType
+  filesize: UploadsFields_sizes_mobile_filesize
+  filename: UploadsFields_sizes_mobile_filename
+}
+
+type UploadsFields_sizes_mobile_url {
+  create: UploadsFields_sizes_mobile_url_Create
+  read: UploadsFields_sizes_mobile_url_Read
+  update: UploadsFields_sizes_mobile_url_Update
+  delete: UploadsFields_sizes_mobile_url_Delete
+}
+
+type UploadsFields_sizes_mobile_url_Create {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_mobile_url_Read {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_mobile_url_Update {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_mobile_url_Delete {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_mobile_width {
+  create: UploadsFields_sizes_mobile_width_Create
+  read: UploadsFields_sizes_mobile_width_Read
+  update: UploadsFields_sizes_mobile_width_Update
+  delete: UploadsFields_sizes_mobile_width_Delete
+}
+
+type UploadsFields_sizes_mobile_width_Create {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_mobile_width_Read {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_mobile_width_Update {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_mobile_width_Delete {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_mobile_height {
+  create: UploadsFields_sizes_mobile_height_Create
+  read: UploadsFields_sizes_mobile_height_Read
+  update: UploadsFields_sizes_mobile_height_Update
+  delete: UploadsFields_sizes_mobile_height_Delete
+}
+
+type UploadsFields_sizes_mobile_height_Create {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_mobile_height_Read {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_mobile_height_Update {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_mobile_height_Delete {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_mobile_mimeType {
+  create: UploadsFields_sizes_mobile_mimeType_Create
+  read: UploadsFields_sizes_mobile_mimeType_Read
+  update: UploadsFields_sizes_mobile_mimeType_Update
+  delete: UploadsFields_sizes_mobile_mimeType_Delete
+}
+
+type UploadsFields_sizes_mobile_mimeType_Create {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_mobile_mimeType_Read {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_mobile_mimeType_Update {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_mobile_mimeType_Delete {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_mobile_filesize {
+  create: UploadsFields_sizes_mobile_filesize_Create
+  read: UploadsFields_sizes_mobile_filesize_Read
+  update: UploadsFields_sizes_mobile_filesize_Update
+  delete: UploadsFields_sizes_mobile_filesize_Delete
+}
+
+type UploadsFields_sizes_mobile_filesize_Create {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_mobile_filesize_Read {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_mobile_filesize_Update {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_mobile_filesize_Delete {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_mobile_filename {
+  create: UploadsFields_sizes_mobile_filename_Create
+  read: UploadsFields_sizes_mobile_filename_Read
+  update: UploadsFields_sizes_mobile_filename_Update
+  delete: UploadsFields_sizes_mobile_filename_Delete
+}
+
+type UploadsFields_sizes_mobile_filename_Create {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_mobile_filename_Read {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_mobile_filename_Update {
+  permission: Boolean!
+}
+
+type UploadsFields_sizes_mobile_filename_Delete {
+  permission: Boolean!
+}
+
+type UploadsCreateAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type UploadsReadAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type UploadsUpdateAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type UploadsDeleteAccess {
   permission: Boolean!
   where: JSONObject
 }
@@ -14931,6 +19625,9 @@ type Mutation {
   forgotPasswordUser(disableEmail: Boolean, email: String!, expiration: Int): Boolean!
   resetPasswordUser(password: String, token: String): usersResetPassword
   verifyEmailUser(token: String): Boolean
+  createUpload(data: mutationUploadInput!, draft: Boolean): Upload
+  updateUpload(id: Int!, autosave: Boolean, data: mutationUploadUpdateInput!, draft: Boolean): Upload
+  deleteUpload(id: Int!): Upload
   createRedirect(data: mutationRedirectInput!, draft: Boolean): Redirect
   updateRedirect(id: Int!, autosave: Boolean, data: mutationRedirectUpdateInput!, draft: Boolean): Redirect
   deleteRedirect(id: Int!): Redirect
@@ -14985,7 +19682,7 @@ enum Page_Layout_SideColumn_style_MutationInput {
 }
 
 input mutationPage_Layout_SideColumn_HeroInput {
-  media: String
+  media: Int
   description: JSON
   links: [mutationPage_Layout_SideColumn_Hero_LinksInput]
 }
@@ -15022,6 +19719,8 @@ enum Page_Layout_SideColumn_Hero_Links_Link_appearance_MutationInput {
 input mutationPage_Layout_SideColumn_ProjectHeroInput {
   year: Float
   client: Int
+  usePostDescription: Boolean
+  customDescription: JSON
   links: [mutationPage_Layout_SideColumn_ProjectHero_LinksInput]
 }
 
@@ -15056,17 +19755,13 @@ enum Page_Layout_SideColumn_ProjectHero_Links_Link_appearance_MutationInput {
 
 input mutationPage_Layout_MainColumnInput {
   style: Page_Layout_MainColumn_style_MutationInput!
-  row1column1: JSON
-  row1column2: JSON
-  row2column1: JSON
-  row2column2: JSON
+  column1: JSON
+  column2: JSON
 }
 
 enum Page_Layout_MainColumn_style_MutationInput {
   singleLayout
-  twoRows
   twoColumns
-  threeSectionGrid
 }
 
 input mutationPage_MetaInput {
@@ -15124,7 +19819,7 @@ enum PageUpdate_Layout_SideColumn_style_MutationInput {
 }
 
 input mutationPageUpdate_Layout_SideColumn_HeroInput {
-  media: String
+  media: Int
   description: JSON
   links: [mutationPageUpdate_Layout_SideColumn_Hero_LinksInput]
 }
@@ -15161,6 +19856,8 @@ enum PageUpdate_Layout_SideColumn_Hero_Links_Link_appearance_MutationInput {
 input mutationPageUpdate_Layout_SideColumn_ProjectHeroInput {
   year: Float
   client: Int
+  usePostDescription: Boolean
+  customDescription: JSON
   links: [mutationPageUpdate_Layout_SideColumn_ProjectHero_LinksInput]
 }
 
@@ -15195,17 +19892,13 @@ enum PageUpdate_Layout_SideColumn_ProjectHero_Links_Link_appearance_MutationInpu
 
 input mutationPageUpdate_Layout_MainColumnInput {
   style: PageUpdate_Layout_MainColumn_style_MutationInput!
-  row1column1: JSON
-  row1column2: JSON
-  row2column1: JSON
-  row2column2: JSON
+  column1: JSON
+  column2: JSON
 }
 
 enum PageUpdate_Layout_MainColumn_style_MutationInput {
   singleLayout
-  twoRows
   twoColumns
-  threeSectionGrid
 }
 
 input mutationPageUpdate_MetaInput {
@@ -15243,7 +19936,7 @@ input mutationPost_PopulatedAuthorsInput {
 }
 
 input mutationPost_CardInput {
-  media: String
+  media: Int
   backgroundColour: String
   overlayImage: Boolean
   showDate: Boolean
@@ -15282,7 +19975,7 @@ enum Post_Layout_SideColumn_style_MutationInput {
 }
 
 input mutationPost_Layout_SideColumn_HeroInput {
-  media: String
+  media: Int
   description: JSON
   links: [mutationPost_Layout_SideColumn_Hero_LinksInput]
 }
@@ -15319,6 +20012,8 @@ enum Post_Layout_SideColumn_Hero_Links_Link_appearance_MutationInput {
 input mutationPost_Layout_SideColumn_ProjectHeroInput {
   year: Float
   client: Int
+  usePostDescription: Boolean
+  customDescription: JSON
   links: [mutationPost_Layout_SideColumn_ProjectHero_LinksInput]
 }
 
@@ -15353,17 +20048,13 @@ enum Post_Layout_SideColumn_ProjectHero_Links_Link_appearance_MutationInput {
 
 input mutationPost_Layout_MainColumnInput {
   style: Post_Layout_MainColumn_style_MutationInput!
-  row1column1: JSON
-  row1column2: JSON
-  row2column1: JSON
-  row2column2: JSON
+  column1: JSON
+  column2: JSON
 }
 
 enum Post_Layout_MainColumn_style_MutationInput {
   singleLayout
-  twoRows
   twoColumns
-  threeSectionGrid
 }
 
 input mutationPost_MetaInput {
@@ -15401,7 +20092,7 @@ input mutationPostUpdate_PopulatedAuthorsInput {
 }
 
 input mutationPostUpdate_CardInput {
-  media: String
+  media: Int
   backgroundColour: String
   overlayImage: Boolean
   showDate: Boolean
@@ -15440,7 +20131,7 @@ enum PostUpdate_Layout_SideColumn_style_MutationInput {
 }
 
 input mutationPostUpdate_Layout_SideColumn_HeroInput {
-  media: String
+  media: Int
   description: JSON
   links: [mutationPostUpdate_Layout_SideColumn_Hero_LinksInput]
 }
@@ -15477,6 +20168,8 @@ enum PostUpdate_Layout_SideColumn_Hero_Links_Link_appearance_MutationInput {
 input mutationPostUpdate_Layout_SideColumn_ProjectHeroInput {
   year: Float
   client: Int
+  usePostDescription: Boolean
+  customDescription: JSON
   links: [mutationPostUpdate_Layout_SideColumn_ProjectHero_LinksInput]
 }
 
@@ -15511,17 +20204,13 @@ enum PostUpdate_Layout_SideColumn_ProjectHero_Links_Link_appearance_MutationInpu
 
 input mutationPostUpdate_Layout_MainColumnInput {
   style: PostUpdate_Layout_MainColumn_style_MutationInput!
-  row1column1: JSON
-  row1column2: JSON
-  row2column1: JSON
-  row2column2: JSON
+  column1: JSON
+  column2: JSON
 }
 
 enum PostUpdate_Layout_MainColumn_style_MutationInput {
   singleLayout
-  twoRows
   twoColumns
-  threeSectionGrid
 }
 
 input mutationPostUpdate_MetaInput {
@@ -15536,31 +20225,19 @@ enum PostUpdate__status_MutationInput {
 }
 
 input mutationMediaInput {
+  media: String!
   alt: String!
   caption: JSON
-  blurhash: String
   updatedAt: String
   createdAt: String
-  url: String
-  filename: String
-  mimeType: String
-  filesize: Float
-  width: Float
-  height: Float
 }
 
 input mutationMediaUpdateInput {
+  media: String
   alt: String
   caption: JSON
-  blurhash: String
   updatedAt: String
   createdAt: String
-  url: String
-  filename: String
-  mimeType: String
-  filesize: Float
-  width: Float
-  height: Float
 }
 
 input mutationCategoryInput {
@@ -15677,6 +20354,158 @@ type usersLoginResult {
 type usersResetPassword {
   token: String
   user: User
+}
+
+input mutationUploadInput {
+  blurhash: String
+  updatedAt: String
+  createdAt: String
+  url: String
+  filename: String
+  mimeType: String
+  filesize: Float
+  width: Float
+  height: Float
+  sizes: mutationUpload_SizesInput
+}
+
+input mutationUpload_SizesInput {
+  card: mutationUpload_Sizes_CardInput
+  desktop: mutationUpload_Sizes_DesktopInput
+  desktopHalf: mutationUpload_Sizes_DesktopHalfInput
+  tablet: mutationUpload_Sizes_TabletInput
+  tabletHalf: mutationUpload_Sizes_TabletHalfInput
+  mobile: mutationUpload_Sizes_MobileInput
+}
+
+input mutationUpload_Sizes_CardInput {
+  url: String
+  width: Float
+  height: Float
+  mimeType: String
+  filesize: Float
+  filename: String
+}
+
+input mutationUpload_Sizes_DesktopInput {
+  url: String
+  width: Float
+  height: Float
+  mimeType: String
+  filesize: Float
+  filename: String
+}
+
+input mutationUpload_Sizes_DesktopHalfInput {
+  url: String
+  width: Float
+  height: Float
+  mimeType: String
+  filesize: Float
+  filename: String
+}
+
+input mutationUpload_Sizes_TabletInput {
+  url: String
+  width: Float
+  height: Float
+  mimeType: String
+  filesize: Float
+  filename: String
+}
+
+input mutationUpload_Sizes_TabletHalfInput {
+  url: String
+  width: Float
+  height: Float
+  mimeType: String
+  filesize: Float
+  filename: String
+}
+
+input mutationUpload_Sizes_MobileInput {
+  url: String
+  width: Float
+  height: Float
+  mimeType: String
+  filesize: Float
+  filename: String
+}
+
+input mutationUploadUpdateInput {
+  blurhash: String
+  updatedAt: String
+  createdAt: String
+  url: String
+  filename: String
+  mimeType: String
+  filesize: Float
+  width: Float
+  height: Float
+  sizes: mutationUploadUpdate_SizesInput
+}
+
+input mutationUploadUpdate_SizesInput {
+  card: mutationUploadUpdate_Sizes_CardInput
+  desktop: mutationUploadUpdate_Sizes_DesktopInput
+  desktopHalf: mutationUploadUpdate_Sizes_DesktopHalfInput
+  tablet: mutationUploadUpdate_Sizes_TabletInput
+  tabletHalf: mutationUploadUpdate_Sizes_TabletHalfInput
+  mobile: mutationUploadUpdate_Sizes_MobileInput
+}
+
+input mutationUploadUpdate_Sizes_CardInput {
+  url: String
+  width: Float
+  height: Float
+  mimeType: String
+  filesize: Float
+  filename: String
+}
+
+input mutationUploadUpdate_Sizes_DesktopInput {
+  url: String
+  width: Float
+  height: Float
+  mimeType: String
+  filesize: Float
+  filename: String
+}
+
+input mutationUploadUpdate_Sizes_DesktopHalfInput {
+  url: String
+  width: Float
+  height: Float
+  mimeType: String
+  filesize: Float
+  filename: String
+}
+
+input mutationUploadUpdate_Sizes_TabletInput {
+  url: String
+  width: Float
+  height: Float
+  mimeType: String
+  filesize: Float
+  filename: String
+}
+
+input mutationUploadUpdate_Sizes_TabletHalfInput {
+  url: String
+  width: Float
+  height: Float
+  mimeType: String
+  filesize: Float
+  filename: String
+}
+
+input mutationUploadUpdate_Sizes_MobileInput {
+  url: String
+  width: Float
+  height: Float
+  mimeType: String
+  filesize: Float
+  filename: String
 }
 
 input mutationRedirectInput {

--- a/src/payload/payload-types.ts
+++ b/src/payload/payload-types.ts
@@ -40,6 +40,7 @@ export interface Config {
     keywords: Keyword;
     clients: Client;
     users: User;
+    uploads: Upload;
     redirects: Redirect;
     'payload-preferences': PayloadPreference;
     'payload-migrations': PayloadMigration;
@@ -62,7 +63,7 @@ export interface Page {
   meta?: {
     title?: string | null;
     description?: string | null;
-    image?: number | Media | null;
+    image?: number | Upload | null;
   };
   updatedAt: string;
   createdAt: string;
@@ -112,7 +113,7 @@ export interface SideColumn {
  * via the `definition` "Hero".
  */
 export interface Hero {
-  media?: number | Media | null;
+  media?: (number | null) | Media;
   description?: {
     root: {
       children: {
@@ -152,6 +153,19 @@ export interface Media {
     };
     [k: string]: unknown;
   } | null;
+  media: number | Upload;
+  mediaDark?: number | Upload | null;
+  mediaMobile?: number | Upload | null;
+  mediaMobileDark?: number | Upload | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "uploads".
+ */
+export interface Upload {
+  id: number;
   blurhash?: string | null;
   updatedAt: string;
   createdAt: string;
@@ -319,7 +333,7 @@ export interface Post {
       }[]
     | null;
   card?: {
-    media?: number | Media | null;
+    media?: (number | null) | Media;
     backgroundColour?: string | null;
     overlayImage?: boolean | null;
     showDate?: boolean | null;
@@ -329,7 +343,7 @@ export interface Post {
   meta?: {
     title?: string | null;
     description?: string | null;
-    image?: number | Media | null;
+    image?: number | Upload | null;
   };
   updatedAt: string;
   createdAt: string;
@@ -505,8 +519,8 @@ export interface MediaBlock {
   sideCaption?: boolean | null;
   layout?: ('default' | 'twoColumn' | 'heroGrid') | null;
   media1: number | Media;
-  media2?: number | Media | null;
-  media3?: number | Media | null;
+  media2?: (number | null) | Media;
+  media3?: (number | null) | Media;
   id?: string | null;
   blockName?: string | null;
   blockType: 'mediaBlock';
@@ -588,6 +602,7 @@ export interface CodeBlock {
  */
 export interface VimeoBlock {
   videoId?: string | null;
+  previewImage?: number | Media | null;
   id?: string | null;
   blockName?: string | null;
   blockType: 'vimeoBlock';

--- a/src/payload/payload.config.ts
+++ b/src/payload/payload.config.ts
@@ -22,6 +22,7 @@ import Keywords from './collections/Keywords'
 import { Media } from './collections/Media'
 import { Pages } from './collections/Pages'
 import { Posts } from './collections/Posts'
+import { Uploads } from './collections/Uploads'
 import Users from './collections/Users'
 import { HiddenLayout } from './globals/Hidden'
 import { Site } from './globals/Site'
@@ -69,7 +70,7 @@ export default buildConfig({
     },
   }),
   serverURL: process.env.PAYLOAD_PUBLIC_SERVER_URL,
-  collections: [Pages, Posts, Media, Category, Keywords, Clients, Users],
+  collections: [Pages, Posts, Media, Category, Keywords, Clients, Users, Uploads],
   globals: [Site, HiddenLayout],
   typescript: {
     outputFile: path.resolve(__dirname, 'payload-types.ts'),
@@ -103,11 +104,11 @@ export default buildConfig({
     seo({
       collections: ['pages', 'posts'],
       generateTitle,
-      uploadsCollection: 'media',
+      uploadsCollection: 'uploads',
     }),
     cloudStorage({
       collections: {
-        media: {
+        uploads: {
           adapter: adapter,
         },
       },


### PR DESCRIPTION
This pull request improves the implementation of custom svg layouts as well as improving the way media is organized in Payload.

The major change is to create a new collection called Media. the old collection called Media that handled file uploads directly is now called Uploads. The purpose of this change was so that a Media collection could handle more than one image. eg the linked images within an SVG. it also allows for other functionality such as a seperate image for mobile and a dark mode image.

Other changes include refactoring the SVG image processing and adding support (currently unimplemented) for text resizing.

This has required a number of changes accross the next.js api and graphql queries as well as how that new data is handled in the Media component.