### PR TITLE
fix/related post styling in safari/webkit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,11 +8,12 @@ COPY package*.json ./
 
 RUN npm install -g pnpm
 
-# RUN apk add --no-cache make gcc g++ python3
+RUN apk add --no-cache make gcc g++ python3
 
 COPY . .
 COPY .env.prod ./.env
 RUN pnpm install
+RUN pnpm add @swc/core
 RUN pnpm build
 
 FROM base as runtime

--- a/src/app/(pages)/posts/[slug]/page.tsx
+++ b/src/app/(pages)/posts/[slug]/page.tsx
@@ -50,10 +50,7 @@ export default async function Post({ params: { slug } }) {
           keywords={filteredKeywords}
           publishedAt={publishedAt}
         />
-        <Layouts layouts={layout} />
-        {relatedPosts && relatedPosts.length > 0 && (
-          <RelatedPosts introContent="More" docs={relatedPosts} />
-        )}
+        <Layouts layouts={layout} relatedPosts={relatedPosts} />
       </main>
     </PageMargin>
   )

--- a/src/app/_components/Card/client/index.tsx
+++ b/src/app/_components/Card/client/index.tsx
@@ -44,7 +44,7 @@ export const CardClient: React.FC<{
   const [localMousePosition, setLocalMousePosition] = useState({ x: 50, y: 50 })
 
   useEffect(() => {
-    if (cardRef.current) {
+    if (cardRef.current && screen.size > screen.breakpoints.md) {
       const rect = cardRef.current.getBoundingClientRect()
       // Calculate mouse position relative to the card
       const x = ((mousePosition.x - rect.left) / rect.width) * 100
@@ -65,19 +65,21 @@ export const CardClient: React.FC<{
   }, [loadDelay])
 
   useEffect(() => {
-    let timeoutId
-
-    if (hover) {
-      timeoutId = setTimeout(() => {
-        setHoverDelayed(true)
-      }, 300)
-    } else {
-      setHoverDelayed(false)
-    }
-
-    return () => {
-      if (timeoutId) {
-        clearTimeout(timeoutId)
+    if (screen.size > screen.breakpoints.md) {
+      let timeoutId
+  
+      if (hover) {
+        timeoutId = setTimeout(() => {
+          setHoverDelayed(true)
+        }, 300)
+      } else {
+        setHoverDelayed(false)
+      }
+  
+      return () => {
+        if (timeoutId) {
+          clearTimeout(timeoutId)
+        }
       }
     }
   }, [hover])

--- a/src/app/_components/Card/client/index.tsx
+++ b/src/app/_components/Card/client/index.tsx
@@ -107,12 +107,17 @@ export const CardClient: React.FC<{
         ...fadeIn,
         ...backgroundStyle,
       }}
-      className={className}
+      className={[
+        `relative rounded-xl overflow-hidden drop-shadow-md h-full aspect-video md:aspect-square transition-transform safari-fix`,
+        className,
+      ]
+        .filter(Boolean)
+        .join(' ')}
     >
       {card.media && (
         <>
           <Media
-            imgClassName={`absolute inset-0 -z-10 object-cover transition-all duration-300 ${
+            imgClassName={`absolute inset-0 -z-20 object-cover transition-all duration-300 ${
               hover ? 'blur-sm scale-[1.15]' : 'scale-105'
             }`}
             resource={card.media}
@@ -124,7 +129,7 @@ export const CardClient: React.FC<{
               ...backgroundStyle,
               backgroundBlendMode: 'difference',
             }}
-            className={`absolute inset-0 z-[-1] transition-all duration-300 opacity-0
+            className={`absolute inset-0 -z-10 transition-all duration-300 opacity-0
             ${card.overlayImage && 'opacity-80'} ${hover && 'opacity-60'}`}
           />
         </>

--- a/src/app/_components/Card/static/index.tsx
+++ b/src/app/_components/Card/static/index.tsx
@@ -35,12 +35,6 @@ export const CardStatic: React.FC<{
   } = doc || {}
 
   const publishedDate = cardProps.showDate && formatDateTime(publishedAt)
-  const clientClassName = [
-    `relative rounded-xl overflow-hidden drop-shadow-md h-full aspect-video md:aspect-square transition-transform`,
-    className,
-  ]
-    .filter(Boolean)
-    .join(' ')
   const titleToUse = titleFromProps || title
   const keywords =
     keywordsProps &&
@@ -68,7 +62,7 @@ export const CardStatic: React.FC<{
 
   return (
     <CardClient
-      className={clientClassName}
+      className={className}
       title={titleToUse}
       description={description}
       publishedDate={publishedDate}

--- a/src/app/_components/CollectionArchive/index.tsx
+++ b/src/app/_components/CollectionArchive/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { Post, PostArchive } from '../../../payload/payload-types'
+import { Post } from '../../../payload/payload-types'
 import { CardStatic } from '../Card/static'
 import { PageRange } from '../PageRange'
 import { Pagination } from '../Pagination'
@@ -24,29 +24,23 @@ export type Props = {
   onResultChange?: (result: Result) => void // eslint-disable-line no-unused-vars
   sort?: string
   limit?: number
-  populatedDocs?: PostArchive['populatedDocs']
-  populatedDocsTotal?: PostArchive['populatedDocsTotal']
-  category?: PostArchive['category']
+  docs?: Post[]
+  docsTotal?: number
 }
 
 export const CollectionArchive: React.FC<Props> = props => {
   const {
     className,
-    relationTo,
     showPageRange,
     onResultChange,
     sort = '-createdAt',
     limit = 12,
-    populatedDocs,
-    populatedDocsTotal,
-    category: catFromProps,
-    populateBy,
+    docs,
+    docsTotal,
   } = props
 
-  const docs = (populatedDocs?.map(doc => doc.value) as Post[]) || []
-
   return (
-    <div className={[className].filter(Boolean).join(' ')}>
+    <div className={className}>
       <div className="absolute left-0 top-[-24]" />
       <div className="grid sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3 w-full gap-3">
         {docs &&

--- a/src/app/_components/CollectionArchive/index.tsx
+++ b/src/app/_components/CollectionArchive/index.tsx
@@ -41,7 +41,6 @@ export const CollectionArchive: React.FC<Props> = props => {
 
   return (
     <div className={className}>
-      <div className="absolute left-0 top-[-24]" />
       <div className="grid sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3 w-full gap-3">
         {docs &&
           docs?.map((doc, index) => {

--- a/src/app/_components/Layouts/MainColumn/index.tsx
+++ b/src/app/_components/Layouts/MainColumn/index.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
 
 import { MainColumn as MainColumnType } from '../../../../payload/payload-types'
-import { CollectionArchive } from '../../CollectionArchive'
 import RichText from '../../RichText/static'
+import { PostArchive } from '../../PostArchive'
 
 export type MainColumnProps = MainColumnType & {
   hasTOC?: boolean
@@ -13,7 +13,7 @@ export const MainColumn: React.FC<MainColumnProps> = props => {
 
   switch (style) {
     case 'postArchive':
-      return <CollectionArchive className="w-full" {...postArchive} />
+      return <PostArchive className="w-full" {...postArchive} />
     case 'singleLayout':
       return <RichText className="w-full" content={column1} hasTOC />
     case 'twoColumns':

--- a/src/app/_components/Layouts/index.tsx
+++ b/src/app/_components/Layouts/index.tsx
@@ -1,16 +1,19 @@
 import React from 'react'
 
-import { Layout as LayoutType } from '../../../payload/payload-types'
+import { Layout as LayoutType, Post } from '../../../payload/payload-types'
 import { Column, Layout } from '../Layout'
 import { MainColumn } from './MainColumn'
 import { SideColumn } from './SideColumn'
+import { RelatedPosts } from '../RelatedPosts'
+import { CollectionArchive } from '../CollectionArchive'
 
 export type LayoutsProps = {
   layouts: LayoutType
+  relatedPosts?: Post[]
 }
 
 export const Layouts: React.FC<LayoutsProps> = props => {
-  const { layouts } = props
+  const { layouts, relatedPosts } = props
 
   const hasLayouts = layouts && Array.isArray(layouts) && layouts.length > 0
 
@@ -40,6 +43,9 @@ export const Layouts: React.FC<LayoutsProps> = props => {
             </div>
           )
         })}
+        {
+          RelatedPosts && <RelatedPosts index={layouts.length + 1} docs={relatedPosts} />
+        }
       </div>
     )
   }

--- a/src/app/_components/PostArchive/index.tsx
+++ b/src/app/_components/PostArchive/index.tsx
@@ -1,0 +1,47 @@
+import { Post, PostArchive as PostArchiveType } from "../../../payload/payload-types"
+import { CollectionArchive } from "../CollectionArchive"
+
+import React from 'react'
+
+type Result = {
+  totalDocs: number
+  docs: Post[]
+  page: number
+  totalPages: number
+  hasPrevPage: boolean
+  hasNextPage: boolean
+  nextPage: number
+  prevPage: number
+}
+
+export type Props = {
+    className?: string
+    relationTo?: 'posts'
+    populateBy?: 'collection' | 'selection'
+    showPageRange?: boolean
+    onResultChange?: (result: Result) => void // eslint-disable-line no-unused-vars
+    sort?: string
+    limit?: number
+    populatedDocs?: PostArchiveType['populatedDocs']
+    populatedDocsTotal?: PostArchiveType['populatedDocsTotal']
+    category?: PostArchiveType['category']
+  }
+
+export const PostArchive: React.FC<Props> = props => {
+    const {
+      className,
+      relationTo,
+      showPageRange,
+      onResultChange,
+      sort = '-createdAt',
+      limit = 12,
+      populatedDocs,
+      populatedDocsTotal,
+      category: catFromProps,
+      populateBy,
+    } = props
+  
+    const docs = (populatedDocs?.map(doc => doc.value) as Post[]) || []
+
+    return <CollectionArchive className={className} showPageRange={showPageRange} onResultChange={onResultChange} sort={sort} limit={limit} docs={docs} docsTotal={populatedDocsTotal} />
+  }

--- a/src/app/_components/RelatedPosts/index.tsx
+++ b/src/app/_components/RelatedPosts/index.tsx
@@ -1,33 +1,34 @@
 import React from 'react'
 
 import { Post } from '../../../payload/payload-types'
-import { CardStatic } from '../../_components/Card/static'
-import { Padding } from '../../_components/Padding'
+import { CollectionArchive } from '../CollectionArchive'
+import { Column, Layout } from '../Layout'
 
 export type RelatedPostsProps = {
-  introContent?: string
+  index: number
   docs?: Post[]
 }
 
 export const RelatedPosts: React.FC<RelatedPostsProps> = props => {
-  const { introContent, docs } = props
+  const { index, docs } = props
 
   return (
-    <Padding className="w-full snap-start flex flex-col lg:flex-row grow">
-      {introContent && (
-        <h3
-          className={`text-2xl flex-none w-full text-center item lg:text-left lg:w-80 overflow-hidden`}
+    <div key={index}>
+        <Layout
+          sideColumn={true}
+          bottom={true}
         >
-          {introContent}
-        </h3>
-      )}
-      <div className="grid sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3 w-full gap-3">
-        {docs && docs?.map((doc, index) => {
-          if (typeof doc === 'string') return null
-
-          return <CardStatic key={index} doc={doc} relationTo="posts" showCategory />
-        })}
-      </div>
-    </Padding>
+          <Column position="side">
+            <h3
+              className={`text-2xl flex-none w-full text-center item lg:text-left lg:w-80 overflow-hidden`}
+            >
+              More
+            </h3>
+          </Column>
+          <Column position="main">
+            <CollectionArchive className='w-full' docs={docs} />
+          </Column>
+        </Layout>
+    </div> 
   )
 }

--- a/src/app/_components/RelatedPosts/index.tsx
+++ b/src/app/_components/RelatedPosts/index.tsx
@@ -12,23 +12,27 @@ export type RelatedPostsProps = {
 export const RelatedPosts: React.FC<RelatedPostsProps> = props => {
   const { index, docs } = props
 
-  return (
-    <div key={index}>
-        <Layout
-          sideColumn={true}
-          bottom={true}
-        >
-          <Column position="side">
-            <h3
-              className={`text-2xl flex-none w-full text-center item lg:text-left lg:w-80 overflow-hidden`}
-            >
-              More
-            </h3>
-          </Column>
-          <Column position="main">
-            <CollectionArchive className='w-full' docs={docs} />
-          </Column>
-        </Layout>
-    </div> 
-  )
+  if (docs && docs.length > 0) {
+    return (
+      <div key={index}>
+          <Layout
+            sideColumn={true}
+            bottom={true}
+          >
+            <Column position="side">
+              <h3
+                className={`text-2xl flex-none w-full text-center item lg:text-left lg:w-80 overflow-hidden`}
+              >
+                More
+              </h3>
+            </Column>
+            <Column position="main">
+              <CollectionArchive className='w-full' docs={docs} />
+            </Column>
+          </Layout>
+      </div> 
+    )
+  } else {
+    return null
+  }
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -25,3 +25,13 @@ body {
     )
     rgb(var(--background-start-rgb));
 }
+
+/*  fixes for safari/webkit bugs (the new internet explorer?)
+    bug 1: where elements are not rendered correctly off screen
+           this forces the element to use hw acceleration
+    bug 2: where rounded corners don't work on background images 
+*/
+.safari-fix {
+  -webkit-transform: translate3d(0, 0, 0);
+  -webkit-backface-visibility: hidden;
+} 


### PR DESCRIPTION
A few layout bugs were found when running the website in safari or other webkit brwoser.
These included components that would dissapear after they were off screen and not reappear. Another issue was in some components not rendering correctly.

These appear to be ongoing bugs in webkit and can be resolved by applying webkit specific styles to the component to force hardware acceleration. 

I have also includes a number of small issues found in the process which includes
- moving styling from server to client component
- Fixing related posts component showing even if no posts are provided
- refactor the archive component to work with both categories and related posts.
- conditionally disabling mouse effects on mobile to improve mobile performance